### PR TITLE
Add `<Portal on:mount>` Event / Hide Unmounted Content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Added the following Components / Component Features
+
+    -   Utilities
+
+        -   `Portal`
+
+            -   `<Portal on:mount>` — Dispatches whenever the `Portal` Component successfully mounts.
+
+-   Updated the following Components / Component Features
+
+    -   Utilities
+
+        -   `Portal`
+
+            -   Updated to hide content whenever not yet mounted.
+
 ## v0.3.3 - 2021/08/01
 
 -   Added `--font-content-size-local-*` / `--font-headline-size-local-*` properties, which use `em` values instead of `rem`.

--- a/src/lib/components/utilities/portal/Portal.svelte
+++ b/src/lib/components/utilities/portal/Portal.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-    // TODO: Stories
+    import {createEventDispatcher, onDestroy, onMount, tick} from "svelte";
 
-    // TODO: Dispatch event for when the containing `<div>` has
-    // been moved
-
-    import {onDestroy, onMount, tick} from "svelte";
+    type $$Events = {
+        mount: CustomEvent<void>;
+    };
 
     type $$Props = {
         element?: HTMLDivElement;
@@ -12,6 +11,8 @@
         prepend?: boolean;
         target?: HTMLElement | string;
     };
+
+    const dispatch = createEventDispatcher();
 
     export let element: $$Props["element"] = undefined;
 
@@ -44,9 +45,12 @@
 
         if (prepend) queried_target.prepend(element);
         else queried_target.append(element);
+
+        element.hidden = false;
+        dispatch("mount");
     });
 </script>
 
-<div bind:this={element} class="portal">
+<div bind:this={element} class="portal" hidden>
     <slot />
 </div>

--- a/src/lib/components/utilities/portal/portal.stories.svelte
+++ b/src/lib/components/utilities/portal/portal.stories.svelte
@@ -1,0 +1,23 @@
+<script>
+    import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
+
+    import Box from "../../surfaces/box/Box.svelte";
+
+    import Portal from "./Portal.svelte";
+
+    let element = undefined;
+</script>
+
+<Meta title="Utilities/Portal" />
+
+<Template>
+    <slot />
+</Template>
+
+<Story name="Default">
+    <Box bind:element palette="accent" padding="small">I am the new container element!</Box>
+
+    <Portal target={element}>
+        <Box padding="small">And I was moved to here!</Box>
+    </Portal>
+</Story>


### PR DESCRIPTION
# CHANGELOG

-   Added the following Components / Component Features

    -   Utilities

        -   `Portal`

            -   `<Portal on:mount>` — Dispatches whenever the `Portal` Component successfully mounts.

-   Updated the following Components / Component Features

    -   Utilities

        -   `Portal`

            -   Updated to hide content whenever not yet mounted.