### PR TITLE
Added `orientation` / `alignment*` support to `<Card.Footer>` / `<Tile.Footer>` / `<Overlay>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@
 
     -   Surfaces
 
-        -   `Card`
+        -   `Card` / `Tile`
 
-            -   `<Card.Footer orientation="vertical/mobile:vertical/tablet:vertical/desktop:vertical/widescreen:vertical">` — Lays content out vertically.
+            -   `<XXX.Footer orientation="vertical/mobile:vertical/tablet:vertical/desktop:vertical/widescreen:vertical">` — Lays content out vertically.
+            -   `<XXX alignment="center/stretch" alignment_x="left/right/center/stretch" alignment_y="top/bottom/center/stretch">` — Used to align the content.
 
     -   Utilities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@
 
         -   `Overlay`
 
-            -   `<Overlay orientation="horizontal/mobile:horizontal/tablet:horizontal/desktop:horizontal/widescreen:horizontal">` - Lays content out horizontally.
+            -   `<Overlay orientation="horizontal/mobile:horizontal/tablet:horizontal/desktop:horizontal/widescreen:horizontal">` — Lays content out horizontally.
+
+    -   Surfaces
+
+        -   `Card`
+
+            -   `<Card.Footer orientation="vertical/mobile:vertical/tablet:vertical/desktop:vertical/widescreen:vertical">` — Lays content out vertically.
 
     -   Utilities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## UNRELEASED
 
--   Updated the following Components / Component Features
+-   Added the following Components / Component Features
+
+    -   Overlays
+
+        -   `Overlay`
+
+            -   `<Overlay orientation="horizontal/mobile:horizontal/tablet:horizontal/desktop:horizontal/widescreen:horizontal">` - Lays content out horizontally.
 
     -   Utilities
 

--- a/src/lib/components/overlays/overlay/Overlay.svelte
+++ b/src/lib/components/overlays/overlay/Overlay.svelte
@@ -9,6 +9,8 @@
 
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
+    import type {DESIGN_ORIENTATION_VERTICAL_ARGUMENT} from "../../../types/orientations";
+    import type {DESIGN_SPACING_ARGUMENT, IPaddingProperties} from "../../../types/spacings";
 
     import {make_id_context} from "../../../stores/id";
     import {make_state_context} from "../../../stores/state";
@@ -16,7 +18,6 @@
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     import ContextBackdrop from "../../utilities/contextbackdrop/ContextBackdrop.svelte";
-    import type {DESIGN_SPACING_ARGUMENT, IPaddingProperties} from "../../../types/spacings";
 
     type $$Events = {
         active: CustomEvent<void>;
@@ -31,6 +32,8 @@
         dismissible?: boolean;
         logic_id?: string;
         state?: boolean;
+
+        orientation?: DESIGN_ORIENTATION_VERTICAL_ARGUMENT;
 
         alignment?: DESIGN_ALIGNMENT_ARGUMENT;
         alignment_x?: DESIGN_ALIGNMENT_X_ARGUMENT;
@@ -58,6 +61,8 @@
     export let dismissible: $$Props["dismissible"] = false;
     export let logic_id: $$Props["logic_id"] = "";
     export let state: $$Props["state"] = false;
+
+    export let orientation: $$Props["orientation"] = undefined;
 
     export let alignment: $$Props["alignment"] = undefined;
     export let alignment_x: $$Props["alignment_x"] = undefined;
@@ -109,6 +114,7 @@
         alignment,
         "alignment-x": alignment_x,
         "alignment-y": alignment_y,
+        orientation,
         spacing,
         "spacing-x": spacing_x,
         "spacing-y": spacing_y,

--- a/src/lib/components/overlays/overlay/overlay.css
+++ b/src/lib/components/overlays/overlay/overlay.css
@@ -1,4 +1,9 @@
 .overlay {
+    --orientation-direction: column;
+
+    --orientation-flex-alignment-x: var(--flex-alignment-x);
+    --orientation-flex-alignment-y: var(--flex-alignment-y);
+
     --flex-alignment-x: center;
     --flex-alignment-y: center;
 
@@ -8,8 +13,10 @@
     @apply fixed flex flex-col gap-x-[var(--spacing-x)] gap-y-[var(--spacing-y)] h-screen
     left-0 pointer-events-none top-0 w-screen z-2;
 
-    align-items: var(--flex-alignment-x);
-    justify-content: var(--flex-alignment-y);
+    align-items: var(--orientation-flex-alignment-x);
+    justify-content: var(--orientation-flex-alignment-y);
+
+    flex-direction: var(--orientation-direction);
 
     transition: opacity 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94),
         transform 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);

--- a/src/lib/components/overlays/overlay/overlay.stories.svelte
+++ b/src/lib/components/overlays/overlay/overlay.stories.svelte
@@ -2,12 +2,18 @@
     import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
 
     import Button from "../../interactables/button/Button.svelte";
+    import Box from "../../surfaces/box/Box.svelte";
     import * as Card from "../../surfaces/card";
     import Code from "../../typography/code/Code.svelte";
     import Text from "../../typography/text/Text.svelte";
     import ContextButton from "../../utilities/contextbutton/ContextButton.svelte";
 
     import Overlay from "./Overlay.svelte";
+
+    const ORIENTATIONS = [
+        ["vertical", true],
+        ["horizontal", false],
+    ];
 </script>
 
 <Meta title="Overlays/Overlay" />
@@ -36,4 +42,26 @@
             </Card.Footer>
         </Card.Container>
     </Overlay>
+</Story>
+
+<Story name="Orientation">
+    {#each ORIENTATIONS as [orientation, is_default] (orientation)}
+        <Button for="overlay-orientation-story-{orientation}" palette="accent">
+            Open {`${orientation.toUpperCase()}${is_default ? " / DEFAULT" : ""}`} Modal
+        </Button>
+
+        <Overlay
+            logic_id="overlay-orientation-story-{orientation}"
+            spacing="medium"
+            {orientation}
+            captive
+            dismissible
+        >
+            <Box palette="inverse">
+                I was oriented {orientation.toUpperCase()}!
+            </Box>
+
+            <Box palette="inverse">And I am a sibling!</Box>
+        </Overlay>
+    {/each}
 </Story>

--- a/src/lib/components/surfaces/card/Card.stories.svelte
+++ b/src/lib/components/surfaces/card/Card.stories.svelte
@@ -20,6 +20,11 @@
         ["highest", false],
     ];
 
+    const ORIENTATIONS = [
+        ["horizontal", true],
+        ["vertical", false],
+    ];
+
     const PALETTES = [
         ["neutral", true],
         ["accent", false],
@@ -171,4 +176,34 @@
             </Card.Container>
         {/each}
     </Stack>
+</Story>
+
+<Story name="Footer Orientation">
+    <Mosaic sizing="huge" spacing="medium">
+        {#each ORIENTATIONS as [orientation, is_default] (orientation)}
+            <Card.Container>
+                <Card.Figure>
+                    <img src={IMAGE_BACKGROUND} />
+                </Card.Figure>
+
+                <Card.Header>
+                    {`${orientation.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                </Card.Header>
+
+                <Card.Section>
+                    <Text>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et
+                        consectetur orci. Curabitur a egestas turpis, vitae convallis sapien. Sed
+                        pellentesque rutrum tellus, in iaculis dolor tincidunt non. Orci varius
+                        natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+                    </Text>
+                </Card.Section>
+
+                <Card.Footer {orientation}>
+                    <Button variation="clear">Cancel</Button>
+                    <Button palette="accent">Confirm</Button>
+                </Card.Footer>
+            </Card.Container>
+        {/each}
+    </Mosaic>
 </Story>

--- a/src/lib/components/surfaces/card/CardFooter.svelte
+++ b/src/lib/components/surfaces/card/CardFooter.svelte
@@ -1,13 +1,25 @@
 <script lang="ts">
+    import type {
+        DESIGN_ALIGNMENT_ARGUMENT,
+        DESIGN_ALIGNMENT_X_ARGUMENT,
+        DESIGN_ALIGNMENT_Y_ARGUMENT,
+    } from "../../../types/alignments";
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
+    import type {DESIGN_ORIENTATION_VERTICAL_ARGUMENT} from "../../../types/orientations";
     import type {IIntrinsicProperties} from "../../../types/sizings";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
-    import {map_global_attributes} from "../../../util/attributes";
+    import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
         element?: HTMLElement;
+
+        orientation?: DESIGN_ORIENTATION_VERTICAL_ARGUMENT;
+
+        alignment?: DESIGN_ALIGNMENT_ARGUMENT;
+        alignment_x?: DESIGN_ALIGNMENT_X_ARGUMENT;
+        alignment_y?: DESIGN_ALIGNMENT_Y_ARGUMENT;
     } & IHTML5Properties &
         IGlobalProperties &
         IIntrinsicProperties &
