### PR TITLE
Add `$$Slots` Typing to all Components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Updated the following Components / Component Features
+
+    -   \*
+
+        -   Added [slot typing](https://github.com/dummdidumm/rfcs/blob/683fe6d12051b1c9107cfe76cfb90af5efe2fc43/text/ts-typing-props-slots-events.md#typing-slots) to all Components.
+
 ## v0.3.3 - 2021/08/01
 
 -   Added `--font-content-size-local-*` / `--font-headline-size-local-*` properties, which use `em` values instead of `rem`.

--- a/src/lib/components/disclosure/tab/TabAnchor.svelte
+++ b/src/lib/components/disclosure/tab/TabAnchor.svelte
@@ -26,6 +26,10 @@
     } & IHTML5Properties &
         IGlobalProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = false;

--- a/src/lib/components/disclosure/tab/TabContainer.svelte
+++ b/src/lib/components/disclosure/tab/TabContainer.svelte
@@ -26,6 +26,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/disclosure/tab/TabGroup.svelte
+++ b/src/lib/components/disclosure/tab/TabGroup.svelte
@@ -5,6 +5,10 @@
         logic_id: string;
     };
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let logic_id: $$Props["logic_id"];
 
     const _logic_id = make_id_context(logic_id as string, CONTEXT_FORM_ID);

--- a/src/lib/components/disclosure/tab/TabLabel.svelte
+++ b/src/lib/components/disclosure/tab/TabLabel.svelte
@@ -23,6 +23,10 @@
     } & IHTML5Properties &
         IGlobalProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = false;

--- a/src/lib/components/disclosure/tab/TabSection.svelte
+++ b/src/lib/components/disclosure/tab/TabSection.svelte
@@ -21,6 +21,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let loading: $$Props["loading"] = undefined;

--- a/src/lib/components/display/badge/Badge.svelte
+++ b/src/lib/components/display/badge/Badge.svelte
@@ -16,6 +16,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/display/list/ListContainer.svelte
+++ b/src/lib/components/display/list/ListContainer.svelte
@@ -16,6 +16,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let is: $$Props["is"] = "ul";

--- a/src/lib/components/display/list/ListItem.svelte
+++ b/src/lib/components/display/list/ListItem.svelte
@@ -11,6 +11,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/display/table/TableColumn.svelte
+++ b/src/lib/components/display/table/TableColumn.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/display/table/TableContainer.svelte
+++ b/src/lib/components/display/table/TableContainer.svelte
@@ -19,6 +19,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;

--- a/src/lib/components/display/table/TableFooter.svelte
+++ b/src/lib/components/display/table/TableFooter.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/display/table/TableHeader.svelte
+++ b/src/lib/components/display/table/TableHeader.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/display/table/TableHeading.svelte
+++ b/src/lib/components/display/table/TableHeading.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/display/table/TableRow.svelte
+++ b/src/lib/components/display/table/TableRow.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/display/table/TableSection.svelte
+++ b/src/lib/components/display/table/TableSection.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/embedded/figure/Figure.svelte
+++ b/src/lib/components/embedded/figure/Figure.svelte
@@ -22,6 +22,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let fit: $$Props["fit"] = undefined;

--- a/src/lib/components/interactables/button/Button.svelte
+++ b/src/lib/components/interactables/button/Button.svelte
@@ -40,6 +40,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = false;

--- a/src/lib/components/interactables/check/Check.svelte
+++ b/src/lib/components/interactables/check/Check.svelte
@@ -46,6 +46,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let id: $$Props["id"] = "";

--- a/src/lib/components/interactables/form/FormControl.svelte
+++ b/src/lib/components/interactables/form/FormControl.svelte
@@ -17,6 +17,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/interactables/form/FormGroup.svelte
+++ b/src/lib/components/interactables/form/FormGroup.svelte
@@ -12,6 +12,10 @@
         logic_state?: IFormStateValue;
     };
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let logic_name: $$Props["logic_name"] = "";
     export let logic_state: $$Props["logic_state"] = "";
 

