### PR TITLE
Fix `keybind({repeat: true})` Misfiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Fixed `keybind({repeat: true})` Svelte Action dispatching `on_bind` before all keys of combinations are pressed.
+
 ## v0.3.3 - 2021/08/01
 
 -   Added `--font-content-size-local-*` / `--font-headline-size-local-*` properties, which use `em` values instead of `rem`.

--- a/src/lib/actions/keybind.stories.svelte
+++ b/src/lib/actions/keybind.stories.svelte
@@ -12,21 +12,14 @@
     let element;
 
     export let is_active = false;
-
-    let action;
-    $: {
-        // HACK: With the CSF format, we can't really use `<svelte:body>`. But
-        // we can imitate it!
-        if (element) {
-            action = keybind(document.body, {
-                binds: "control+/",
-                on_bind,
-            });
-        } else if (action) {
-            action.destroy();
-        }
-    }
 </script>
+
+<svelte:window
+    use:keybind={{
+        binds: "control+/",
+        on_bind,
+    }}
+/>
 
 <Meta title="Actions/keybind" />
 
@@ -46,7 +39,7 @@
     />
 </Story>
 
-<Story name="svelte:body">
+<Story name="svelte:window">
     <div
         bind:this={element}
         class="box"

--- a/src/lib/actions/keybind.ts
+++ b/src/lib/actions/keybind.ts
@@ -201,7 +201,7 @@ export function keybind(element: HTMLElement, options: IKeybindOptions): IKeybin
             state.update(event.key, is_down);
 
             const active = state.is_active();
-            if (cache !== active || repeat) {
+            if (cache !== active || (active && repeat)) {
                 const detail: IKeybindEvent["detail"] = {active, repeat: event.repeat};
                 const custom_event: IKeybindEvent = new CustomEvent("bind", {
                     cancelable: true,


### PR DESCRIPTION
# CHANGELOG

- Fixed `keybind({repeat: true})` Svelte Action dispatching on_bind before all keys of combinations are pressed.