@@ -19,8 +31,23 @@
     };
 
     export let element: $$Props["element"] = undefined;
+
+    export let orientation: $$Props["orientation"] = undefined;
+
+    export let alignment: $$Props["alignment"] = undefined;
+    export let alignment_x: $$Props["alignment_x"] = undefined;
+    export let alignment_y: $$Props["alignment_y"] = undefined;
 </script>
 
-<footer bind:this={element} {...map_global_attributes($$props)}>
+<footer
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    {...map_data_attributes({
+        alignment,
+        "alignment-x": alignment_x,
+        "alignment-y": alignment_y,
+        orientation,
+    })}
+>
     <slot />
 </footer>

--- a/src/lib/components/surfaces/card/CardFooter.svelte
+++ b/src/lib/components/surfaces/card/CardFooter.svelte
@@ -6,7 +6,7 @@
     } from "../../../types/alignments";
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
-    import type {DESIGN_ORIENTATION_VERTICAL_ARGUMENT} from "../../../types/orientations";
+    import type {DESIGN_ORIENTATION_HORIZONTAL_ARGUMENT} from "../../../types/orientations";
     import type {IIntrinsicProperties} from "../../../types/sizings";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -15,7 +15,7 @@
     type $$Props = {
         element?: HTMLElement;
 
-        orientation?: DESIGN_ORIENTATION_VERTICAL_ARGUMENT;
+        orientation?: DESIGN_ORIENTATION_HORIZONTAL_ARGUMENT;
 
         alignment?: DESIGN_ALIGNMENT_ARGUMENT;
         alignment_x?: DESIGN_ALIGNMENT_X_ARGUMENT;

--- a/src/lib/components/surfaces/card/card.css
+++ b/src/lib/components/surfaces/card/card.css
@@ -1,4 +1,12 @@
 .card {
+    --orientation-direction: row;
+
+    --orientation-flex-alignment-x: var(--flex-alignment-x);
+    --orientation-flex-alignment-y: var(--flex-alignment-y);
+
+    --flex-alignment-x: flex-end;
+    --flex-alignment-y: center;
+
     --elevation: var(--elevation-lowest);
 
     --palette-background-normal: var(--palette-auto-off-normal);
@@ -22,11 +30,14 @@
     }
 
     & > footer {
-        @apply justify-end;
+        align-items: var(--orientation-flex-alignment-x);
+        justify-content: var(--orientation-flex-alignment-y);
+
+        flex-direction: var(--orientation-direction);
     }
 
     & > header {
-        @apply font-bold leading-[var(--font-content-line-height-medium)];
+        @apply font-bold items-center leading-[var(--font-content-line-height-medium)];
 
         font-size: var(--font-content-size-local-medium);
     }
@@ -42,7 +53,7 @@
     }
 
     & > :is(header, footer) {
-        @apply flex gap-[var(--spacing-local-small)] items-center;
+        @apply flex gap-[var(--spacing-local-small)];
     }
 
     & > :is(figure, footer, header) {

--- a/src/lib/components/surfaces/tile/Tile.stories.svelte
+++ b/src/lib/components/surfaces/tile/Tile.stories.svelte
@@ -17,6 +17,11 @@
         ["highest", false],
     ];
 