--- a/src/lib/components/interactables/form/FormHelpText.svelte
+++ b/src/lib/components/interactables/form/FormHelpText.svelte
@@ -13,6 +13,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/interactables/form/FormLabel.svelte
+++ b/src/lib/components/interactables/form/FormLabel.svelte
@@ -31,6 +31,10 @@
         IGlobalProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = false;

--- a/src/lib/components/interactables/radio/Radio.svelte
+++ b/src/lib/components/interactables/radio/Radio.svelte
@@ -46,6 +46,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let id: $$Props["id"] = "";

--- a/src/lib/components/layouts/container/Container.svelte
+++ b/src/lib/components/layouts/container/Container.svelte
@@ -19,6 +19,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/layouts/divider/Divider.svelte
+++ b/src/lib/components/layouts/divider/Divider.svelte
@@ -18,6 +18,10 @@
         IIntrinsicProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;

--- a/src/lib/components/layouts/grid/GridContainer.svelte
+++ b/src/lib/components/layouts/grid/GridContainer.svelte
@@ -34,6 +34,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/layouts/grid/GridItem.svelte
+++ b/src/lib/components/layouts/grid/GridItem.svelte
@@ -14,6 +14,10 @@
     } & IHTML5Properties &
         IGlobalProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/layouts/group/Group.svelte
+++ b/src/lib/components/layouts/group/Group.svelte
@@ -18,6 +18,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let orientation: $$Props["orientation"] = undefined;

--- a/src/lib/components/layouts/mosaic/Mosaic.svelte
+++ b/src/lib/components/layouts/mosaic/Mosaic.svelte
@@ -38,6 +38,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/layouts/scrollable/Scrollable.svelte
+++ b/src/lib/components/layouts/scrollable/Scrollable.svelte
@@ -18,6 +18,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/layouts/spacer/Spacer.svelte
+++ b/src/lib/components/layouts/spacer/Spacer.svelte
@@ -18,6 +18,10 @@
     } & IHTML5Properties &
         IGlobalProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/layouts/stack/Stack.svelte
+++ b/src/lib/components/layouts/stack/Stack.svelte
@@ -36,6 +36,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/navigation/anchor/Anchor.svelte
+++ b/src/lib/components/navigation/anchor/Anchor.svelte
@@ -37,6 +37,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = false;

--- a/src/lib/components/navigation/aside/AsideContainer.svelte
+++ b/src/lib/components/navigation/aside/AsideContainer.svelte
@@ -38,6 +38,13 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+
+        close: {};
+        open: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -79,6 +86,9 @@
             {...map_data_attributes({palette, placement, variation})}
         >
             <slot />
+
+            <slot name="open" />
+            <slot name="close" />
         </nav>
     </Offscreen>
 {:else}
@@ -89,5 +99,8 @@
         {...map_data_attributes({palette, placement, variation})}
     >
         <slot />
+
+        <slot name="open" />
+        <slot name="close" />
     </nav>
 {/if}

--- a/src/lib/components/navigation/aside/AsideFooter.svelte
+++ b/src/lib/components/navigation/aside/AsideFooter.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/navigation/aside/AsideHeader.svelte
+++ b/src/lib/components/navigation/aside/AsideHeader.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/navigation/aside/AsideSection.svelte
+++ b/src/lib/components/navigation/aside/AsideSection.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/navigation/aside/stories/AsideDefaultStory.svelte
+++ b/src/lib/components/navigation/aside/stories/AsideDefaultStory.svelte
@@ -55,6 +55,11 @@
         </Anchor>
     </Aside.Footer>
 
-    <ContextButton variation="clear">+</ContextButton>
-    <ContextButton palette="dark" variation="clear">x</ContextButton>
+    <svelte:fragment slot="open">
+        <ContextButton variation="clear">+</ContextButton>
+    </svelte:fragment>
+
+    <svelte:fragment slot="close">
+        <ContextButton palette="dark" variation="clear">x</ContextButton>
+    </svelte:fragment>
 </Aside.Container>

