### PR TITLE
Update Browser Support List

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ File [a new issue](https://github.com/novacbn/kahi-ui/issues/new) or visit the o
 
 ## Browser Support
 
--   Chrome 87+ — November 2020
--   Edge 87+ — November 2020
--   Firefox 67+ — May 2019
+-   Chrome 88+ — January 2021
+-   Edge 88+ — January 2021
+-   Firefox 84+ — December 2020
 -   Safari 14.1+ — April 2021
 -   Edge _(Pre Chromium)_ — **UNSUPPORTED**
 -   Internet Explorer — **UNSUPPORTED**


### PR DESCRIPTION
# Description

Due to extensive usage of [`:not w/ Selector List`](https://developer.mozilla.org/en-US/docs/Web/CSS/:not#browser_compatibility) and [`:is`](https://developer.mozilla.org/en-US/docs/Web/CSS/:is#browser_compatibility), the following Browser minimums need bumped:

- Chrome `87`_November 2020_  -> `88` _January 2021_.
- Edge `87`_November 2020_ -> `88` _January 2021_.
- Firefox `67` _May 2019_ -> `84` _December 2020_.

## Related

#36 