### PR TITLE
[0.4.10] Migrate "Typography" Components to Custom Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Added CSS Theming Variables to the following Components: `Blockquote`, `Code`, `Heading`, `Text`.
+
+-   Updated the following Components / Component Features
+
+    -   Typography
+
+        -   `Blockquote` / `Code` / `Heading` / `Text`
+
+            -   Added corresponding class names `blockquote` / `code` / `heading` / `text` respectively.
+
+        -   `Text`
+
+            -   Scoped attributes to `text` class to reduce CSS specificity conflict.
+
 ## v0.4.9 - 2021/10/27
 
 -   Hotfix for missing CSS distributables.

--- a/src/framework/index.css
+++ b/src/framework/index.css
@@ -34,15 +34,19 @@
 @import url("../lib/components/surfaces/card/card.theme.css");
 @import url("../lib/components/surfaces/hero/hero.theme.css");
 @import url("../lib/components/surfaces/tile/tile.theme.css");
+@import url("../lib/components/typography/blockquote/blockquote.theme.css");
+@import url("../lib/components/typography/code/code.theme.css");
+@import url("../lib/components/typography/heading/heading.theme.css");
+@import url("../lib/components/typography/text/text.theme.css");
 @import url("../lib/components/utilities/transition/transition.theme.css");
 
 @import url("./document.css");
 @import url("./embedded.css");
 
-@import url("../lib/components/typography/blockquote/blockquote.css");
-@import url("../lib/components/typography/code/code.css");
 @import url("../lib/components/typography/heading/heading.css");
 @import url("../lib/components/typography/text/text.css");
+@import url("../lib/components/typography/blockquote/blockquote.css");
+@import url("../lib/components/typography/code/code.css");
 
 @import url("../lib/components/interactables/button/button.css");
 @import url("../lib/components/interactables/check/check.css");

--- a/src/lib/components/typography/blockquote/BlockquoteContainer.svelte
+++ b/src/lib/components/typography/blockquote/BlockquoteContainer.svelte
@@ -23,12 +23,16 @@
 
     export let element: $$Props["element"] = undefined;
 
+    let _class: $$Props["class"] = "";
+    export {_class as class};
+
     export let palette: $$Props["palette"] = undefined;
 </script>
 
 <blockquote
     bind:this={element}
     {...map_global_attributes($$props)}
+    class="blockquote {_class}"
     {...map_data_attributes({palette})}
 >
     <slot />

--- a/src/lib/components/typography/blockquote/blockquote.css
+++ b/src/lib/components/typography/blockquote/blockquote.css
@@ -1,13 +1,18 @@
 blockquote {
-    --palette-background-lightest: var(--palette-inverse-off-lightest);
-    --palette-background-normal: var(--palette-neutral-normal);
+    position: relative;
 
-    @apply border-l-5 border-solid border-[rgb(var(--palette-background-normal))] px-[var(--spacing-root-large)]
-    py-[var(--spacing-root-medium)] relative;
+    padding: var(--blockquote-padding-y) var(--blockquote-padding-x);
 
-    background-color: rgba(var(--palette-background-lightest), theme("opacity.20"));
-    border-radius: var(--radius-small);
+    background: rgba(var(--blockquote-background-color), var(--blockquote-background-opacity));
+    border-left: var(--blockquote-border-width) var(--blockquote-border-style)
+        rgb(var(--blockquote-border-color));
+    border-radius: var(--blockquote-border-radius);
 
-    transition: background-color 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94),
-        border-color 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    transition: background var(--animation-visual-duration) var(--animation-visual-function),
+        border-color var(--animation-visual-duration) var(--animation-visual-function);
+
+    &[data-palette] {
+        border-color: rgb(var(--palette-background-normal));
+        background: rgba(var(--palette-background-lightest), var(--blockquote-background-opacity));
+    }
 }

--- a/src/lib/components/typography/blockquote/blockquote.theme.css
+++ b/src/lib/components/typography/blockquote/blockquote.theme.css
@@ -1,0 +1,12 @@
+:root {
+    /** */
+
+    --blockquote-background-color: var(--palette-inverse-off-lightest);
+    --blockquote-background-opacity: 0.2;
+    --blockquote-border-color: var(--palette-neutral-normal);
+    --blockquote-border-style: solid;
+    --blockquote-border-width: 5px;
+    --blockquote-border-radius: var(--radius-small);
+    --blockquote-padding-x: var(--spacing-root-large);
+    --blockquote-padding-y: var(--spacing-root-medium);
+}