--- a/src/lib/components/navigation/breadcrumb/BreadcrumbAnchor.svelte
+++ b/src/lib/components/navigation/breadcrumb/BreadcrumbAnchor.svelte
@@ -24,6 +24,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let active: boolean = false;

--- a/src/lib/components/navigation/breadcrumb/BreadcrumbContainer.svelte
+++ b/src/lib/components/navigation/breadcrumb/BreadcrumbContainer.svelte
@@ -20,6 +20,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/navigation/breadcrumb/BreadcrumbItem.svelte
+++ b/src/lib/components/navigation/breadcrumb/BreadcrumbItem.svelte
@@ -15,6 +15,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = false;

--- a/src/lib/components/navigation/menu/MenuAnchor.svelte
+++ b/src/lib/components/navigation/menu/MenuAnchor.svelte
@@ -26,6 +26,10 @@
     } & IHTML5Properties &
         IGlobalProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = false;

--- a/src/lib/components/navigation/menu/MenuButton.svelte
+++ b/src/lib/components/navigation/menu/MenuButton.svelte
@@ -21,6 +21,10 @@
     } & IHTML5Properties &
         IGlobalProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = false;

--- a/src/lib/components/navigation/menu/MenuContainer.svelte
+++ b/src/lib/components/navigation/menu/MenuContainer.svelte
@@ -19,6 +19,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/navigation/menu/MenuDivider.svelte
+++ b/src/lib/components/navigation/menu/MenuDivider.svelte
@@ -11,6 +11,12 @@
     } & IHTML5Properties &
         IGlobalProperties;
 
+    type $$Slots = {
+        default: {};
+
+        "sub-menu": {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/navigation/menu/MenuHeading.svelte
+++ b/src/lib/components/navigation/menu/MenuHeading.svelte
@@ -11,6 +11,12 @@
     } & IHTML5Properties &
         IGlobalProperties;
 
+    type $$Slots = {
+        default: {};
+
+        "sub-menu": {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/navigation/menu/MenuItem.svelte
+++ b/src/lib/components/navigation/menu/MenuItem.svelte
@@ -9,6 +9,10 @@
     } & IHTML5Properties &
         IGlobalProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/navigation/menu/MenuLabel.svelte
+++ b/src/lib/components/navigation/menu/MenuLabel.svelte
@@ -23,6 +23,10 @@
     } & IHTML5Properties &
         IGlobalProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = false;

--- a/src/lib/components/navigation/menu/MenuSubMenu.svelte
+++ b/src/lib/components/navigation/menu/MenuSubMenu.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/navigation/omni/OmniContainer.svelte
+++ b/src/lib/components/navigation/omni/OmniContainer.svelte
@@ -46,6 +46,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/navigation/omni/OmniFooter.svelte
+++ b/src/lib/components/navigation/omni/OmniFooter.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/navigation/omni/OmniHeader.svelte
+++ b/src/lib/components/navigation/omni/OmniHeader.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/navigation/omni/OmniSection.svelte
+++ b/src/lib/components/navigation/omni/OmniSection.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/overlays/offscreen/Offscreen.svelte
+++ b/src/lib/components/overlays/offscreen/Offscreen.svelte
@@ -40,6 +40,10 @@
     } & IHTML5Properties &
         IGlobalProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     const dispatch = createEventDispatcher();
 
     export let element: $$Props["element"] = undefined;

--- a/src/lib/components/overlays/overlay/Overlay.svelte
+++ b/src/lib/components/overlays/overlay/Overlay.svelte
@@ -43,6 +43,10 @@
         IGlobalProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     const dispatch = createEventDispatcher();
 
     export let element: $$Props["element"] = undefined;

--- a/src/lib/components/overlays/popover/Popover.svelte
+++ b/src/lib/components/overlays/popover/Popover.svelte
@@ -45,6 +45,10 @@
     } & IHTML5Properties &
         IGlobalProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     const dispatch = createEventDispatcher();
 
     export let element: $$Props["element"] = undefined;