+    const ORIENTATIONS = [
+        ["horizontal", true],
+        ["vertical", false],
+    ];
+
     const PALETTES = [
         ["neutral", true],
         ["accent", false],
@@ -154,6 +159,35 @@
                         </Text>
                     </Text>
                 </Tile.Section>
+            </Tile.Container>
+        {/each}
+    </Stack>
+</Story>
+
+<Story name="Footer Orientation">
+    <Stack orientation="horizontal" spacing="medium" variation="wrap">
+        {#each ORIENTATIONS as [orientation, is_default] (orientation)}
+            <Tile.Container width="content-max">
+                <Tile.Figure shape="pill">
+                    <img src={IMAGE_AVATAR} />
+                </Tile.Figure>
+
+                <Tile.Section>
+                    <Tile.Header>
+                        {`${orientation.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                    </Tile.Header>
+
+                    <Text>
+                        <Text is="small">
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        </Text>
+                    </Text>
+                </Tile.Section>
+
+                <Tile.Footer {orientation}>
+                    <Button palette="affirmative" size="small">Confirm</Button>
+                    <Button palette="negative" size="small">Cancel</Button>
+                </Tile.Footer>
             </Tile.Container>
         {/each}
     </Stack>

--- a/src/lib/components/surfaces/tile/TileFooter.svelte
+++ b/src/lib/components/surfaces/tile/TileFooter.svelte
@@ -1,13 +1,25 @@
 <script lang="ts">
+    import type {
+        DESIGN_ALIGNMENT_ARGUMENT,
+        DESIGN_ALIGNMENT_X_ARGUMENT,
+        DESIGN_ALIGNMENT_Y_ARGUMENT,
+    } from "../../../types/alignments";
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
+    import type {DESIGN_ORIENTATION_VERTICAL_ARGUMENT} from "../../../types/orientations";
     import type {IIntrinsicProperties} from "../../../types/sizings";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
-    import {map_global_attributes} from "../../../util/attributes";
+    import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
         element?: HTMLElement;
+
+        orientation?: DESIGN_ORIENTATION_VERTICAL_ARGUMENT;
+
+        alignment?: DESIGN_ALIGNMENT_ARGUMENT;
+        alignment_x?: DESIGN_ALIGNMENT_X_ARGUMENT;
+        alignment_y?: DESIGN_ALIGNMENT_Y_ARGUMENT;
     } & IHTML5Properties &
         IGlobalProperties &
         IIntrinsicProperties &
@@ -19,8 +31,23 @@
     };
 
     export let element: $$Props["element"] = undefined;
+
+    export let orientation: $$Props["orientation"] = undefined;
+
+    export let alignment: $$Props["alignment"] = undefined;
+    export let alignment_x: $$Props["alignment_x"] = undefined;
+    export let alignment_y: $$Props["alignment_y"] = undefined;
 </script>
 
-<footer bind:this={element} {...map_global_attributes($$props)}>
+<footer
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    {...map_data_attributes({
+        alignment,
+        "alignment-x": alignment_x,
+        "alignment-y": alignment_y,
+        orientation,
+    })}
+>
     <slot />
 </footer>

--- a/src/lib/components/surfaces/tile/tile.css
+++ b/src/lib/components/surfaces/tile/tile.css
@@ -1,4 +1,12 @@
 .tile {
+    --orientation-direction: row;
+
+    --orientation-flex-alignment-x: var(--flex-alignment-x);
+    --orientation-flex-alignment-y: var(--flex-alignment-y);
+
+    --flex-alignment-x: center;
+    --flex-alignment-y: center;
+
     --elevation: var(--elevation-lowest);
 
     --palette-background-normal: var(--palette-auto-off-normal);
@@ -18,6 +26,8 @@
         color 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 
     & > figure {
+        @apply items-center;
+
         & > * {
             /** HACK: This should really point to variables made element sizing, but it'll do for now */
             @apply h-[var(--font-headline-size-local-huge)] w-[var(--font-headline-size-local-huge)];
@@ -25,7 +35,12 @@
     }
 
     & > footer {
-        @apply gap-[var(--spacing-local-small)] justify-end ml-auto;
+        @apply gap-[var(--spacing-local-small)] ml-auto;
+
+        align-items: var(--orientation-flex-alignment-x);
+        justify-content: var(--orientation-flex-alignment-y);
+
+        flex-direction: var(--orientation-direction);
     }
 
     & > section {
@@ -44,10 +59,6 @@
 
             font-size: var(--font-content-size-local-medium);
         }
-    }
-
-    & > :is(figure, footer) {
-        @apply items-center;
     }
 
     & > :is(figure, footer, section) {


### PR DESCRIPTION
# CHANGELOG

-   Added the following Components / Component Features

    -   Overlays

        -   `Overlay`

            -   `<Overlay orientation="horizontal/mobile:horizontal/tablet:horizontal/desktop:horizontal/widescreen:horizontal">` — Lays content out horizontally.

    -   Surfaces

        -   `Card` / `Tile`

            -   `<XXX.Footer orientation="vertical/mobile:vertical/tablet:vertical/desktop:vertical/widescreen:vertical">` — Lays content out vertically.
            -   `<XXX alignment="center/stretch" alignment_x="left/right/center/stretch" alignment_y="top/bottom/center/stretch">` — Used to align the content.