### PR TITLE
Add `Progress` Feedback Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+-   Fixed some internal Component typings.
+
 -   Added the following Components / Component Features
 
     -   Disclosure
@@ -12,6 +14,7 @@
 
                 -   `<Tab.Container logic_name="XXX">` — Used to synchronize the form name between each radio button.
                 -   `<Tab.Container logic_state="XXX">` — Used to set which form ID is the current active tab.
+                -   `<Tab.Container sizing="tiny/small/medium/large/huge">` — Used to change how large the children buttons renders as.
 
             -   `<Tab.Group>` — Used for grouping together `<Tab.Label>` / `<Tab.Section>` Components.
 
@@ -25,9 +28,24 @@
 
                 -   `<Tab.Anchor current="XXX">` — Wrapper around `aria-current`, used to make the tab active.
 
+            -   `<Tab.Anchor>` / `<Tab.Label>`
+
+                -   `<Tab.XXX palette="accent/dark/light/alert/affirmative/negative">` — Used to change the rendered color palette.
+
             -   `<Tab.Section>` — Used for wrapping tab content that will render when active.
 
                 -   `<Tab.Section loading="lazy">` — When paired with `<Tab.Group>` / `<Tab.Label>`, disables rendering of tab content to DOM when not active.
+
+    -   Feedback
+
+        -   `Progress`
+
+            -   `<Progress>` — Used for displaying the process of an ongoing action to the end-user.
+
+                -   `<Progress palette="accent/dark/light/alert/affirmative/negative">` — Used to change the rendered color palette.
+                -   `<Progress shape="circle">` — Used to change the rendering of the Component to be a circle.
+                -   `<Progress size="tiny/small/medium/large/huge">` — Used to change how large the Component renders as.
+                -   `<Progress value="0.0...1.0">` — Used to control the current percent displayed.
 
 -   Added the following Actions / Action Features
 

--- a/src/framework/index.css
+++ b/src/framework/index.css
@@ -23,6 +23,7 @@
 
 @import url("../lib/components/feedback/ellipsis/ellipsis.css");
 @import url("../lib/components/feedback/dot/dot.css");
+@import url("../lib/components/feedback/progress/progress.css");
 @import url("../lib/components/feedback/spinner/spinner.css");
 @import url("../lib/components/feedback/wave/wave.css");
 

--- a/src/lib/components/disclosure/tab/TabContainer.svelte
+++ b/src/lib/components/disclosure/tab/TabContainer.svelte
@@ -14,7 +14,7 @@
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
-        element?: HTMLSpanElement;
+        element?: HTMLDivElement;
 
         logic_name?: string;
         logic_state?: IFormStateValue;

--- a/src/lib/components/feedback/progress/Progress.svelte
+++ b/src/lib/components/feedback/progress/Progress.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+    import type {IGlobalProperties} from "../../../types/global";
+    import type {IHTML5Properties} from "../../../types/html5";
+    import type {DESIGN_PALETTE_ARGUMENT} from "../../../types/palettes";
+    import type {IMarginProperties} from "../../../types/spacings";
+
+    import {
+        map_aria_attributes,
+        map_data_attributes,
+        map_global_attributes,
+    } from "../../../util/attributes";
+
+    type $$Props = {
+        element?: HTMLSpanElement;
+
+        max?: number | string;
+        value?: number | string;
+
+        palette?: DESIGN_PALETTE_ARGUMENT;
+    } & IHTML5Properties &
+        IGlobalProperties &
+        IMarginProperties;
+
+    export let element: $$Props["element"] = undefined;
+
+    export let style: $$Props["style"] = undefined;
+
+    export let max: $$Props["max"] = undefined;
+    export let value: $$Props["value"] = undefined;
+
+    export let palette: $$Props["palette"] = undefined;
+</script>
+
+<div
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    role="progressbar"
+    {...map_aria_attributes({valuemax: max ?? 1, valuemin: 0, valuenow: value})}
+    {...map_data_attributes({palette})}
+    style="{style ? `${style};` : ''}{value ? `--value:${value};` : ''}"
+>
+    <slot />
+</div>

--- a/src/lib/components/feedback/progress/Progress.svelte
+++ b/src/lib/components/feedback/progress/Progress.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
+    // TODO: Investigate SVG 2 support, the `cx`, `cy`, `r` attributes could be inlined
+    // in the CSS stylesheet
+
+    // TODO: Hopefully in the future where `attr` is supported everywhere in CSS
+    // rules, we can drop the `--value` scheme
+
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
     import type {DESIGN_PALETTE_ARGUMENT} from "../../../types/palettes";