--- a/src/lib/components/surfaces/box/Box.svelte
+++ b/src/lib/components/surfaces/box/Box.svelte
@@ -17,6 +17,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/surfaces/card/CardContainer.svelte
+++ b/src/lib/components/surfaces/card/CardContainer.svelte
@@ -22,6 +22,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/surfaces/card/CardFigure.svelte
+++ b/src/lib/components/surfaces/card/CardFigure.svelte
@@ -22,6 +22,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let fit: $$Props["fit"] = undefined;

--- a/src/lib/components/surfaces/card/CardFooter.svelte
+++ b/src/lib/components/surfaces/card/CardFooter.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/surfaces/card/CardHeader.svelte
+++ b/src/lib/components/surfaces/card/CardHeader.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/surfaces/card/CardSection.svelte
+++ b/src/lib/components/surfaces/card/CardSection.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/surfaces/hero/HeroContainer.svelte
+++ b/src/lib/components/surfaces/hero/HeroContainer.svelte
@@ -17,6 +17,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/surfaces/hero/HeroFooter.svelte
+++ b/src/lib/components/surfaces/hero/HeroFooter.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/surfaces/hero/HeroHeader.svelte
+++ b/src/lib/components/surfaces/hero/HeroHeader.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/surfaces/hero/HeroSection.svelte
+++ b/src/lib/components/surfaces/hero/HeroSection.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/surfaces/tile/TileContainer.svelte
+++ b/src/lib/components/surfaces/tile/TileContainer.svelte
@@ -22,6 +22,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/surfaces/tile/TileFigure.svelte
+++ b/src/lib/components/surfaces/tile/TileFigure.svelte
@@ -23,6 +23,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let fit: $$Props["fit"] = undefined;

--- a/src/lib/components/surfaces/tile/TileFooter.svelte
+++ b/src/lib/components/surfaces/tile/TileFooter.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/surfaces/tile/TileHeader.svelte
+++ b/src/lib/components/surfaces/tile/TileHeader.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/surfaces/tile/TileSection.svelte
+++ b/src/lib/components/surfaces/tile/TileSection.svelte
@@ -14,6 +14,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/typography/blockquote/BlockquoteCite.svelte
+++ b/src/lib/components/typography/blockquote/BlockquoteCite.svelte
@@ -11,6 +11,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 </script>
 

--- a/src/lib/components/typography/blockquote/BlockquoteContainer.svelte
+++ b/src/lib/components/typography/blockquote/BlockquoteContainer.svelte
@@ -17,6 +17,10 @@
         IMarginProperties &
         IPaddingProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;

--- a/src/lib/components/typography/code/Code.svelte
+++ b/src/lib/components/typography/code/Code.svelte
@@ -18,6 +18,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let is: $$Props["is"] = "code";

--- a/src/lib/components/typography/heading/Heading.svelte
+++ b/src/lib/components/typography/heading/Heading.svelte
@@ -25,6 +25,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let is: $$Props["is"] = "h1";

--- a/src/lib/components/typography/text/Text.svelte
+++ b/src/lib/components/typography/text/Text.svelte
@@ -45,6 +45,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let is: $$Props["is"] = "p";

--- a/src/lib/components/utilities/contextbutton/ContextButton.svelte
+++ b/src/lib/components/utilities/contextbutton/ContextButton.svelte
@@ -29,6 +29,10 @@
         IGlobalProperties &
         IMarginProperties;
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/utilities/portal/Portal.svelte
+++ b/src/lib/components/utilities/portal/Portal.svelte
@@ -13,6 +13,10 @@
         target?: HTMLElement | string;
     };
 
+    type $$Slots = {
+        default: {};
+    };
+
     export let element: $$Props["element"] = undefined;
 
     export let prepend: $$Props["prepend"] = false;


### PR DESCRIPTION
# CHANGELOG

-   Updated the following Components / Component Features

    -   \*

        -   Added [slot typing](https://github.com/dummdidumm/rfcs/blob/683fe6d12051b1c9107cfe76cfb90af5efe2fc43/text/ts-typing-props-slots-events.md#typing-slots) to all Components.