--- a/src/lib/components/typography/code/Code.stories.svelte
+++ b/src/lib/components/typography/code/Code.stories.svelte
@@ -38,20 +38,30 @@
                 </Text>
 
                 <br />
-                <Code palette={palette === "default" ? undefined : palette}
-                    >import * as Kahi from "@kahi-ui/framework";</Code
-                >
+                <Code palette={palette === "default" ? undefined : palette}>
+                    import * as Kahi from "@kahi-ui/framework";
+                </Code>
             </div>
         {/each}
     </Stack>
 </Story>
 
 <Story name="Pre">
-    <!-- prettier-ignore -->
-    <Code is="pre">
-import math from "a-math-library";
+    <Stack orientation="horizontal" spacing="medium" variation="wrap">
+        {#each PALETTES as [palette, is_default]}
+            <div>
+                <Text is="strong">
+                    {`${palette.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                </Text>
 
+                <br />
+                <!-- prettier-ignore -->
+                <Code is="pre" palette={palette === "default" ? undefined : palette}>
+import math from "a-math-library";
+    
 const result = math.add(1, 1);
-console.log("Our value is:", result);
-</Code>
+console.log("Our value is:", result);</Code>
+            </div>
+        {/each}
+    </Stack>
 </Story>

--- a/src/lib/components/typography/code/Code.svelte
+++ b/src/lib/components/typography/code/Code.svelte
@@ -2,7 +2,6 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
-    import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
@@ -13,7 +12,6 @@
         is?: "code" | "pre";
 
         palette?: PROPERTY_PALETTE;
-        size?: PROPERTY_SIZING;
     } & IHTML5Properties &
         IGlobalProperties &
         IMarginProperties;
@@ -24,21 +22,23 @@
 
     export let element: $$Props["element"] = undefined;
 
+    let _class: $$Props["class"] = "";
+    export {_class as class};
+
     export let is: $$Props["is"] = "code";
 
     export let palette: $$Props["palette"] = undefined;
-    export let size: $$Props["size"] = undefined;
 </script>
 
 {#if is === "pre"}
     <pre
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="code {_class}"
         {...map_data_attributes({
             palette,
-            size,
         })}>
-        <code>
+        <code >
             <slot />
         </code>
     </pre>
@@ -46,7 +46,8 @@
     <code
         bind:this={element}
         {...map_global_attributes($$props)}
-        {...map_data_attributes({palette, size})}
+        class="code {_class}"
+        {...map_data_attributes({palette})}
     >
         <slot />
     </code>

--- a/src/lib/components/typography/code/code.css
+++ b/src/lib/components/typography/code/code.css
@@ -1,13 +1,32 @@
+code,
+pre {
+    --palette-background-lightest: var(--code-palette-background-lightest);
+
+    padding: var(--code-padding-y) var(--code-padding-x);
+
+    background: rgba(var(--palette-background-lightest), var(--code-background-opacity));
+    border-radius: var(--code-border-radius);
+
+    font-family: var(--code-font-family);
+
+    transition: background var(--animation-visual-duration) var(--animation-visual-function);
+}
+
 code {
-    --size-text-size: 80% !important;
+    font-size: var(--code-font-size);
 
-    @apply break-words;
+    overflow-wrap: break-word;
+}
 
-    font-size: var(--size-text-size);
+pre {
+    overflow-x: auto;
 }
 
 pre {
     & > code {
-        @apply bg-transparent p-0 whitespace-pre;
+        background: transparent;
+        padding: 0;
+
+        white-space: pre;
     }
 }

--- a/src/lib/components/typography/code/code.css
+++ b/src/lib/components/typography/code/code.css
@@ -20,9 +20,7 @@ code {
 
 pre {
     overflow-x: auto;
-}
 
-pre {
     & > code {
         background: transparent;
         padding: 0;

--- a/src/lib/components/typography/code/code.theme.css
+++ b/src/lib/components/typography/code/code.theme.css
@@ -1,0 +1,12 @@
+:root {
+    /** */
+
+    --code-palette-background-lightest: var(--palette-inverse-off-lightest);
+
+    --code-background-opacity: 0.2;
+    --code-font-family: var(--font-family-monospace);
+    --code-font-size: 80%;
+    --code-border-radius: var(--radius-small);
+    --code-padding-x: var(--spacing-local-small);
+    --code-padding-y: var(--spacing-local-tiny);
+}

--- a/src/lib/components/typography/heading/Heading.svelte
+++ b/src/lib/components/typography/heading/Heading.svelte
@@ -31,6 +31,9 @@
 
     export let element: $$Props["element"] = undefined;
 
+    let _class: $$Props["class"] = "";
+    export {_class as class};
+
     export let is: $$Props["is"] = "h1";
 
     export let align: $$Props["align"] = undefined;
@@ -44,6 +47,7 @@
     <h6
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="heading {_class}"
         {...map_data_attributes({align, palette, transform, variation})}
     >
         <slot />
@@ -52,6 +56,7 @@
     <h5
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="heading {_class}"
         {...map_data_attributes({align, palette, transform, variation})}
     >
         <slot />
@@ -60,6 +65,7 @@
     <h4
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="heading {_class}"
         {...map_data_attributes({align, palette, transform, variation})}
     >
         <slot />
@@ -68,6 +74,7 @@
     <h3
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="heading {_class}"
         {...map_data_attributes({align, palette, transform, variation})}
     >
         <slot />
@@ -76,6 +83,7 @@
     <h2
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="heading {_class}"
         {...map_data_attributes({align, palette, transform, variation})}
     >
         <slot />
@@ -84,6 +92,7 @@
     <h1
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="heading {_class}"
         {...map_data_attributes({align, palette, transform, variation})}
     >
         <slot />

--- a/src/lib/components/typography/heading/heading.css
+++ b/src/lib/components/typography/heading/heading.css
@@ -4,92 +4,86 @@ h3,
 h4,
 h5,
 h6 {
-    --palette-background-normal: currentColor;
+    color: currentColor;
+    font-weight: var(--heading-font-weight);
 
-    @apply font-bold text-[var(--palette-background-normal)];
+    transition: color var(--animation-visual-duration) var(--animation-visual-function);
 
-    text-align: var(--align-text, inherit);
-    text-transform: var(--transform-text, inherit);
-
-    transition: color 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    &[data-align] {
+        text-align: var(--align-text);
+    }
 
     &[data-palette] {
-        @apply text-[rgb(var(--palette-background-normal))];
+        color: rgb(var(--palette-background-normal));
+    }
+
+    &[data-transform] {
+        text-transform: var(--transform-text);
     }
 
     &[data-variation~="truncate"] {
-        @apply truncate;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 }
 
 h1 {
-    @apply leading-[var(--font-content-line-height-massive)];
-
-    font-size: var(--font-content-size-root-massive);
+    font-size: var(--heading-h1-font-size);
+    line-height: var(--heading-h1-line-height);
 
     &[data-variation~="headline"] {
-        @apply leading-[var(--font-headline-line-height-massive)];
-
-        font-size: var(--font-headline-size-root-massive);
+        font-size: var(--heading-h1-headline-font-size);
+        line-height: var(--heading-h1-headline-line-height);
     }
 }
 
 h2 {
-    @apply leading-[var(--font-content-line-height-huge)];
-
-    font-size: var(--font-content-size-root-huge);
+    font-size: var(--heading-h2-font-size);
+    line-height: var(--heading-h2-line-height);
 
     &[data-variation~="headline"] {
-        @apply leading-[var(--font-headline-line-height-huge)];
-
-        font-size: var(--font-headline-size-root-huge);
+        font-size: var(--heading-h2-headline-font-size);
+        line-height: var(--heading-h2-headline-line-height);
     }
 }
 
 h3 {
-    @apply leading-[var(--font-content-line-height-large)];
-
-    font-size: var(--font-content-size-root-large);
+    font-size: var(--heading-h3-font-size);
+    line-height: var(--heading-h3-line-height);
 
     &[data-variation~="headline"] {
-        @apply leading-[var(--font-headline-line-height-large)];
-
-        font-size: var(--font-headline-size-root-large);
+        font-size: var(--heading-h3-headline-font-size);
+        line-height: var(--heading-h3-headline-line-height);
     }
 }
 
 h4 {
-    @apply leading-[var(--font-content-line-height-medium)];
-
-    font-size: var(--font-content-size-root-medium);
+    font-size: var(--heading-h4-font-size);
+    line-height: var(--heading-h4-line-height);
 
     &[data-variation~="headline"] {
-        @apply leading-[var(--font-headline-line-height-medium)];
-
-        font-size: var(--font-headline-size-root-medium);
+        font-size: var(--heading-h4-headline-font-size);
+        line-height: var(--heading-h4-headline-line-height);
     }
 }
 
 h5 {
-    @apply leading-[var(--font-content-line-height-small)];
-
-    font-size: var(--font-content-size-root-small);
+    font-size: var(--heading-h5-font-size);
+    line-height: var(--heading-h5-line-height);
 
     &[data-variation~="headline"] {
-        @apply leading-[var(--font-headline-line-height-small)];
-
-        font-size: var(--font-headline-size-root-small);
+        font-size: var(--heading-h5-headline-font-size);
+        line-height: var(--heading-h5-headline-line-height);
     }
 }
 
 h6 {
-    @apply leading-[var(--font-content-line-height-tiny)];
-
-    font-size: var(--font-content-size-root-tiny);
+    font-size: var(--heading-h6-font-size);
+    line-height: var(--heading-h6-line-height);
 
     &[data-variation~="headline"] {
-        @apply leading-[var(--font-headline-line-height-tiny)];
-
-        font-size: var(--font-headline-size-root-tiny);
+        font-size: var(--heading-h6-headline-font-size);
+        line-height: var(--heading-h6-headline-line-height);
     }
 }

--- a/src/lib/components/typography/heading/heading.theme.css
+++ b/src/lib/components/typography/heading/heading.theme.css
@@ -1,0 +1,53 @@
+:root {
+    /** */
+
+    --heading-font-weight: bold;
+
+    /** */
+
+    --heading-h1-font-size: var(--font-content-size-root-massive);
+    --heading-h1-line-height: var(--font-content-line-height-massive);
+
+    --heading-h1-headline-font-size: var(--font-headline-size-root-massive);
+    --heading-h1-headline-line-height: var(--font-headline-line-height-massive);
+
+    /** */
+
+    --heading-h2-font-size: var(--font-content-size-root-huge);
+    --heading-h2-line-height: var(--font-content-line-height-huge);
+
+    --heading-h2-headline-font-size: var(--font-headline-size-root-huge);
+    --heading-h2-headline-line-height: var(--font-headline-line-height-huge);
+
+    /** */
+
+    --heading-h3-font-size: var(--font-content-size-root-large);
+    --heading-h3-line-height: var(--font-content-line-height-large);
+
+    --heading-h3-headline-font-size: var(--font-headline-size-root-large);
+    --heading-h3-headline-line-height: var(--font-headline-line-height-large);
+
+    /** */
+
+    --heading-h4-font-size: var(--font-content-size-root-medium);
+    --heading-h4-line-height: var(--font-content-line-height-medium);
+
+    --heading-h4-headline-font-size: var(--font-headline-size-root-medium);
+    --heading-h4-headline-line-height: var(--font-headline-line-height-medium);
+
+    /** */
+
+    --heading-h5-font-size: var(--font-content-size-root-small);
+    --heading-h5-line-height: var(--font-content-line-height-small);
+
+    --heading-h5-headline-font-size: var(--font-headline-size-root-small);
+    --heading-h5-headline-line-height: var(--font-headline-line-height-small);
+
+    /** */
+
+    --heading-h6-font-size: var(--font-content-size-root-tiny);
+    --heading-h6-line-height: var(--font-content-line-height-tiny);
+
+    --heading-h6-headline-font-size: var(--font-headline-size-root-tiny);
+    --heading-h6-headline-line-height: var(--font-headline-line-height-tiny);
+}

--- a/src/lib/components/typography/text/Text.stories.svelte
+++ b/src/lib/components/typography/text/Text.stories.svelte
@@ -170,3 +170,29 @@ p q r s t u v w x y z &lbrace; | &rbrace; ~
 ~ 0 1 2 3 4 5 6 7 8 9 : ; &lt; = &gt; ? @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ] ^ _ ` a b c d e f g h i j k l m n o p q r s t u v w x y z &lbrace; | &rbrace; ~
 </Text>
 </Story>
+
+<Story name="Other Tags">
+    <Stack alignment_x="left" spacing="medium">
+        <Text is="abbr">Abbreviation</Text>
+
+        <Text is="b">Bold</Text>
+        <Text is="strong">Strong</Text>
+
+        <Text is="del">Deleted</Text>
+        <Text is="s">Strikethrough</Text>
+
+        <Text is="em">Emphasis</Text>
+        <Text is="i">Italic</Text>
+
+        <Text is="ins">Inserted</Text>
+        <Text is="u">Underline</Text>
+
+        <Text is="kbd">CTRL + C</Text>
+        <Text is="mark">Highlighted</Text>
+        <Text is="samp">Sample</Text>
+        <Text is="small">Small</Text>
+
+        <Text is="sub">sub</Text>
+        <Text is="sup">sup</Text>
+    </Stack>
+</Story>

--- a/src/lib/components/typography/text/Text.svelte
+++ b/src/lib/components/typography/text/Text.svelte
@@ -51,6 +51,9 @@
 
     export let element: $$Props["element"] = undefined;
 
+    let _class: $$Props["class"] = "";
+    export {_class as class};
+
     export let is: $$Props["is"] = "p";
 
     export let align: $$Props["align"] = undefined;
@@ -65,6 +68,7 @@
     <abbr
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
     >
         <slot />
@@ -73,6 +77,7 @@
     <b
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
     >
         <slot />
@@ -81,6 +86,7 @@
     <del
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
     >
         <slot />
@@ -89,6 +95,7 @@
     <em
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
     >
         <slot />
@@ -97,6 +104,7 @@
     <i
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
     >
         <slot />
@@ -105,6 +113,7 @@
     <ins
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
     >
         <slot />
@@ -113,7 +122,8 @@
     <kbd
         bind:this={element}
         {...map_global_attributes($$props)}
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        class="text {_class}"
+        {...map_data_attributes({align, palette, transform, variation})}
     >
         <slot />
     </kbd>
@@ -121,6 +131,7 @@
     <mark
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
     >
         <slot />
@@ -129,10 +140,10 @@
     <pre
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({
             align,
             palette,
-            size,
             transform,
             variation,
         })}>
@@ -142,6 +153,7 @@
     <s
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
     >
         <slot />
@@ -150,6 +162,7 @@
     <samp
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
     >
         <slot />
@@ -158,7 +171,8 @@
     <small
         bind:this={element}
         {...map_global_attributes($$props)}
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        class="text {_class}"
+        {...map_data_attributes({align, palette, transform, variation})}
     >
         <slot />
     </small>
@@ -166,6 +180,7 @@
     <span
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
     >
         <slot />
@@ -174,6 +189,7 @@
     <strong
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
     >
         <slot />
@@ -182,6 +198,7 @@
     <sub
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
     >
         <slot />
@@ -190,6 +207,7 @@
     <sup
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
     >
         <slot />
@@ -198,6 +216,7 @@
     <u
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
     >
         <slot />
@@ -206,6 +225,7 @@
     <p
         bind:this={element}
         {...map_global_attributes($$props)}
+        class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
     >
         <slot />

--- a/src/lib/components/typography/text/text.css
+++ b/src/lib/components/typography/text/text.css
@@ -1,106 +1,54 @@
-/**
- * TODO: A bit lame having to use `:not` selectors due to the `span` selector. Need to
- * update to use `:where`, when support is better.
- */
+.text {
+    color: currentColor;
+    transition: color var(--animation-visual-duration) var(--animation-visual-function);
 
-abbr,
-b,
-del,
-em,
-i,
-ins,
-kbd,
-mark,
-p,
-pre,
-s,
-samp,
-small,
-span:not([class], [role]),
-strong,
-sub,
-sup,
-u {
-    --palette-background-normal: currentColor;
-
-    @apply text-[var(--palette-background-normal)];
-
-    text-align: var(--align-text);
-    text-transform: var(--transform-text);
-
-    transition: color 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-
-    &:not([data-align]) {
-        --align-text: inherit;
+    &[data-align] {
+        text-align: var(--align-text);
     }
 
     &[data-palette] {
-        @apply text-[rgb(var(--palette-background-normal))];
+        color: rgb(var(--palette-background-normal));
     }
 
-    &:not([data-variation]) {
-        @apply leading-[var(--size-text-line-height)];
-
+    &[data-size] {
         font-size: var(--size-text-size);
+        line-height: var(--size-text-line-height);
+    }
+
+    &[data-transform] {
+        text-transform: var(--transform-text);
     }
 
     &[data-variation~="headline"] {
-        @apply leading-[var(--size-headline-line-height)];
-
-        font-size: var(--size-headline-size);
-    }
-
-    &:not([data-size]) {
-        --size-text-size: inherit;
-        --size-text-line-height: inherit;
-    }
-
-    &:not([data-transform]) {
-        --transform-text: inherit;
+        &[data-size] {
+            font-size: var(--size-headline-size);
+            line-height: var(--size-headline-line-height);
+        }
     }
 
     &[data-variation~="truncate"] {
-        @apply truncate;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 }
 
 kbd {
-    --palette-background-normal: var(--palette-neutral-normal);
+    padding: var(--text-kbd-padding-y) var(--text-kbd-padding-x);
 
-    --size-text-size: 70% !important;
+    background: rgba(var(--text-kbd-background-color), var(--text-kbd-background-opacity));
+    border-bottom: var(--text-kbd-border-width) var(--text-kbd-border-style)
+        rgb(var(--text-kbd-border-color));
+    border-radius: var(--text-kbd-border-radius);
 
-    @apply border-b-4 border-[rgb(var(--palette-background-normal))] text-extrabold whitespace-nowrap;
+    font-size: var(--text-kbd-font-size);
+    font-family: var(--text-kbd-font-family);
+    font-weight: var(--text-kbd-font-weight);
 
-    border-style: ridge;
-
-    font-size: var(--size-text-size);
-}
-
-pre {
-    @apply overflow-x-auto;
-}
-
-code,
-kbd,
-pre {
-    --palette-background-lightest: var(--palette-inverse-off-lightest);
-
-    @apply px-[var(--spacing-local-small)] py-[var(--spacing-local-tiny)] rounded-md;
-
-    background: rgba(var(--palette-background-lightest), theme("opacity.20"));
-
-    font-family: var(--font-family-monospace);
-
-    &,
-    &[data-palette] {
-        @apply text-current;
-    }
+    white-space: nowrap;
 }
 
 small {
-    --size-text-size: 80% !important;
-
-    @apply opacity-75;
-
-    font-size: var(--size-text-size);
+    font-size: var(--text-small-font-size);
+    opacity: var(--text-small-opacity);
 }

--- a/src/lib/components/typography/text/text.theme.css
+++ b/src/lib/components/typography/text/text.theme.css
@@ -1,0 +1,20 @@
+:root {
+    /** */
+
+    --text-kbd-background-color: var(--palette-inverse-off-lightest);
+    --text-kbd-background-opacity: 0.2;
+    --text-kbd-border-color: var(--palette-neutral-normal);
+    --text-kbd-border-radius: var(--radius-small);
+    --text-kbd-border-style: ridge;
+    --text-kbd-border-width: 4px;
+    --text-kbd-font-family: var(--font-family-monospace);
+    --text-kbd-font-size: 70%;
+    --text-kbd-font-weight: bolder;
+    --text-kbd-padding-x: var(--spacing-local-small);
+    --text-kbd-padding-y: var(--spacing-local-tiny);
+
+    /** */
+
+    --text-small-font-size: 80%;
+    --text-small-opacity: 0.75;
+}

--- a/src/lib/types/hidden.ts
+++ b/src/lib/types/hidden.ts
@@ -8,4 +8,4 @@ export const TOKENS_HIDDEN = {
     ...TOKENS_VIEWPORT,
 } as const;
 
-export type PROPERTY_HIDDEN = ArrayEnum<LiteralEnum<keyof typeof TOKENS_HIDDEN>>;
+export type PROPERTY_HIDDEN = boolean | ArrayEnum<LiteralEnum<keyof typeof TOKENS_HIDDEN>>;


### PR DESCRIPTION
# CHANGELOG

-   Added CSS Theming Variables to the following Components: `Blockquote`, `Code`, `Heading`, `Text`.

-   Updated the following Components / Component Features

    -   Typography

        -   `Blockquote` / `Code` / `Heading` / `Text`

            -   Added corresponding class names `blockquote` / `code` / `heading` / `text` respectively.

        -   `Text`

            -   Scoped attributes to `text` class to reduce CSS specificity conflict.