### PR TITLE
Add `Tab` Disclosure Components

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -6,6 +6,6 @@ module.exports = {
     },
 
     stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx|svelte)"],
-    addons: ["@storybook/addon-essentials"],
+    addons: ["@storybook/addon-essentials", "@storybook/addon-svelte-csf"],
     svelteOptions,
 };

--- a/.storybook/preview.cjs
+++ b/.storybook/preview.cjs
@@ -1,4 +1,4 @@
-import "../dist/kahi-ui.framework.css";
+import "../package/dist/kahi-ui.framework.css";
 
 export const parameters = {
     layout: "fullscreen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Added the following Components / Component Features
+
+    -   Disclosure
+
+        -   `Tab`
+
+            -   `<Tab.Container>` — Wrapper Component which provides stylings and Svelte Contexts for radio button functionality.
+
+                -   `<Tab.Container logic_name="XXX">` — Used to synchronize the form name between each radio button.
+                -   `<Tab.Container logic_state="XXX">` — Used to set which form ID is the current active tab.
+
+            -   `<Tab.Group>` — Used for grouping together `<Tab.Label>` / `<Tab.Section>` Components.
+
+                -   `<Tab.Group logic_id="XXX">` — Used to synchronize the form IDs between the radio buttons, tab content, and Svelte Contexts.
+
+            -   `<Tab.Label>` — Used for providing radio buttons for navigating tabs without Javascript.
+
+                -   `<Tab.Label state>` — Wrapper around `<input type="radio" checked={false/true}>`, used to make the tab active.
+
+            -   `<Tab.Anchor>` — Used for providing page-based navigation buttons.
+
+                -   `<Tab.Anchor current="XXX">` — Wrapper around `aria-current`, used to make the tab active.
+
+            -   `<Tab.Section>` — Used for wrapping tab content that will render when active.
+
+                -   `<Tab.Section loading="lazy">` — When paired with `<Tab.Group>` / `<Tab.Label>`, disables rendering of tab content to DOM when not active.
+
 ## v0.3.0 - 2021/08/10
 
 -   First NPM release, install via `npm install @kahi-ui/framework`.

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "test": "npm run test:types && npm run test:svelte",
         "test:svelte": "svelte-check --tsconfig ./tsconfig.json",
         "test:types": "tsc --noEmit",
-        "watch:framework": "postcss --config postcss.config.cjs --output ./package/dist/kahi-ui.framework.css --watch ./src/index.css"
+        "watch:framework": "postcss --config postcss.config.cjs --output ./package/dist/kahi-ui.framework.css --watch ./src/framework/index.css"
     },
     "dependencies": {
         "svelte": "^3.40.2"

--- a/src/framework/index.css
+++ b/src/framework/index.css
@@ -15,6 +15,8 @@
 @import url("../lib/components/typography/heading/heading.css");
 @import url("../lib/components/typography/text/text.css");
 
+@import url("../lib/components/disclosure/tab/tab.css");
+
 @import url("../lib/components/display/badge/badge.css");
 @import url("../lib/components/display/list/list.css");
 @import url("../lib/components/display/table/table.css");

--- a/src/lib/components/disclosure/tab/Tab.stories.svelte
+++ b/src/lib/components/disclosure/tab/Tab.stories.svelte
@@ -46,41 +46,93 @@
 
 <Story name="Default">
     <Tab.Container logic_name="tab-default" logic_state="tab-1" alignment_x="stretch">
-        <Tab.Label id="tab-1" palette="accent">Tab One <span>ICON</span></Tab.Label>
-        <Tab.Section>
-            <Heading>Tab One Content</Heading>
+        <Tab.Group logic_id="tab-1">
+            <Tab.Label palette="accent">Tab One <span>ICON</span></Tab.Label>
+            <Tab.Section>
+                <Heading>Tab One Content</Heading>
 
-            <Text>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur orci.
-                Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque rutrum tellus,
-                in iaculis dolor tincidunt non. Orci varius natoque penatibus et magnis dis
-                parturient montes, nascetur ridiculus mus.
-            </Text>
-        </Tab.Section>
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Tab.Section>
+        </Tab.Group>
 
-        <Tab.Label id="tab-2" palette="accent">Tab Two <span>ICON</span></Tab.Label>
-        <Tab.Section>
-            <Heading>Tab Two Content</Heading>
+        <Tab.Group logic_id="tab-2">
+            <Tab.Label palette="accent">Tab Two <span>ICON</span></Tab.Label>
+            <Tab.Section>
+                <Heading>Tab Two Content</Heading>
 
-            <Text>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur orci.
-                Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque rutrum tellus,
-                in iaculis dolor tincidunt non. Orci varius natoque penatibus et magnis dis
-                parturient montes, nascetur ridiculus mus.
-            </Text>
-        </Tab.Section>
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Tab.Section>
+        </Tab.Group>
 
-        <Tab.Label id="tab-3" palette="accent">Tab Three <span>ICON</span></Tab.Label>
-        <Tab.Section>
-            <Heading>Tab Three Content</Heading>
+        <Tab.Group logic_id="tab-3">
+            <Tab.Label palette="accent">Tab Three <span>ICON</span></Tab.Label>
+            <Tab.Section>
+                <Heading>Tab Three Content</Heading>
 
-            <Text>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur orci.
-                Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque rutrum tellus,
-                in iaculis dolor tincidunt non. Orci varius natoque penatibus et magnis dis
-                parturient montes, nascetur ridiculus mus.
-            </Text>
-        </Tab.Section>
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Tab.Section>
+        </Tab.Group>
+    </Tab.Container>
+</Story>
+
+<Story name="Lazy">
+    <Tab.Container logic_name="tab-lazy" logic_state="tab-1" alignment_x="stretch">
+        <Tab.Group logic_id="tab-1">
+            <Tab.Label palette="accent">Tab One <span>ICON</span></Tab.Label>
+            <Tab.Section loading="lazy">
+                <Heading>Tab One Content</Heading>
+
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Tab.Section>
+        </Tab.Group>
+
+        <Tab.Group logic_id="tab-2">
+            <Tab.Label palette="accent">Tab Two <span>ICON</span></Tab.Label>
+            <Tab.Section loading="lazy">
+                <Heading>Tab Two Content</Heading>
+
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Tab.Section>
+        </Tab.Group>
+
+        <Tab.Group logic_id="tab-3">
+            <Tab.Label palette="accent">Tab Three <span>ICON</span></Tab.Label>
+            <Tab.Section loading="lazy">
+                <Heading>Tab Three Content</Heading>
+
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Tab.Section>
+        </Tab.Group>
     </Tab.Container>
 </Story>
 
@@ -127,23 +179,22 @@
 <Story name="Palette">
     <Tab.Container logic_name="tab-palette" logic_state="tab-default">
         {#each PALETTES as [palette, is_default] (palette)}
-            <Tab.Label
-                id="tab-{is_default ? 'default' : palette}"
-                palette={is_default ? undefined : palette}
-            >
-                Tab {`${palette.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
-            </Tab.Label>
+            <Tab.Group logic_id="tab-{is_default ? 'default' : palette}">
+                <Tab.Label palette={is_default ? undefined : palette}>
+                    Tab {`${palette.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                </Tab.Label>
 
-            <Tab.Section>
-                <Heading>Tab {palette.toUpperCase()} Content</Heading>
+                <Tab.Section>
+                    <Heading>Tab {palette.toUpperCase()} Content</Heading>
 
-                <Text>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
-                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
-                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
-                    magnis dis parturient montes, nascetur ridiculus mus.
-                </Text>
-            </Tab.Section>
+                    <Text>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et
+                        consectetur orci. Curabitur a egestas turpis, vitae convallis sapien. Sed
+                        pellentesque rutrum tellus, in iaculis dolor tincidunt non. Orci varius
+                        natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+                    </Text>
+                </Tab.Section>
+            </Tab.Group>
         {/each}
     </Tab.Container>
 </Story>
@@ -162,21 +213,23 @@
                     sizing={is_default ? undefined : sizing}
                 >
                     {#each TABS as tab (tab)}
-                        <Tab.Label id="tab-{tab}-{sizing}">
-                            Tab {tab}
-                        </Tab.Label>
+                        <Tab.Group logic_id="tab-{tab}-{sizing}">
+                            <Tab.Label>
+                                Tab {tab}
+                            </Tab.Label>
 
-                        <Tab.Section>
-                            <Heading>Tab {tab} Content</Heading>
+                            <Tab.Section>
+                                <Heading>Tab {tab} Content</Heading>
 
-                            <Text>
-                                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et
-                                consectetur orci. Curabitur a egestas turpis, vitae convallis
-                                sapien. Sed pellentesque rutrum tellus, in iaculis dolor tincidunt
-                                non. Orci varius natoque penatibus et magnis dis parturient montes,
-                                nascetur ridiculus mus.
-                            </Text>
-                        </Tab.Section>
+                                <Text>
+                                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin
+                                    et consectetur orci. Curabitur a egestas turpis, vitae convallis
+                                    sapien. Sed pellentesque rutrum tellus, in iaculis dolor
+                                    tincidunt non. Orci varius natoque penatibus et magnis dis
+                                    parturient montes, nascetur ridiculus mus.
+                                </Text>
+                            </Tab.Section>
+                        </Tab.Group>
                     {/each}
                 </Tab.Container>
             </div>
@@ -198,21 +251,23 @@
                     alignment_x={is_default ? undefined : alignment_x}
                 >
                     {#each TABS as tab (tab)}
-                        <Tab.Label id="tab-{tab}-{alignment_x}">
-                            Tab {tab}
-                        </Tab.Label>
+                        <Tab.Group logic_id="tab-{tab}-{alignment_x}">
+                            <Tab.Label>
+                                Tab {tab}
+                            </Tab.Label>
 
-                        <Tab.Section>
-                            <Heading>Tab {tab} Content</Heading>
+                            <Tab.Section>
+                                <Heading>Tab {tab} Content</Heading>
 
-                            <Text>
-                                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et
-                                consectetur orci. Curabitur a egestas turpis, vitae convallis
-                                sapien. Sed pellentesque rutrum tellus, in iaculis dolor tincidunt
-                                non. Orci varius natoque penatibus et magnis dis parturient montes,
-                                nascetur ridiculus mus.
-                            </Text>
-                        </Tab.Section>
+                                <Text>
+                                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin
+                                    et consectetur orci. Curabitur a egestas turpis, vitae convallis
+                                    sapien. Sed pellentesque rutrum tellus, in iaculis dolor
+                                    tincidunt non. Orci varius natoque penatibus et magnis dis
+                                    parturient montes, nascetur ridiculus mus.
+                                </Text>
+                            </Tab.Section>
+                        </Tab.Group>
                     {/each}
                 </Tab.Container>
             </div>

--- a/src/lib/components/disclosure/tab/Tab.stories.svelte
+++ b/src/lib/components/disclosure/tab/Tab.stories.svelte
@@ -1,0 +1,181 @@
+<script>
+    import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
+
+    import * as Grid from "../../layouts/grid";
+    import Heading from "../../typography/heading/Heading.svelte";
+    import Text from "../../typography/text/Text.svelte";
+
+    import * as Tab from "./index";
+
+    const ALIGNMENTS_X = [
+        ["left", true],
+        ["right", false],
+        ["center", false],
+        ["stretch", false],
+    ];
+
+    const PALETTES = [
+        ["neutral", true],
+        ["accent", false],
+        ["auto", false],
+        ["inverse", false],
+        ["dark", false],
+        ["light", false],
+        ["alert", false],
+        ["affirmative", false],
+        ["negative", false],
+    ];
+
+    const SIZINGS = [
+        ["default", true],
+        ["tiny", false],
+        ["small", false],
+        ["medium", false],
+        ["large", false],
+        ["huge", false],
+    ];
+
+    const TABS = ["One", "Two", "Three"];
+</script>
+
+<Meta title="Disclosure/Tab" component={Tab.Container} />
+
+<Template>
+    <slot />
+</Template>
+
+<Story name="Default">
+    <Tab.Container logic_name="tab-default" logic_state="tab-1" alignment_x="stretch">
+        <Tab.Label id="tab-1" palette="accent">Tab One <span>ICON</span></Tab.Label>
+        <Tab.Section>
+            <Heading>Tab One Content</Heading>
+
+            <Text>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur orci.
+                Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque rutrum tellus,
+                in iaculis dolor tincidunt non. Orci varius natoque penatibus et magnis dis
+                parturient montes, nascetur ridiculus mus.
+            </Text>
+        </Tab.Section>
+
+        <Tab.Label id="tab-2" palette="accent">Tab Two <span>ICON</span></Tab.Label>
+        <Tab.Section>
+            <Heading>Tab Two Content</Heading>
+
+            <Text>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur orci.
+                Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque rutrum tellus,
+                in iaculis dolor tincidunt non. Orci varius natoque penatibus et magnis dis
+                parturient montes, nascetur ridiculus mus.
+            </Text>
+        </Tab.Section>
+
+        <Tab.Label id="tab-3" palette="accent">Tab Three <span>ICON</span></Tab.Label>
+        <Tab.Section>
+            <Heading>Tab Three Content</Heading>
+
+            <Text>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur orci.
+                Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque rutrum tellus,
+                in iaculis dolor tincidunt non. Orci varius natoque penatibus et magnis dis
+                parturient montes, nascetur ridiculus mus.
+            </Text>
+        </Tab.Section>
+    </Tab.Container>
+</Story>
+
+<Story name="Palette">
+    <Tab.Container logic_name="tab-palette" logic_state="tab-default">
+        {#each PALETTES as [palette, is_default] (palette)}
+            <Tab.Label
+                id="tab-{is_default ? 'default' : palette}"
+                palette={is_default ? undefined : palette}
+            >
+                Tab {`${palette.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+            </Tab.Label>
+
+            <Tab.Section>
+                <Heading>Tab {palette.toUpperCase()} Content</Heading>
+
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Tab.Section>
+        {/each}
+    </Tab.Container>
+</Story>
+
+<Story name="Sizing">
+    <Grid.Container points={["2", "tablet:1", "mobile:1"]} spacing="medium">
+        {#each SIZINGS as [sizing, is_default] (sizing)}
+            <div>
+                <Text is="strong">
+                    {`${sizing.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                </Text>
+
+                <Tab.Container
+                    logic_name="tab-sizing-{sizing}"
+                    logic_state="tab-One-{sizing}"
+                    sizing={is_default ? undefined : sizing}
+                >
+                    {#each TABS as tab (tab)}
+                        <Tab.Label id="tab-{tab}-{sizing}">
+                            Tab {tab}
+                        </Tab.Label>
+
+                        <Tab.Section>
+                            <Heading>Tab {tab} Content</Heading>
+
+                            <Text>
+                                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et
+                                consectetur orci. Curabitur a egestas turpis, vitae convallis
+                                sapien. Sed pellentesque rutrum tellus, in iaculis dolor tincidunt
+                                non. Orci varius natoque penatibus et magnis dis parturient montes,
+                                nascetur ridiculus mus.
+                            </Text>
+                        </Tab.Section>
+                    {/each}
+                </Tab.Container>
+            </div>
+        {/each}
+    </Grid.Container>
+</Story>
+
+<Story name="Alignment">
+    <Grid.Container points={["2", "tablet:1", "mobile:1"]} spacing="medium">
+        {#each ALIGNMENTS_X as [alignment_x, is_default] (alignment_x)}
+            <div>
+                <Text is="strong">
+                    {`${alignment_x.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                </Text>
+
+                <Tab.Container
+                    logic_name="tab-alignment-{alignment_x}"
+                    logic_state="tab-One-{alignment_x}"
+                    alignment_x={is_default ? undefined : alignment_x}
+                >
+                    {#each TABS as tab (tab)}
+                        <Tab.Label id="tab-{tab}-{alignment_x}">
+                            Tab {tab}
+                        </Tab.Label>
+
+                        <Tab.Section>
+                            <Heading>Tab {tab} Content</Heading>
+
+                            <Text>
+                                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et
+                                consectetur orci. Curabitur a egestas turpis, vitae convallis
+                                sapien. Sed pellentesque rutrum tellus, in iaculis dolor tincidunt
+                                non. Orci varius natoque penatibus et magnis dis parturient montes,
+                                nascetur ridiculus mus.
+                            </Text>
+                        </Tab.Section>
+                    {/each}
+                </Tab.Container>
+            </div>
+        {/each}
+    </Grid.Container>
+</Story>

--- a/src/lib/components/disclosure/tab/Tab.stories.svelte
+++ b/src/lib/components/disclosure/tab/Tab.stories.svelte
@@ -84,6 +84,46 @@
     </Tab.Container>
 </Story>
 
+<Story name="Anchor">
+    <Tab.Container logic_name="tab-anchor" logic_state="tab-1" alignment_x="stretch">
+        <Tab.Anchor href="#" current="page" palette="accent">Tab One <span>ICON</span></Tab.Anchor>
+        <Tab.Section>
+            <Heading>Tab One Content</Heading>
+
+            <Text>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur orci.
+                Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque rutrum tellus,
+                in iaculis dolor tincidunt non. Orci varius natoque penatibus et magnis dis
+                parturient montes, nascetur ridiculus mus.
+            </Text>
+        </Tab.Section>
+
+        <Tab.Anchor href="#" palette="accent">Tab Two <span>ICON</span></Tab.Anchor>
+        <Tab.Section>
+            <Heading>Tab Two Content</Heading>
+
+            <Text>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur orci.
+                Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque rutrum tellus,
+                in iaculis dolor tincidunt non. Orci varius natoque penatibus et magnis dis
+                parturient montes, nascetur ridiculus mus.
+            </Text>
+        </Tab.Section>
+
+        <Tab.Anchor href="#" palette="accent">Tab Three <span>ICON</span></Tab.Anchor>
+        <Tab.Section>
+            <Heading>Tab Three Content</Heading>
+
+            <Text>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur orci.
+                Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque rutrum tellus,
+                in iaculis dolor tincidunt non. Orci varius natoque penatibus et magnis dis
+                parturient montes, nascetur ridiculus mus.
+            </Text>
+        </Tab.Section>
+    </Tab.Container>
+</Story>
+
 <Story name="Palette">
     <Tab.Container logic_name="tab-palette" logic_state="tab-default">
         {#each PALETTES as [palette, is_default] (palette)}

--- a/src/lib/components/disclosure/tab/TabAnchor.svelte
+++ b/src/lib/components/disclosure/tab/TabAnchor.svelte
@@ -1,20 +1,11 @@
 <script lang="ts">
-    /**
-     * TODO: Satisfy ARIA warnings from the Compiler by making non-optional properties
-     */
-
     import type {ARIA_CURRENT_ARGUMENT} from "../../../types/aria";
+
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
     import type {DESIGN_PALETTE_ARGUMENT} from "../../../types/palettes";
-    import type {IMarginProperties} from "../../../types/spacings";
 
-    import {
-        map_aria_attributes,
-        map_attributes,
-        map_data_attributes,
-        map_global_attributes,
-    } from "../../../util/attributes";
+    import Anchor from "../../navigation/anchor/Anchor.svelte";
 
     type $$Events = {
         click: MouseEvent;
@@ -27,15 +18,13 @@
         current?: ARIA_CURRENT_ARGUMENT;
         disabled?: boolean;
 
-        download?: string;
         href?: string;
         rel?: string;
         target?: string;
 
         palette?: DESIGN_PALETTE_ARGUMENT;
     } & IHTML5Properties &
-        IGlobalProperties &
-        IMarginProperties;
+        IGlobalProperties;
 
     export let element: $$Props["element"] = undefined;
 
@@ -43,7 +32,6 @@
     export let current: $$Props["current"] = undefined;
     export let disabled: $$Props["disabled"] = false;
 
-    export let download: $$Props["download"] = "";
     export let href: $$Props["href"] = "";
     export let rel: $$Props["rel"] = "";
     export let target: $$Props["target"] = "";
@@ -51,13 +39,6 @@
     export let palette: $$Props["palette"] = undefined;
 </script>
 
-<a
-    bind:this={element}
-    {...map_global_attributes($$props)}
-    {...map_aria_attributes({pressed: active, current, disabled})}
-    {...map_attributes({download, href, rel, target})}
-    {...map_data_attributes({palette})}
-    on:click
->
+<Anchor bind:element {current} {active} {disabled} {href} {rel} {palette} {target} on:click>
     <slot />
-</a>
+</Anchor>

--- a/src/lib/components/disclosure/tab/TabContainer.svelte
+++ b/src/lib/components/disclosure/tab/TabContainer.svelte
@@ -1,12 +1,27 @@
 <script lang="ts">
+    import {afterUpdate} from "svelte";
+
+    import type {DESIGN_ALIGNMENT_X_SINGULAR_ARGUMENT} from "../../../types/alignments";
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
+    import type {DESIGN_SIZING_ARGUMENT} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
+
+    import type {IFormStateValue} from "../../../stores/formstate";
+    import {make_formstate_context} from "../../../stores/formstate";
+    import {CONTEXT_FORM_NAME, make_id_context} from "../../../stores/id";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
         element?: HTMLSpanElement;
+
+        logic_name?: string;
+        logic_state?: IFormStateValue;
+
+        sizing?: DESIGN_SIZING_ARGUMENT;
+
+        alignment_x?: DESIGN_ALIGNMENT_X_SINGULAR_ARGUMENT;
     } & IHTML5Properties &
         IGlobalProperties &
         IMarginProperties;
@@ -15,13 +30,30 @@
 
     let _class: $$Props["class"] = "";
     export {_class as class};
+
+    export let logic_name: $$Props["logic_name"] = "";
+    export let logic_state: $$Props["logic_state"] = "";
+
+    export let sizing: $$Props["sizing"] = undefined;
+
+    export let alignment_x: $$Props["alignment_x"] = undefined;
+
+    const _form_name = make_id_context(logic_name as string, CONTEXT_FORM_NAME);
+    const _form_state = make_formstate_context(logic_state as IFormStateValue);
+
+    afterUpdate(() => {
+        $_form_state = logic_state as IFormStateValue;
+    });
+
+    $: $_form_name = logic_name as string;
+    $: logic_state = $_form_state;
 </script>
 
 <div
     bind:this={element}
     {...map_global_attributes($$props)}
     class="tab {_class}"
-    {...map_data_attributes({})}
+    {...map_data_attributes({"alignment-x": alignment_x, sizing})}
 >
     <slot />
 </div>

--- a/src/lib/components/disclosure/tab/TabContainer.svelte
+++ b/src/lib/components/disclosure/tab/TabContainer.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+    import type {IGlobalProperties} from "../../../types/global";
+    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IMarginProperties} from "../../../types/spacings";
+
+    import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Props = {
+        element?: HTMLSpanElement;
+    } & IHTML5Properties &
+        IGlobalProperties &
+        IMarginProperties;
+
+    export let element: $$Props["element"] = undefined;
+
+    let _class: $$Props["class"] = "";
+    export {_class as class};
+</script>
+
+<div
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    class="tab {_class}"
+    {...map_data_attributes({})}
+>
+    <slot />
+</div>

--- a/src/lib/components/disclosure/tab/TabGroup.svelte
+++ b/src/lib/components/disclosure/tab/TabGroup.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+    import {CONTEXT_FORM_ID, make_id_context} from "../../../stores/id";
+
+    type $$Props = {
+        logic_id: string;
+    };
+
+    export let logic_id: $$Props["logic_id"];
+
+    const _logic_id = make_id_context(logic_id as string, CONTEXT_FORM_ID);
+
+    $: $_logic_id = logic_id as string;
+</script>
+
+<slot />

--- a/src/lib/components/disclosure/tab/TabLabel.svelte
+++ b/src/lib/components/disclosure/tab/TabLabel.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+    import type {IGlobalProperties} from "../../../types/global";
+    import type {IHTML5Properties} from "../../../types/html5";
+    import type {DESIGN_PALETTE_ARGUMENT} from "../../../types/palettes";
+
+    import {get_formstate_context} from "../../../stores/formstate";
+    import {CONTEXT_FORM_NAME, get_id_context} from "../../../stores/id";
+
+    import FormLabel from "../../interactables/form/FormLabel.svelte";
+
+    type $$Events = {
+        click: MouseEvent;
+    };
+
+    type $$Props = {
+        element?: HTMLLabelElement;
+
+        id: string;
+
+        active?: boolean;
+        disabled?: boolean;
+        state?: boolean;
+
+        palette?: DESIGN_PALETTE_ARGUMENT;
+    } & IHTML5Properties &
+        IGlobalProperties;
+
+    export let element: $$Props["element"] = undefined;
+
+    export let id: $$Props["id"];
+
+    export let active: $$Props["active"] = false;
+    export let disabled: $$Props["disabled"] = false;
+    export let state: $$Props["state"] = false;
+
+    export let palette: $$Props["palette"] = undefined;
+
+    const _form_name = get_id_context(CONTEXT_FORM_NAME);
+    const _form_state = get_formstate_context();
+
+    if (!_form_name) {
+        throw new ReferenceError(
+            "bad initialization to `Tab.Label` (failed to get `formname` Svelte Store from context)"
+        );
+    }
+
+    if (!_form_state) {
+        throw new ReferenceError(
+            "bad initialization to `Tab.Label` (failed to get `formstate` Svelte Store from context)"
+        );
+    }
+
+    function on_change(event: Event): void {
+        // HACK: We can't directly bind `checked` on `type="radio"`, so we need to watch events
+        state = true;
+    }
+
+    $: if (state) {
+        _form_state.clear();
+        _form_state.push_value(id as string);
+    }
+
+    $: if (id) state = $_form_state === id;
+</script>
+
+<input
+    role="presentation"
+    type="radio"
+    name={$_form_name}
+    checked={state}
+    {id}
+    on:change={on_change}
+    on:change
+/>
+
+<FormLabel bind:element for={id} {active} {disabled} {palette} on:click>
+    <slot />
+</FormLabel>

--- a/src/lib/components/disclosure/tab/TabLabel.svelte
+++ b/src/lib/components/disclosure/tab/TabLabel.svelte
@@ -4,7 +4,7 @@
     import type {DESIGN_PALETTE_ARGUMENT} from "../../../types/palettes";
 
     import {get_formstate_context} from "../../../stores/formstate";
-    import {CONTEXT_FORM_NAME, get_id_context} from "../../../stores/id";
+    import {CONTEXT_FORM_ID, CONTEXT_FORM_NAME, get_id_context} from "../../../stores/id";
 
     import FormLabel from "../../interactables/form/FormLabel.svelte";
 
@@ -14,8 +14,6 @@
 
     type $$Props = {
         element?: HTMLLabelElement;
-
-        id: string;
 
         active?: boolean;
         disabled?: boolean;
@@ -27,16 +25,21 @@
 
     export let element: $$Props["element"] = undefined;
 
-    export let id: $$Props["id"];
-
     export let active: $$Props["active"] = false;
     export let disabled: $$Props["disabled"] = false;
     export let state: $$Props["state"] = false;
 
     export let palette: $$Props["palette"] = undefined;
 
+    const _form_id = get_id_context(CONTEXT_FORM_ID);
     const _form_name = get_id_context(CONTEXT_FORM_NAME);
     const _form_state = get_formstate_context();
+
+    if (!_form_id) {
+        throw new ReferenceError(
+            "bad initialization to `Tab.Label` (failed to get `formid` Svelte Store from context)"
+        );
+    }
 
     if (!_form_name) {
         throw new ReferenceError(
@@ -57,22 +60,22 @@
 
     $: if (state) {
         _form_state.clear();
-        _form_state.push_value(id as string);
+        _form_state.push_value($_form_id as string);
     }
 
-    $: if (id) state = $_form_state === id;
+    $: state = $_form_state === $_form_id;
 </script>
 
 <input
     role="presentation"
     type="radio"
+    id={$_form_id}
     name={$_form_name}
     checked={state}
-    {id}
     on:change={on_change}
     on:change
 />
 
-<FormLabel bind:element for={id} {active} {disabled} {palette} on:click>
+<FormLabel bind:element for={$_form_id} {active} {disabled} {palette} on:click>
     <slot />
 </FormLabel>

--- a/src/lib/components/disclosure/tab/TabSection.svelte
+++ b/src/lib/components/disclosure/tab/TabSection.svelte
@@ -1,13 +1,20 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
+    import type {LOADING_BEHAVIORS_ARGUMENT} from "../../../types/loading";
+    import {LOADING_BEHAVIORS} from "../../../types/loading";
     import type {IIntrinsicProperties} from "../../../types/sizings";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import {CONTEXT_FORM_ID, get_id_context} from "../../../stores/id";
+
     import {map_global_attributes} from "../../../util/attributes";
+    import {get_formstate_context} from "../../../stores/formstate";
 
     type $$Props = {
         element?: HTMLElement;
+
+        loading?: LOADING_BEHAVIORS_ARGUMENT;
     } & IHTML5Properties &
         IGlobalProperties &
         IIntrinsicProperties &
@@ -15,8 +22,19 @@
         IPaddingProperties;
 
     export let element: $$Props["element"] = undefined;
+
+    export let loading: $$Props["loading"] = undefined;
+
+    const _form_id = get_id_context(CONTEXT_FORM_ID);
+    const _form_state = get_formstate_context();
+
+    let state: boolean = true;
+    $: if (_form_id && _form_state && loading === LOADING_BEHAVIORS.lazy)
+        state = $_form_state === $_form_id;
 </script>
 
 <section bind:this={element} {...map_global_attributes($$props)}>
-    <slot />
+    {#if state}
+        <slot />
+    {/if}
 </section>

--- a/src/lib/components/disclosure/tab/TabSection.svelte
+++ b/src/lib/components/disclosure/tab/TabSection.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+    import type {IGlobalProperties} from "../../../types/global";
+    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IIntrinsicProperties} from "../../../types/sizings";
+    import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
+
+    import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Props = {
+        element?: HTMLElement;
+    } & IHTML5Properties &
+        IGlobalProperties &
+        IIntrinsicProperties &
+        IMarginProperties &
+        IPaddingProperties;
+
+    export let element: $$Props["element"] = undefined;
+</script>
+
+<section bind:this={element} {...map_global_attributes($$props)}>
+    <slot />
+</section>

--- a/src/lib/components/disclosure/tab/index.ts
+++ b/src/lib/components/disclosure/tab/index.ts
@@ -2,4 +2,5 @@ export {default as Container} from "./TabContainer.svelte";
 
 export {default as Anchor} from "./TabAnchor.svelte";
 export {default as Label} from "./TabLabel.svelte";
+export {default as Group} from "./TabGroup.svelte";
 export {default as Section} from "./TabSection.svelte";

--- a/src/lib/components/disclosure/tab/index.ts
+++ b/src/lib/components/disclosure/tab/index.ts
@@ -1,1 +1,4 @@
 export {default as Container} from "./TabContainer.svelte";
+
+export {default as Label} from "./TabLabel.svelte";
+export {default as Section} from "./TabSection.svelte";

--- a/src/lib/components/disclosure/tab/index.ts
+++ b/src/lib/components/disclosure/tab/index.ts
@@ -1,4 +1,5 @@
 export {default as Container} from "./TabContainer.svelte";
 
+export {default as Anchor} from "./TabAnchor.svelte";
 export {default as Label} from "./TabLabel.svelte";
 export {default as Section} from "./TabSection.svelte";

--- a/src/lib/components/disclosure/tab/index.ts
+++ b/src/lib/components/disclosure/tab/index.ts
@@ -1,0 +1,1 @@
+export {default as Container} from "./TabContainer.svelte";

--- a/src/lib/components/disclosure/tab/tab.css
+++ b/src/lib/components/disclosure/tab/tab.css
@@ -42,7 +42,7 @@
 
     &:not([data-variation~="borders"]) {
         & > :is(a, label) {
-            @apply relative;
+            @apply !no-underline relative text-current;
 
             &::before {
                 @apply absolute border-x-0 border-b-2 border-solid border-current;

--- a/src/lib/components/disclosure/tab/tab.css
+++ b/src/lib/components/disclosure/tab/tab.css
@@ -1,0 +1,91 @@
+.tab {
+    --sizing-text-size: var(--document-font-size);
+    --sizing-text-line-height: var(--document-font-line-height);
+
+    @apply flex flex-wrap;
+
+    & > [type="radio"][role="presentation"] {
+        @apply hidden;
+
+        &:not(:checked) + :is(a, label) {
+            @apply;
+
+            border-color: rgba(var(--palette-background-bold), theme("opacity.20"));
+
+            & + section {
+                @apply hidden;
+            }
+        }
+
+        &:checked + :is(a, label) {
+            border-color: rgb(var(--palette-background-bold));
+        }
+    }
+
+    &[data-variation~="borders"] {
+        & > [type="radio"][role="presentation"] {
+            @apply hidden;
+
+            &:not(:checked) + :is(a, label) {
+                @apply;
+
+                border-top-color: transparent;
+                border-left-color: transparent;
+                border-right-color: transparent;
+            }
+
+            &:checked + :is(a, label) {
+                @apply;
+
+                border-bottom-color: transparent;
+            }
+        }
+    }
+
+    & > :is(a, label) {
+        all: unset;
+
+        @apply border-solid flex-grow inline-flex justify-center gap-[var(--spacing-local-small)]
+        leading-[var(--sizing-text-line-height)] px-[var(--spacing-local-small)]
+        py-[var(--spacing-local-tiny)];
+
+        border-width: 0px 0px theme("borderWidth.2") 0px;
+
+        font-size: var(--sizing-text-size);
+
+        transition: border-color 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+        &:not([data-palette]) {
+            --palette-background-bold: var(--palette-neutral-bold);
+        }
+    }
+
+    & > section {
+        @apply order-last w-full;
+
+        transition: border-color 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    }
+
+    &:not([data-variation~="borders"]) {
+        & > :is(a, label) {
+            @apply;
+
+            border-width: 0px 0px theme("borderWidth.2") 0px;
+        }
+    }
+
+    &[data-variation~="borders"] {
+        & > :is(a, label) {
+            @apply border-2;
+
+            border-top-left-radius: var(--radius-small);
+            border-top-right-radius: var(--radius-small);
+        }
+
+        & > section {
+            @apply border-b-2 border-x-2;
+
+            border-color: rgba(var(--palette-neutral-bold), theme("opacity.20"));
+        }
+    }
+}

--- a/src/lib/components/disclosure/tab/tab.css
+++ b/src/lib/components/disclosure/tab/tab.css
@@ -1,91 +1,95 @@
 .tab {
+    --flex-alignment-x: initial;
+
     --sizing-text-size: var(--document-font-size);
     --sizing-text-line-height: var(--document-font-line-height);
 
     @apply flex flex-wrap;
 
-    & > [type="radio"][role="presentation"] {
+    justify-content: var(--flex-alignment-x);
+
+    & > [type="radio"] {
         @apply hidden;
-
-        &:not(:checked) + :is(a, label) {
-            @apply;
-
-            border-color: rgba(var(--palette-background-bold), theme("opacity.20"));
-
-            & + section {
-                @apply hidden;
-            }
-        }
-
-        &:checked + :is(a, label) {
-            border-color: rgb(var(--palette-background-bold));
-        }
-    }
-
-    &[data-variation~="borders"] {
-        & > [type="radio"][role="presentation"] {
-            @apply hidden;
-
-            &:not(:checked) + :is(a, label) {
-                @apply;
-
-                border-top-color: transparent;
-                border-left-color: transparent;
-                border-right-color: transparent;
-            }
-
-            &:checked + :is(a, label) {
-                @apply;
-
-                border-bottom-color: transparent;
-            }
-        }
     }
 
     & > :is(a, label) {
         all: unset;
 
-        @apply border-solid flex-grow inline-flex justify-center gap-[var(--spacing-local-small)]
+        @apply cursor-pointer inline-flex justify-center gap-[var(--spacing-local-small)]
         leading-[var(--sizing-text-line-height)] px-[var(--spacing-local-small)]
         py-[var(--spacing-local-tiny)];
 
-        border-width: 0px 0px theme("borderWidth.2") 0px;
-
         font-size: var(--sizing-text-size);
 
-        transition: border-color 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-
-        &:not([data-palette]) {
-            --palette-background-bold: var(--palette-neutral-bold);
-        }
+        transition: background-color 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+            color 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+            opacity 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
     }
 
     & > section {
         @apply order-last w-full;
+    }
 
-        transition: border-color 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    & > :is(a:not([aria-current]), [type="radio"]:not(:checked) + label) + section {
+        @apply hidden;
+    }
+
+    &[data-alignment-x="stretch"] {
+        & > :is(a, label) {
+            @apply flex-grow;
+        }
     }
 
     &:not([data-variation~="borders"]) {
         & > :is(a, label) {
-            @apply;
+            @apply relative;
 
-            border-width: 0px 0px theme("borderWidth.2") 0px;
+            &::before {
+                @apply absolute border-x-0 border-b-2 border-solid border-current;
+
+                content: "";
+
+                inset: 0 0 -2px 0;
+
+                color: transparent;
+
+                transition: color 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+            }
         }
-    }
 
-    &[data-variation~="borders"] {
-        & > :is(a, label) {
-            @apply border-2;
+        & > :is(a, label):is(:focus, :hover, [aria-pressed="true"]) {
+            @apply opacity-50;
 
-            border-top-left-radius: var(--radius-small);
-            border-top-right-radius: var(--radius-small);
+            &[data-palette] {
+                @apply text-[rgb(var(--palette-background-bold))];
+            }
+
+            &::before {
+                @apply text-current;
+            }
+        }
+
+        & > :is(a, label):is(:active, [aria-current]),
+        & > [type="radio"]:checked + label {
+            @apply opacity-100;
+
+            &[data-palette] {
+                @apply text-[rgb(var(--palette-background-bold))];
+            }
+
+            &::before {
+                @apply text-current;
+            }
+        }
+
+        & > :is(a, label)[aria-disabled="true"] {
+            @apply cursor-not-allowed opacity-40;
         }
 
         & > section {
-            @apply border-b-2 border-x-2;
+            @apply border-t-2 border-solid;
 
-            border-color: rgba(var(--palette-neutral-bold), theme("opacity.20"));
+            border-color: rgba(var(--palette-inverse-off-lightest), theme("opacity.40"));
         }
     }
 }

--- a/src/lib/components/display/badge/stories/BadgePaletteStory.svelte
+++ b/src/lib/components/display/badge/stories/BadgePaletteStory.svelte
@@ -5,6 +5,7 @@
 
     const PALETTES = [
         ["neutral", true],
+        ["accent", false],
         ["auto", false],
         ["inverse", false],
         ["dark", false],

--- a/src/lib/components/navigation/menu/stories/MenuPaletteStory.svelte
+++ b/src/lib/components/navigation/menu/stories/MenuPaletteStory.svelte
@@ -6,6 +6,7 @@
 
     const PALETTES = [
         ["default", true],
+        ["accent", false],
         ["auto", false],
         ["inverse", false],
         ["dark", false],

--- a/src/lib/components/typography/heading/stories/HeadingPaletteStory.svelte
+++ b/src/lib/components/typography/heading/stories/HeadingPaletteStory.svelte
@@ -6,9 +6,9 @@
 
     const PALETTES = [
         "default",
+        "accent",
         "auto",
         "inverse",
-        "accent",
         "dark",
         "light",
         "alert",

--- a/src/lib/components/typography/text/stories/TextPaletteStory.svelte
+++ b/src/lib/components/typography/text/stories/TextPaletteStory.svelte
@@ -5,9 +5,9 @@
 
     const PALETTES = [
         "default",
+        "accent",
         "auto",
         "inverse",
-        "accent",
         "dark",
         "light",
         "alert",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -18,6 +18,9 @@ export * from "./types/text";
 export * from "./types/variations";
 export * from "./types/viewports";
 
+import * as Tab from "./components/disclosure/tab";
+export {Tab};
+
 export * from "./components/display/badge";
 import * as List from "./components/display/list";
 export {List};

--- a/src/lib/types/loading.ts
+++ b/src/lib/types/loading.ts
@@ -1,0 +1,13 @@
+/**
+ * Represents the valid loading behaviors that can be applied to Framework Components
+ */
+export enum LOADING_BEHAVIORS {
+    /**
+     * Represents the that Component's content is not loaded until active somehow
+     */
+    lazy = "lazy",
+}
+
+export const LOADING_BEHAVIORS_LITERALS = {...LOADING_BEHAVIORS} as const;
+
+export type LOADING_BEHAVIORS_ARGUMENT = keyof typeof LOADING_BEHAVIORS_LITERALS;

--- a/svelte.config.cjs
+++ b/svelte.config.cjs
@@ -1,8 +1,8 @@
-import sveltePreprocess from "svelte-preprocess";
+const sveltePreprocess = require("svelte-preprocess");
 
 // HACK: Vite expects ES Module, and Storybook expects CommonJS. So...
 // duplicate files
 
-export default {
+module.exports = {
     preprocess: [sveltePreprocess()],
 };


### PR DESCRIPTION
# CHANGELOG

-   Added the following Components / Component Features

    -   Disclosure

        -   `Tab`

            -   `<Tab.Container>` — Wrapper Component which provides stylings and Svelte Contexts for radio button functionality.

                -   `<Tab.Container logic_name="XXX">` — Used to synchronize the form name between each radio button.
                -   `<Tab.Container logic_state="XXX">` — Used to set which form ID is the current active tab.

            -   `<Tab.Group>` — Used for grouping together `<Tab.Label>` / `<Tab.Section>` Components.

                -   `<Tab.Group logic_id="XXX">` — Used to synchronize the form IDs between the radio buttons, tab content, and Svelte Contexts.

            -   `<Tab.Label>` — Used for providing radio buttons for navigating tabs without Javascript.

                -   `<Tab.Label state>` — Wrapper around `<input type="radio" checked={false/true}>`, used to make the tab active.

            -   `<Tab.Anchor>` — Used for providing page-based navigation buttons.

                -   `<Tab.Anchor current="XXX">` — Wrapper around `aria-current`, used to make the tab active.

            -   `<Tab.Section>` — Used for wrapping tab content that will render when active.

                -   `<Tab.Section loading="lazy">` — When paired with `<Tab.Group>` / `<Tab.Label>`, disables rendering of tab content to DOM when not active.