### PR TITLE
Fixed `Breadcrumb` Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 -   Fixed `viewport("widescreen")` / `viewports({widescreen: true})` using incorrect values.
 
+-   Fix the following Components / Component Features
+
+    -   Navigation
+
+        -   `Breadcrumb`
+
+            -   `<Breadcrumb.Container separator="XXX">` — Fixed typings to not error on no value being present.
+
+-   Updated the following Components / Component Features
+
+    -   Navigation
+
+        -   `Breadcrumb`
+
+            -   Updated spacing for separators `small` -> `tiny` tier.
+
 ## v0.3.2 - 2021/08/24
 
 -   Fixed attribute mapping not rejecting `false` values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 -   Fixed `viewport("widescreen")` / `viewports({widescreen: true})` using incorrect values.
 
--   Fix the following Components / Component Features
+-   Fixed the following Components / Component Features
 
     -   Navigation
 

--- a/src/lib/components/navigation/breadcrumb/BreadcrumbContainer.svelte
+++ b/src/lib/components/navigation/breadcrumb/BreadcrumbContainer.svelte
@@ -13,7 +13,7 @@
     type $$Props = {
         element?: HTMLElement;
 
-        separator: string | typeof SvelteComponent;
+        separator?: string | typeof SvelteComponent;
     } & IHTML5Properties &
         IGlobalProperties &
         IIntrinsicProperties &
@@ -27,9 +27,9 @@
 
     export let separator: $$Props["separator"] = "/";
 
-    const _separator = make_component_context(separator);
+    const _separator = make_component_context(separator ?? "/");
 
-    $: $_separator = separator;
+    $: $_separator = separator ?? "/";
 </script>
 
 <nav

--- a/src/lib/components/navigation/breadcrumb/breadcrumb.css
+++ b/src/lib/components/navigation/breadcrumb/breadcrumb.css
@@ -10,7 +10,7 @@ nav.breadcrumb {
             }
 
             & > [role="presentation"] {
-                @apply mx-[var(--spacing-local-small)] opacity-30 pointer-events-none select-none;
+                @apply mx-[var(--spacing-local-tiny)] opacity-30 pointer-events-none select-none;
             }
         }
     }


### PR DESCRIPTION
-   Fixed the following Components / Component Features

    -   Navigation

        -   `Breadcrumb`

            -   `<Breadcrumb.Container separator="XXX">` — Fixed typings to not error on no value being present.

-   Updated the following Components / Component Features

    -   Navigation

        -   `Breadcrumb`

            -   Updated spacing for separators `small` -> `tiny` tier.