+    import type {DESIGN_SIZE_ARGUMENT} from "../../../types/sizes";
     import type {IMarginProperties} from "../../../types/spacings";
 
     import {
@@ -11,12 +18,13 @@
     } from "../../../util/attributes";
 
     type $$Props = {
-        element?: HTMLSpanElement;
+        element?: HTMLDivElement;
 
-        max?: number | string;
         value?: number | string;
 
         palette?: DESIGN_PALETTE_ARGUMENT;
+        shape?: "circle";
+        size?: DESIGN_SIZE_ARGUMENT;
     } & IHTML5Properties &
         IGlobalProperties &
         IMarginProperties;
@@ -25,19 +33,27 @@
 
     export let style: $$Props["style"] = undefined;
 
-    export let max: $$Props["max"] = undefined;
     export let value: $$Props["value"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
+    export let shape: $$Props["shape"] = undefined;
+    export let size: $$Props["size"] = undefined;
 </script>
 
 <div
     bind:this={element}
-    {...map_global_attributes($$props)}
+    {...map_global_attributes({
+        ...$$props,
+        style: `${style ? `${style};` : ""}${value ? `--value:${value};` : ""}`,
+    })}
     role="progressbar"
-    {...map_aria_attributes({valuemax: max ?? 1, valuemin: 0, valuenow: value})}
-    {...map_data_attributes({palette})}
-    style="{style ? `${style};` : ''}{value ? `--value:${value};` : ''}"
+    {...map_aria_attributes({valuemax: 1, valuemin: 0, valuenow: value})}
+    {...map_data_attributes({palette, size})}
 >
-    <slot />
+    {#if shape === "circle"}
+        <svg viewBox="0 0 32 32">
+            <circle cx="16" cy="16" r="14" />
+            <circle cx="16" cy="16" r="14" />
+        </svg>
+    {/if}
 </div>

--- a/src/lib/components/feedback/progress/progress.css
+++ b/src/lib/components/feedback/progress/progress.css
@@ -1,0 +1,37 @@
+[role="progressbar"] {
+    --palette-background-bold: var(--palette-neutral-bold);
+    --palette-foreground-normal: var(--palette-light-normal);
+
+    --value: 0;
+
+    @apply align-middle inline-flex h-[var(--spacing-root-tiny)] justify-center items-center
+    relative select-none text-bold text-[rgb(var(--palette-foreground-normal))] w-full;
+
+    border-radius: var(--radius-pill);
+
+    &::after,
+    &::before {
+        @apply absolute block;
+
+        content: "";
+
+        inset: 0;
+
+        border-radius: var(--radius-pill);
+
+        transition: background-color 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+            max-width 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    }
+
+    &::before {
+        @apply;
+
+        background-color: rgba(var(--palette-background-bold), theme("opacity.50"));
+    }
+
+    &::after {
+        max-width: calc(var(--value) * 100%);
+
+        background-color: rgb(var(--palette-background-bold));
+    }
+}

--- a/src/lib/components/feedback/progress/progress.css
+++ b/src/lib/components/feedback/progress/progress.css
@@ -1,37 +1,95 @@
 [role="progressbar"] {
     --palette-background-bold: var(--palette-neutral-bold);
-    --palette-foreground-normal: var(--palette-light-normal);
+    --size-icon: var(--sizes-icon-medium);
 
     --value: 0;
 
-    @apply align-middle inline-flex h-[var(--spacing-root-tiny)] justify-center items-center
-    relative select-none text-bold text-[rgb(var(--palette-foreground-normal))] w-full;
+    &:empty {
+        @apply w-full;
 
-    border-radius: var(--radius-pill);
-
-    &::after,
-    &::before {
-        @apply absolute block;
-
-        content: "";
-
-        inset: 0;
+        height: calc(var(--size-icon) * 0.25);
 
         border-radius: var(--radius-pill);
 
-        transition: background-color 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94),
-            max-width 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+        background-image: linear-gradient(
+            to right,
+            rgb(var(--palette-background-bold)) 50%,
+            rgba(var(--palette-background-bold), theme("opacity.50")) 50%
+        );
+        background-position: calc(100% - var(--value) * 100%) 0%;
+        background-size: 200% 100%;
+
+        transition: background-image 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+            background-position 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+        &:not([aria-valuenow]) {
+            animation: progress-bar-indeterminate 1.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) infinite;
+        }
     }
 
-    &::before {
-        @apply;
+    &:not(:empty) {
+        & svg {
+            @apply h-[var(--size-icon)] w-[var(--size-icon)];
+        }
 
-        background-color: rgba(var(--palette-background-bold), theme("opacity.50"));
+        & circle {
+            @apply;
+
+            fill: transparent;
+            stroke-width: theme("borderWidth.4");
+
+            transform: rotate(-90deg);
+            transform-origin: 50% 50%;
+
+            transition: stroke 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                stroke-dashoffset 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+        }
+
+        & circle:first-child {
+            @apply;
+
+            stroke: rgba(var(--palette-background-bold), theme("opacity.50"));
+        }
+
+        & circle:last-child {
+            stroke: rgb(var(--palette-background-bold));
+            stroke-dasharray: 88px 88px;
+            stroke-dashoffset: calc(88px * (1 - var(--value)));
+        }
+
+        &:not([aria-valuenow]) {
+            & circle:last-child {
+                animation: progress-circle-indeterminate 1.5s cubic-bezier(0.25, 0.46, 0.45, 0.94)
+                    infinite;
+            }
+        }
+    }
+}
+
+@keyframes progress-bar-indeterminate {
+    0% {
+        background-position: 100% 0%;
     }
 
-    &::after {
-        max-width: calc(var(--value) * 100%);
+    50% {
+        background-position: -100% 0%;
+    }
 
-        background-color: rgb(var(--palette-background-bold));
+    100% {
+        background-position: -100% 0%;
+    }
+}
+
+@keyframes progress-circle-indeterminate {
+    0% {
+        stroke-dashoffset: 88px;
+    }
+
+    50% {
+        stroke-dashoffset: -88px;
+    }
+
+    100% {
+        stroke-dashoffset: -88px;
     }
 }

--- a/src/lib/components/feedback/progress/progress.stories.svelte
+++ b/src/lib/components/feedback/progress/progress.stories.svelte
@@ -3,6 +3,7 @@
 
     import Button from "../../interactables/button/Button.svelte";
     import Mosaic from "../../layouts/mosaic/Mosaic.svelte";
+    import Stack from "../../layouts/stack/Stack.svelte";
     import Text from "../../typography/text/Text.svelte";
 
     import Progress from "./Progress.svelte";
@@ -17,6 +18,15 @@
         ["alert", false],
         ["affirmative", false],
         ["negative", false],
+    ];
+
+    const SIZES = [
+        ["default", true],
+        ["tiny", false],
+        ["small", false],
+        ["medium", false],
+        ["large", false],
+        ["huge", false],
     ];
 
     let value = 0.5;
@@ -37,13 +47,96 @@
 </Template>
 
 <Story name="Default">
-    <Progress {value}>55%</Progress>
+    <Progress shape="circle" {value} />
+    <Progress {value} />
 
     <Button palette="negative" on:click={on_subtract_click}>-</Button>
     <Button palette="affirmative" on:click={on_add_click}>+</Button>
 </Story>
 
 <Story name="Palette">
+    <Stack spacing="medium">
+        <Stack orientation="horizontal" spacing="medium">
+            {#each PALETTES as [palette, is_default] (palette)}
+                <div>
+                    <Text is="strong">
+                        {`${palette.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                    </Text>
+
+                    <br />
+
+                    <Progress
+                        shape="circle"
+                        value="0.5"
+                        palette={is_default ? undefined : palette}
+                    />
+                </div>
+            {/each}
+        </Stack>
+
+        <Mosaic sizing="medium" spacing="medium">
+            {#each PALETTES as [palette, is_default] (palette)}
+                <div>
+                    <Text is="strong">
+                        {`${palette.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                    </Text>
+
+                    <br />
+
+                    <Progress value="0.5" palette={is_default ? undefined : palette} />
+                </div>
+            {/each}
+        </Mosaic>
+    </Stack>
+</Story>
+
+<Story name="Size">
+    <Stack spacing="medium">
+        <Stack orientation="horizontal" spacing="medium">
+            {#each SIZES as [size, is_default] (size)}
+                <div>
+                    <Text is="strong">
+                        {`${size.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                    </Text>
+
+                    <br />
+
+                    <Progress shape="circle" value="0.5" size={is_default ? undefined : size} />
+                </div>
+            {/each}
+        </Stack>
+
+        <Mosaic sizing="medium" spacing="medium">
+            {#each SIZES as [size, is_default] (size)}
+                <div>
+                    <Text is="strong">
+                        {`${size.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                    </Text>
+
+                    <br />
+
+                    <Progress value="0.5" size={is_default ? undefined : size} />
+                </div>
+            {/each}
+        </Mosaic>
+    </Stack>
+</Story>
+
+<Story name="Indeterminate">
+    <Stack orientation="horizontal" spacing="medium">
+        {#each PALETTES as [palette, is_default] (palette)}
+            <div>
+                <Text is="strong">
+                    {`${palette.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                </Text>
+
+                <br />
+
+                <Progress shape="circle" palette={is_default ? undefined : palette} />
+            </div>
+        {/each}
+    </Stack>
+
     <Mosaic sizing="medium" spacing="medium">
         {#each PALETTES as [palette, is_default] (palette)}
             <div>
@@ -51,7 +144,9 @@
                     {`${palette.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
                 </Text>
 
-                <Progress value="0.5" palette={is_default ? undefined : palette} />
+                <br />
+
+                <Progress palette={is_default ? undefined : palette} />
             </div>
         {/each}
     </Mosaic>

--- a/src/lib/components/feedback/progress/progress.stories.svelte
+++ b/src/lib/components/feedback/progress/progress.stories.svelte
@@ -1,0 +1,58 @@
+<script>
+    import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
+
+    import Button from "../../interactables/button/Button.svelte";
+    import Mosaic from "../../layouts/mosaic/Mosaic.svelte";
+    import Text from "../../typography/text/Text.svelte";
+
+    import Progress from "./Progress.svelte";
+
+    const PALETTES = [
+        ["neutral", true],
+        ["accent", false],
+        ["auto", false],
+        ["inverse", false],
+        ["dark", false],
+        ["light", false],
+        ["alert", false],
+        ["affirmative", false],
+        ["negative", false],
+    ];
+
+    let value = 0.5;
+
+    function on_add_click(event) {
+        value = Math.min(value + 0.05, 1);
+    }
+
+    function on_subtract_click(event) {
+        value = Math.max(value - 0.05, 0);
+    }
+</script>
+
+<Meta title="Feedback/Progress" />
+
+<Template>
+    <slot />
+</Template>
+
+<Story name="Default">
+    <Progress {value}>55%</Progress>
+
+    <Button palette="negative" on:click={on_subtract_click}>-</Button>
+    <Button palette="affirmative" on:click={on_add_click}>+</Button>
+</Story>
+
+<Story name="Palette">
+    <Mosaic sizing="medium" spacing="medium">
+        {#each PALETTES as [palette, is_default] (palette)}
+            <div>
+                <Text is="strong">
+                    {`${palette.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                </Text>
+
+                <Progress value="0.5" palette={is_default ? undefined : palette} />
+            </div>
+        {/each}
+    </Mosaic>
+</Story>

--- a/src/lib/components/feedback/wave/Wave.svelte
+++ b/src/lib/components/feedback/wave/Wave.svelte
@@ -2,8 +2,6 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
     import type {DESIGN_PALETTE_ARGUMENT} from "../../../types/palettes";
-    import type {DESIGN_POSITION_ARGUMENT} from "../../../types/positions";
-    import type {DESIGN_SIZE_ARGUMENT} from "../../../types/sizes";
     import type {IMarginProperties} from "../../../types/spacings";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
@@ -12,7 +10,6 @@
         element?: HTMLSpanElement;
 
         palette?: DESIGN_PALETTE_ARGUMENT;
-        position?: DESIGN_POSITION_ARGUMENT;
     } & IHTML5Properties &
         IGlobalProperties &
         IMarginProperties;

--- a/src/lib/util/attributes.ts
+++ b/src/lib/util/attributes.ts
@@ -65,6 +65,15 @@ type IPropPrimitive = boolean | null | number | string | undefined;
 export type IProps = Record<string, IPropPrimitive | IPropPrimitive[]>;
 
 /**
+ * Returns if the value is not undefined or empty string
+ * @param value
+ * @returns
+ */
+function is_truthy(value: any): boolean {
+    return value !== undefined && value !== "";
+}
+
+/**
  * Returns the mapped the input [[props]] to output props, filtering out props with
  * falsy values or not matched against the input [[set]] of valid props. Also prefixes
  * attributes with the given [[prefix]] string if available
@@ -80,7 +89,7 @@ export function map_attributes(props: IProps, set?: Set<string>, prefix: string 
         attribute = ATTRIBUTE_REMAP[attribute] ?? attribute;
 
         if (set && !set.has(attribute)) return false;
-        return Array.isArray(value) ? value.length > 0 : !!value;
+        return Array.isArray(value) ? value.length > 0 : is_truthy(value);
     });
 
     entries = entries.map((entry) => {


### PR DESCRIPTION
# CHANGELOG

-   Fixed some internal Component typings.

-   Added the following Components / Component Features

    -   Feedback

        -   `Progress`

            -   `<Progress>` — Used for displaying the process of an ongoing action to the end-user.

                -   `<Progress palette="accent/dark/light/alert/affirmative/negative">` — Used to change the rendered color palette.
                -   `<Progress shape="circle">` — Used to change the rendering of the Component to be a circle.
                -   `<Progress size="tiny/small/medium/large/huge">` — Used to change how large the Component renders as.
                -   `<Progress value="0.0...1.0">` — Used to control the current percent displayed.