### PR TITLE
Last Minute `0.4.6` Fixes

### DIFF
--- a/src/lib/components/layouts/stack/Stack.stories.svelte
+++ b/src/lib/components/layouts/stack/Stack.stories.svelte
@@ -7,8 +7,8 @@
     import Stack from "./Stack.svelte";
 
     const ORIENTATIONS = [
-        ["horizontal", true],
-        ["vertical", false],
+        ["vertical", true],
+        ["horizontal", false],
     ];
 
     const SPACINGS = [

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -105,14 +105,11 @@ export * from "./actions/keybind";
 export * from "./actions/intersection_observer";
 export * from "./actions/mutation_observer";
 
-export * from "./stores/component";
 export * from "./stores/darkmode";
 export * from "./stores/htmlpalette";
-export * from "./stores/id";
 export * from "./stores/mediaquery";
 export * from "./stores/prefersscheme";
 export * from "./stores/scrolllock";
-export * from "./stores/state";
 export * from "./stores/viewport";
 
 export * from "./util/environment";


### PR DESCRIPTION
# CHANGELOG

- Fixed ordering of `Stack`'s "Orientation" story
- Removed extraneous store exports