### PR TITLE
[Future] Change `<Ellipsis character="XXX" />` to `<Ellipsis>XXX</Ellipsis>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Updated the following Components / Component Features
+
+    -   Feedback
+
+        -   `Ellipsis`
+
+            -   **(BREAKING)** `<Ellipsis character />` — Changed from property to default slot, to support icons and other non-text characters.
+
 ## v0.4.5 - 2021/10/20
 
 -   Added CSS Theming Variables to the following Components: `Tab`.

--- a/src/lib/components/feedback/ellipsis/Ellipsis.svelte
+++ b/src/lib/components/feedback/ellipsis/Ellipsis.svelte
@@ -7,8 +7,6 @@
 
     type $$Props = {
         element?: HTMLSpanElement;
-
-        character?: string;
     } & IHTML5Properties &
         IGlobalProperties &
         IMarginProperties;
@@ -16,22 +14,19 @@
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
-    export let style: $$Props["style"] = "";
-
     export {_class as class};
-
-    export let character: $$Props["character"] = "";
-
-    $: _character = character ? `\\${character.charCodeAt(0).toString(16)}` : undefined;
 </script>
 
-<span
-    bind:this={element}
-    {...map_global_attributes($$props)}
-    class="ellipsis {_class}"
-    style={character ? `${style}--character:"${_character}";` : style}
->
-    <span />
-    <span />
-    <span />
+<span bind:this={element} {...map_global_attributes($$props)} class="ellipsis {_class}">
+    <span>
+        <slot>.</slot>
+    </span>
+
+    <span>
+        <slot>.</slot>
+    </span>
+
+    <span>
+        <slot>.</slot>
+    </span>
 </span>

--- a/src/lib/components/feedback/ellipsis/ellipsis.css
+++ b/src/lib/components/feedback/ellipsis/ellipsis.css
@@ -1,21 +1,11 @@
 .ellipsis {
-    --character: var(--ellipsis-character);
-
-    color: currentColor;
-
     white-space: nowrap;
 
-    transition: color var(--animation-visual-duration) var(--animation-visual-function);
-
     & > span {
+        display: inline;
+
         animation: ellipsis-pulse var(--animation-attention-duration)
             var(--animation-attention-function) infinite;
-
-        &::before {
-            display: inline;
-
-            content: var(--character);
-        }
 
         &:first-child {
             animation-delay: var(--ellipsis-content-first-animation-delay);

--- a/src/lib/components/feedback/ellipsis/ellipsis.stories.svelte
+++ b/src/lib/components/feedback/ellipsis/ellipsis.stories.svelte
@@ -30,3 +30,10 @@
         </Heading>
     </Stack>
 </Story>
+
+<Story name="Slot">
+    <Heading>
+        Loading
+        <Ellipsis>/</Ellipsis>
+    </Heading>
+</Story>


### PR DESCRIPTION
> This PR will be merged with other bigger planned breaking changes, later.

# CHANGELOG

-   Updated the following Components / Component Features

    -   Feedback

        -   `Ellipsis`

            -   **(BREAKING)** `<Ellipsis character />` — Changed from property to default slot, to support icons and other non-text characters.