### PR TITLE
[0.4.11] Improve DateTime Component Typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Added the following Components / Component Features
+
+    -   Display
+
+        -   `DateStamp`, `DateTimeStamp`, `TimeStamp`
+
+            -   Updated typings to make `calendar` and `locale` properties optional as intended.
+
 ## v0.4.10 - 2021/11/14
 
 -   Added CSS Theming Variables to the following Components: `Blockquote`, `Code`, `Heading`, `Text`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,6 @@
 
 -   Updated the following Components / Component Features
 
-    -   `TimePicker`
-
-        -   Up
-
     -   Display
 
         -   `DateStamp`, `DateTimeStamp`, `TimeStamp`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 -   Added the following Components / Component Features
 
+    -   `TimePicker`
+
+        -   Respects system default for `<TimePicker hour_12={boolean}>` property.
+
+-   Fixed the following Components / Component Features
+
+    -   Widgets
+
+        -   `TimePicker`
+
+            -   Displayed range of clock times will now be flat `hh:mm:ss` values, stripping microsecond, minisecond, and nanosecond units.
+
+-   Updated the following Components / Component Features
+
+    -   `TimePicker`
+
+        -   Up
+
     -   Display
 
         -   `DateStamp`, `DateTimeStamp`, `TimeStamp`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 -   Added the following Components / Component Features
 
-    -   `TimePicker`
+    -   Widgets
 
-        -   Respects system default for `<TimePicker hour_12={boolean}>` property.
+        -   `TimePicker`
+
+            -   Respects system default for `<TimePicker hour_12={boolean}>` property.
 
 -   Fixed the following Components / Component Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@
 
         -   `DateStamp`, `DateTimeStamp`, `TimeStamp`
 
-            -   Updated typings to make `calendar` and `locale` properties optional as intended.
+            -   Updated typings to make `calendar` and `locale` properties optional as originally intended.
+
+    -   Widgets
+
+        -   `DayPicker`, `DayStepper`, `MonthPicker`, `MonthStepper`, `TimePicker`, `YearPicker`, `YearStepper`
+
+            -   Updated typings to make `calendar`, `day`, `disabled`, `highlight`, `locale`, `month`, `step`, `timestamp`, `value`, and `weekday` properties optional.
 
 ## v0.4.10 - 2021/11/14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,13 @@
 
     -   Display
 
-        -   `DateStamp`, `DateTimeStamp`, `TimeStamp`
+        -   `DateStamp` / `DateTimeStamp` / `TimeStamp`
 
             -   Updated typings to make `calendar` and `locale` properties optional as originally intended.
 
     -   Widgets
 
-        -   `DayPicker`, `DayStepper`, `MonthPicker`, `MonthStepper`, `TimePicker`, `YearPicker`, `YearStepper`
+        -   `DayPicker` / `DayStepper` / `MonthPicker` / `MonthStepper` / `TimePicker` / `YearPicker` / `YearStepper`
 
             -   Updated typings to make `calendar`, `day`, `disabled`, `highlight`, `locale`, `month`, `step`, `timestamp`, `value`, and `weekday` properties optional.
 

--- a/src/lib/components/display/datestamp/DateStamp.svelte
+++ b/src/lib/components/display/datestamp/DateStamp.svelte
@@ -12,8 +12,8 @@
     type $$Props = {
         element?: HTMLTimeElement;
 
-        calendar: string;
-        locale: string;
+        calendar?: string;
+        locale?: string;
 
         day?: Intl.DateTimeFormatOptions["day"];
         month?: Intl.DateTimeFormatOptions["month"];
@@ -30,8 +30,8 @@
     let _class = "";
     export {_class as class};
 
-    export let calendar: $$Props["calendar"] = DEFAULT_CALENDAR;
-    export let locale: $$Props["locale"] = DEFAULT_LOCALE;
+    export let calendar: $$Props["calendar"] = undefined;
+    export let locale: $$Props["locale"] = undefined;
 
     export let day: $$Props["day"] = undefined;
     export let month: $$Props["month"] = undefined;
@@ -53,8 +53,8 @@
     class="date-stamp {_class}"
     datetime={_date.toString({calendarName: "never"})}
 >
-    {_date.toLocaleString(locale, {
-        calendar,
+    {_date.toLocaleString(locale ?? DEFAULT_LOCALE, {
+        calendar: calendar ?? DEFAULT_CALENDAR,
         day: _options.day,
         month: _options.month,
         weekday: _options.weekday,

--- a/src/lib/components/display/datetimestamp/DateTimeStamp.svelte
+++ b/src/lib/components/display/datetimestamp/DateTimeStamp.svelte
@@ -13,8 +13,8 @@
     type $$Props = {
         element?: HTMLTimeElement;
 
-        calendar: string;
-        locale: string;
+        calendar?: string;
+        locale?: string;
 
         day?: Intl.DateTimeFormatOptions["day"];
         month?: Intl.DateTimeFormatOptions["month"];
@@ -36,8 +36,8 @@
     let _class = "";
     export {_class as class};
 
-    export let calendar: $$Props["calendar"] = DEFAULT_CALENDAR;
-    export let locale: $$Props["locale"] = DEFAULT_LOCALE;
+    export let calendar: $$Props["calendar"] = undefined;
+    export let locale: $$Props["locale"] = undefined;
 
     export let day: $$Props["day"] = undefined;
     export let month: $$Props["month"] = undefined;
@@ -69,8 +69,8 @@
     class="date-time-stamp {_class}"
     datetime={_datetime.toString({calendarName: "never"})}
 >
-    {_datetime.toLocaleString(locale, {
-        calendar,
+    {_datetime.toLocaleString(locale ?? DEFAULT_LOCALE, {
+        calendar: calendar ?? DEFAULT_CALENDAR,
         day: _options.day,
         month: _options.month,
         weekday: _options.weekday,

--- a/src/lib/components/display/timestamp/TimeStamp.svelte
+++ b/src/lib/components/display/timestamp/TimeStamp.svelte
@@ -12,7 +12,7 @@
     type $$Props = {
         element?: HTMLTimeElement;
 
-        locale: string;
+        locale?: string;
 
         hour?: Intl.DateTimeFormatOptions["hour"];
         hour_12?: Intl.DateTimeFormatOptions["hour12"];
@@ -29,7 +29,7 @@
     let _class = "";
     export {_class as class};
 
-    export let locale: $$Props["locale"] = DEFAULT_LOCALE;
+    export let locale: $$Props["locale"] = undefined;
 
     export let hour: $$Props["hour"] = undefined;
     export let hour_12: $$Props["hour_12"] = undefined;
@@ -48,7 +48,7 @@
     class="time-stamp {_class}"
     datetime={_time.toString()}
 >
-    {_time.toLocaleString(locale, {
+    {_time.toLocaleString(locale ?? DEFAULT_LOCALE, {
         hour: _options.hour,
         hour12: _options.hour_12,
         minute: _options.minute,

--- a/src/lib/components/widgets/daypicker/DayPicker.svelte
+++ b/src/lib/components/widgets/daypicker/DayPicker.svelte
@@ -36,19 +36,19 @@
         once?: boolean;
         readonly?: boolean;
 
-        calendar: string;
-        locale: string;
+        calendar?: string;
+        locale?: string;
 
-        day: Intl.DateTimeFormatOptions["day"];
-        weekday: Intl.DateTimeFormatOptions["weekday"];
+        day?: Intl.DateTimeFormatOptions["day"];
+        weekday?: Intl.DateTimeFormatOptions["weekday"];
 
-        disabled: boolean | readonly string[];
+        disabled?: boolean | readonly string[];
         max?: string;
         min?: string;
 
-        highlight: readonly string[];
-        timestamp: string;
-        value: readonly string[];
+        highlight?: readonly string[];
+        timestamp?: string;
+        value?: readonly string[];
 
         palette?: PROPERTY_PALETTE;
         sizing?: PROPERTY_SIZING;
@@ -63,50 +63,57 @@
     let _class = "";
     export {_class as class};
 
-    export let multiple: $$Props["multiple"] = false;
-    export let once: $$Props["once"] = false;
-    export let readonly: $$Props["readonly"] = false;
+    export let multiple: $$Props["multiple"] = undefined;
+    export let once: $$Props["once"] = undefined;
+    export let readonly: $$Props["readonly"] = undefined;
 
-    export let calendar: $$Props["calendar"] = DEFAULT_CALENDAR;
-    export let locale: $$Props["locale"] = DEFAULT_LOCALE;
+    export let calendar: $$Props["calendar"] = undefined;
+    export let locale: $$Props["locale"] = undefined;
 
-    export let day: $$Props["day"] = "2-digit";
-    export let weekday: $$Props["weekday"] = "short";
+    export let day: $$Props["day"] = undefined;
+    export let weekday: $$Props["weekday"] = undefined;
 
-    export let disabled: $$Props["disabled"] = false;
+    export let disabled: $$Props["disabled"] = undefined;
     export let max: $$Props["max"] = undefined;
     export let min: $$Props["min"] = undefined;
 
-    export let highlight: $$Props["highlight"] = [get_daystamp(calendar)];
-    export let timestamp: $$Props["timestamp"] = get_monthstamp(calendar);
-    export let value: $$Props["value"] = [];
+    export let highlight: $$Props["highlight"] = undefined;
+    export let timestamp: $$Props["timestamp"] = undefined;
+    export let value: $$Props["value"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
 
     function on_day_click(day: Temporal.PlainDate, event: MouseEvent): void {
         if (readonly) return;
 
-        if (!once && has_day(value, day)) {
-            value = multiple ? value.filter((entry) => !day.equals(entry)) : [];
+        if (!once && has_day(_value, day)) {
+            value = multiple ? _value.filter((entry) => !day.equals(entry)) : [];
 
             dispatch("change");
         } else {
             value = multiple
-                ? [...value, day.toString({calendarName: "always"})]
+                ? [..._value, day.toString({calendarName: "always"})]
                 : [day.toString({calendarName: "always"})];
 
             dispatch("change");
         }
     }
 
-    $: _weeks = get_calendar_weeks(timestamp);
+    const _daystamp = get_daystamp(calendar ?? DEFAULT_CALENDAR);
+    const _monthstamp = get_monthstamp(calendar ?? DEFAULT_CALENDAR);
+
+    $: _highlight = highlight ?? [_daystamp];
+    $: _weeks = get_calendar_weeks(timestamp ?? _monthstamp);
+    $: _value = value ?? [];
 </script>
 
 <WidgetContainer {...$$props} bind:element class="day-picker {_class}">
     <WidgetSection>
         {#each _weeks[0] as _day (_day.dayOfWeek)}
             <WidgetHeader>
-                {_day.toLocaleString(locale, {weekday}).toLocaleUpperCase(locale)}
+                {_day
+                    .toLocaleString(locale ?? DEFAULT_LOCALE, {weekday: weekday ?? "short"})
+                    .toLocaleUpperCase(locale ?? DEFAULT_LOCALE)}
             </WidgetHeader>
         {/each}
     </WidgetSection>
@@ -115,14 +122,14 @@
         <WidgetSection>
             {#each _week as _day (`${_day.month}${_day.day}`)}
                 <WidgetButton
-                    variation={has_day(highlight, _day) ? "outline" : undefined}
+                    variation={has_day(_highlight, _day) ? "outline" : undefined}
                     palette={_day.dayOfWeek > 5 ? undefined : palette}
-                    active={has_day(value, _day)}
+                    active={has_day(_value, _day)}
                     disabled={!is_day_in_range(_day, max, min, true) ||
-                        (typeof disabled === "boolean" ? disabled : has_day(disabled, _day))}
+                        (disabled instanceof Array ? has_day(disabled, _day) : disabled)}
                     on:click={on_day_click.bind(null, _day)}
                 >
-                    {_day.toLocaleString(locale, {day})}
+                    {_day.toLocaleString(locale, {day: day ?? "2-digit"})}
                 </WidgetButton>
             {/each}
         </WidgetSection>

--- a/src/lib/components/widgets/daystepper/DayStepper.svelte
+++ b/src/lib/components/widgets/daystepper/DayStepper.svelte
@@ -30,18 +30,18 @@
         disabled?: boolean;
         readonly?: boolean;
 
-        calendar: string;
-        locale: string;
+        calendar?: string;
+        locale?: string;
 
-        day: Intl.DateTimeFormatOptions["day"];
-        month: Intl.DateTimeFormatOptions["month"];
-        weekday: Intl.DateTimeFormatOptions["weekday"];
+        day?: Intl.DateTimeFormatOptions["day"];
+        month?: Intl.DateTimeFormatOptions["month"];
+        weekday?: Intl.DateTimeFormatOptions["weekday"];
 
         max?: string;
         min?: string;
-        step: number | string;
+        step?: number | string;
 
-        value: string;
+        value?: string;
 
         palette?: PROPERTY_PALETTE;
         sizing?: PROPERTY_SIZING;
@@ -62,21 +62,21 @@
     let _class = "";
     export {_class as class};
 
-    export let disabled: $$Props["disabled"] = false;
-    export let readonly: $$Props["readonly"] = false;
+    export let disabled: $$Props["disabled"] = undefined;
+    export let readonly: $$Props["readonly"] = undefined;
 
-    export let calendar: $$Props["calendar"] = DEFAULT_CALENDAR;
-    export let locale: $$Props["locale"] = DEFAULT_LOCALE;
+    export let calendar: $$Props["calendar"] = undefined;
+    export let locale: $$Props["locale"] = undefined;
 
-    export let day: $$Props["day"] = "2-digit";
-    export let month: $$Props["month"] = "long";
-    export let weekday: $$Props["weekday"] = "long";
+    export let day: $$Props["day"] = undefined;
+    export let month: $$Props["month"] = undefined;
+    export let weekday: $$Props["weekday"] = undefined;
 
     export let max: $$Props["max"] = undefined;
     export let min: $$Props["min"] = undefined;
-    export let step: $$Props["step"] = 1;
+    export let step: $$Props["step"] = undefined;
 
-    export let value: $$Props["value"] = get_daystamp(calendar);
+    export let value: $$Props["value"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
 
@@ -90,14 +90,20 @@
         dispatch("change");
     }
 
-    $: _step = typeof step === "string" ? Math.abs(parseInt(step)) : Math.abs(step);
-    $: _day = Temporal.PlainDate.from(value);
+    const _daystamp = get_daystamp(calendar ?? DEFAULT_CALENDAR);
+
+    $: _day = Temporal.PlainDate.from(value ?? _daystamp);
+    $: _step = step ? (typeof step === "string" ? Math.abs(parseInt(step)) : Math.abs(step)) : 1;
 </script>
 
 <WidgetContainer {...$$props} bind:element class="day-stepper {_class}">
     <Stack orientation="horizontal" alignment_y="center">
         <WidgetHeader>
-            {_day.toLocaleString(locale, {month, weekday, day})}
+            {_day.toLocaleString(locale ?? DEFAULT_LOCALE, {
+                day: day ?? "2-digit",
+                month: month ?? "long",
+                weekday: weekday ?? "long",
+            })}
         </WidgetHeader>
 
         <Spacer variation="inline" />

--- a/src/lib/components/widgets/monthpicker/MonthPicker.svelte
+++ b/src/lib/components/widgets/monthpicker/MonthPicker.svelte
@@ -35,18 +35,18 @@
         once?: boolean;
         readonly?: boolean;
 
-        calendar: string;
-        locale: string;
+        calendar?: string;
+        locale?: string;
 
-        month: Intl.DateTimeFormatOptions["month"];
+        month?: Intl.DateTimeFormatOptions["month"];
 
-        disabled: boolean | readonly string[];
+        disabled?: boolean | readonly string[];
         max?: string;
         min?: string;
 
-        highlight: readonly string[];
-        timestamp: string;
-        value: readonly string[];
+        highlight?: readonly string[];
+        timestamp?: string;
+        value?: readonly string[];
 
         palette?: PROPERTY_PALETTE;
         sizing?: PROPERTY_SIZING;
@@ -61,21 +61,21 @@
     let _class = "";
     export {_class as class};
 
-    export let multiple: $$Props["multiple"] = false;
-    export let once: $$Props["once"] = false;
-    export let readonly: $$Props["readonly"] = false;
+    export let multiple: $$Props["multiple"] = undefined;
+    export let once: $$Props["once"] = undefined;
+    export let readonly: $$Props["readonly"] = undefined;
 
-    export let calendar: $$Props["calendar"] = DEFAULT_CALENDAR;
-    export let locale: $$Props["locale"] = DEFAULT_LOCALE;
+    export let calendar: $$Props["calendar"] = undefined;
+    export let locale: $$Props["locale"] = undefined;
 
     export let month: $$Props["month"] = "short";
 
-    export let disabled: $$Props["disabled"] = false;
+    export let disabled: $$Props["disabled"] = undefined;
     export let max: $$Props["max"] = undefined;
     export let min: $$Props["min"] = undefined;
 
-    export let highlight: $$Props["highlight"] = [get_monthstamp(calendar)];
-    export let timestamp: $$Props["timestamp"] = get_yearstamp(calendar);
+    export let highlight: $$Props["highlight"] = undefined;
+    export let timestamp: $$Props["timestamp"] = undefined;
     export let value: $$Props["value"] = [];
 
     export let palette: $$Props["palette"] = undefined;
@@ -83,20 +83,25 @@
     function on_month_click(month: Temporal.PlainYearMonth, event: MouseEvent): void {
         if (readonly) return;
 
-        if (!once && has_month(value, month)) {
-            value = multiple ? value.filter((entry) => !month.equals(entry)) : [];
+        if (!once && has_month(_value, month)) {
+            value = multiple ? _value.filter((entry) => !month.equals(entry)) : [];
 
             dispatch("change");
         } else {
             value = multiple
-                ? [...value, month.toString({calendarName: "always"})]
+                ? [..._value, month.toString({calendarName: "always"})]
                 : [month.toString({calendarName: "always"})];
 
             dispatch("change");
         }
     }
 
-    $: _quaters = get_calendar_quaters(timestamp);
+    const _monthstamp = get_monthstamp(calendar ?? DEFAULT_CALENDAR);
+    const _yearstamp = get_yearstamp(calendar ?? DEFAULT_CALENDAR);
+
+    $: _highlight = highlight ?? [_monthstamp];
+    $: _quaters = get_calendar_quaters(timestamp ?? _yearstamp);
+    $: _value = value ?? [];
 </script>
 
 <WidgetContainer {...$$props} bind:element class="month-picker {_class}">
@@ -104,14 +109,16 @@
         <WidgetSection>
             {#each _quater as _month (_month.month)}
                 <WidgetButton
-                    variation={has_month(highlight, _month) ? "outline" : undefined}
+                    variation={has_month(_highlight, _month) ? "outline" : undefined}
                     palette={_month.month % (_month.monthsInYear / 4) === 1 ? undefined : palette}
-                    active={has_month(value, _month)}
+                    active={has_month(_value, _month)}
                     disabled={!is_month_in_range(_month, max, min, true) ||
-                        (typeof disabled === "boolean" ? disabled : has_month(disabled, _month))}
+                        (disabled instanceof Array ? has_month(disabled, _month) : disabled)}
                     on:click={on_month_click.bind(null, _month)}
                 >
-                    {_month.toLocaleString(locale, {month}).toLocaleUpperCase(locale)}
+                    {_month
+                        .toLocaleString(locale ?? DEFAULT_LOCALE, {month: month ?? "short"})
+                        .toLocaleUpperCase(locale ?? DEFAULT_LOCALE)}
                 </WidgetButton>
             {/each}
         </WidgetSection>

--- a/src/lib/components/widgets/monthpicker/MonthPicker.svelte
+++ b/src/lib/components/widgets/monthpicker/MonthPicker.svelte
@@ -68,7 +68,7 @@
     export let calendar: $$Props["calendar"] = undefined;
     export let locale: $$Props["locale"] = undefined;
 
-    export let month: $$Props["month"] = "short";
+    export let month: $$Props["month"] = undefined;
 
     export let disabled: $$Props["disabled"] = undefined;
     export let max: $$Props["max"] = undefined;
@@ -76,7 +76,7 @@
 
     export let highlight: $$Props["highlight"] = undefined;
     export let timestamp: $$Props["timestamp"] = undefined;
-    export let value: $$Props["value"] = [];
+    export let value: $$Props["value"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
 

--- a/src/lib/components/widgets/monthstepper/MonthStepper.svelte
+++ b/src/lib/components/widgets/monthstepper/MonthStepper.svelte
@@ -30,17 +30,17 @@
         disabled?: boolean;
         readonly?: boolean;
 
-        calendar: string;
-        locale: string;
+        calendar?: string;
+        locale?: string;
 
-        month: Intl.DateTimeFormatOptions["month"];
-        year: Intl.DateTimeFormatOptions["year"];
+        month?: Intl.DateTimeFormatOptions["month"];
+        year?: Intl.DateTimeFormatOptions["year"];
 
         max?: string;
         min?: string;
-        step: number | string;
+        step?: number | string;
 
-        value: string;
+        value?: string;
         palette?: PROPERTY_PALETTE;
         sizing?: PROPERTY_SIZING;
     } & IHTML5Properties &
@@ -60,20 +60,20 @@
     let _class = "";
     export {_class as class};
 
-    export let disabled: $$Props["disabled"] = false;
-    export let readonly: $$Props["readonly"] = false;
+    export let disabled: $$Props["disabled"] = undefined;
+    export let readonly: $$Props["readonly"] = undefined;
 
-    export let calendar: $$Props["calendar"] = DEFAULT_CALENDAR;
-    export let locale: $$Props["locale"] = DEFAULT_LOCALE;
+    export let calendar: $$Props["calendar"] = undefined;
+    export let locale: $$Props["locale"] = undefined;
 
-    export let month: $$Props["month"] = "long";
-    export let year: $$Props["year"] = "numeric";
+    export let month: $$Props["month"] = undefined;
+    export let year: $$Props["year"] = undefined;
 
     export let max: $$Props["max"] = undefined;
     export let min: $$Props["min"] = undefined;
-    export let step: $$Props["step"] = 1;
+    export let step: $$Props["step"] = undefined;
 
-    export let value: $$Props["value"] = get_monthstamp(calendar);
+    export let value: $$Props["value"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
 
@@ -94,14 +94,19 @@
         dispatch("change");
     }
 
-    $: _month = Temporal.PlainYearMonth.from(value);
-    $: _step = typeof step === "string" ? Math.abs(parseInt(step)) : Math.abs(step);
+    const _monthstamp = get_monthstamp(calendar ?? DEFAULT_CALENDAR);
+
+    $: _month = Temporal.PlainYearMonth.from(value ?? _monthstamp);
+    $: _step = step ? (typeof step === "string" ? Math.abs(parseInt(step)) : Math.abs(step)) : 1;
 </script>
 
 <WidgetContainer {...$$props} bind:element class="month-stepper {_class}">
     <Stack orientation="horizontal" alignment_y="center">
         <WidgetHeader>
-            {_month.toLocaleString(locale, {month, year})}
+            {_month.toLocaleString(locale ?? DEFAULT_LOCALE, {
+                month: month ?? "long",
+                year: year ?? "numeric",
+            })}
         </WidgetHeader>
 
         <Spacer variation="inline" />

--- a/src/lib/components/widgets/timepicker/TimePicker.svelte
+++ b/src/lib/components/widgets/timepicker/TimePicker.svelte
@@ -131,7 +131,9 @@
 
     const _timestamp = get_timestamp();
 
-    $: [_hours, _minutes, _seconds] = get_clock_ranges(value || min, hour_12, period);
+    $: _hour_12 = hour_12 ?? DEFAULT_HOUR_12;
+
+    $: [_hours, _minutes, _seconds] = get_clock_ranges(value || min, _hour_12, period);
 
     $: _highlight = Temporal.PlainTime.from(highlight ?? _timestamp);
     $: _value = value ? Temporal.PlainTime.from(value) : null;
@@ -150,7 +152,7 @@
                 >
                     {_hour.toLocaleString(locale ?? DEFAULT_LOCALE, {
                         hour: hour ?? "2-digit",
-                        hour12: hour_12 ?? DEFAULT_HOUR_12,
+                        hour12: _hour_12,
                     })}
                 </WidgetButton>
             {/each}
@@ -202,14 +204,14 @@
         </WidgetSection>
     </WidgetSection>
 
-    {#if hour_12 || now}
+    {#if _hour_12 || now}
         <!-- TODO: Figure out localization strategy for below text strings -->
         <WidgetSection>
             {#if now}
                 <WidgetButton {disabled} {palette} on:click={on_now_click}>NOW</WidgetButton>
             {/if}
 
-            {#if hour_12}
+            {#if _hour_12}
                 <WidgetButton
                     active={period === TOKENS_CLOCK_PERIOD.am}
                     {disabled}

--- a/src/lib/components/widgets/timepicker/TimePicker.svelte
+++ b/src/lib/components/widgets/timepicker/TimePicker.svelte
@@ -13,7 +13,7 @@
 
     import {get_clock_ranges, get_timestamp, is_time_in_range} from "../../../util/datetime";
     import {scroll_into_container} from "../../../util/element";
-    import {DEFAULT_LOCALE} from "../../../util/locale";
+    import {DEFAULT_HOUR_12, DEFAULT_LOCALE} from "../../../util/locale";
 
     import WidgetButton from "../widget/WidgetButton.svelte";
     import WidgetContainer from "../widget/WidgetContainer.svelte";
@@ -32,7 +32,7 @@
         readonly?: boolean;
         scroll?: boolean;
 
-        locale: string;
+        locale?: string;
 
         hour?: Intl.DateTimeFormatOptions["hour"];
         hour_12?: Intl.DateTimeFormatOptions["hour12"];
@@ -40,12 +40,12 @@
         minute?: Intl.DateTimeFormatOptions["minute"];
         second?: Intl.DateTimeFormatOptions["second"];
 
-        disabled: boolean;
+        disabled?: boolean;
         max?: string;
         min?: string;
 
-        highlight: string;
-        value: string;
+        highlight?: string;
+        value?: string;
 
         palette?: PROPERTY_PALETTE;
         sizing?: PROPERTY_SIZING;
@@ -64,23 +64,23 @@
     let _class = "";
     export {_class as class};
 
-    export let now: $$Props["now"] = false;
-    export let readonly: $$Props["readonly"] = false;
-    export let scroll: $$Props["scroll"] = false;
+    export let now: $$Props["now"] = undefined;
+    export let readonly: $$Props["readonly"] = undefined;
+    export let scroll: $$Props["scroll"] = undefined;
 
-    export let locale: $$Props["locale"] = DEFAULT_LOCALE;
+    export let locale: $$Props["locale"] = undefined;
 
-    export let hour: $$Props["hour"] = "2-digit";
-    export let hour_12: $$Props["hour_12"] = false;
-    export let minute: $$Props["minute"] = "2-digit";
-    export let second: $$Props["second"] = "2-digit";
+    export let hour: $$Props["hour"] = undefined;
+    export let hour_12: $$Props["hour_12"] = undefined;
+    export let minute: $$Props["minute"] = undefined;
+    export let second: $$Props["second"] = undefined;
 
-    export let disabled: $$Props["disabled"] = false;
+    export let disabled: $$Props["disabled"] = undefined;
     export let max: $$Props["max"] = undefined;
     export let min: $$Props["min"] = undefined;
 
-    export let highlight: $$Props["highlight"] = get_timestamp();
-    export let value: $$Props["value"] = "";
+    export let highlight: $$Props["highlight"] = undefined;
+    export let value: $$Props["value"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
 
@@ -129,9 +129,11 @@
         if (scroll) scroll_to_current();
     });
 
+    const _timestamp = get_timestamp();
+
     $: [_hours, _minutes, _seconds] = get_clock_ranges(value || min, hour_12, period);
 
-    $: _highlight = Temporal.PlainTime.from(highlight);
+    $: _highlight = Temporal.PlainTime.from(highlight ?? _timestamp);
     $: _value = value ? Temporal.PlainTime.from(value) : null;
 </script>
 
@@ -146,7 +148,10 @@
                     disabled={disabled || !is_time_in_range(_hour, max, min, true)}
                     on:click={on_time_click.bind(null, _hour)}
                 >
-                    {_hour.toLocaleString(locale, {hour, hour12: hour_12})}
+                    {_hour.toLocaleString(locale ?? DEFAULT_LOCALE, {
+                        hour: hour ?? "2-digit",
+                        hour12: hour_12 ?? DEFAULT_HOUR_12,
+                    })}
                 </WidgetButton>
             {/each}
         </WidgetSection>
@@ -165,7 +170,9 @@
                     disabled={disabled || !is_time_in_range(_minute, max, min, true)}
                     on:click={on_time_click.bind(null, _minute)}
                 >
-                    {_minute.toLocaleString(locale, {minute})}
+                    {_minute.toLocaleString(locale ?? DEFAULT_LOCALE, {
+                        minute: minute ?? "2-digit",
+                    })}
                 </WidgetButton>
             {/each}
         </WidgetSection>
@@ -187,7 +194,9 @@
                     disabled={disabled || !is_time_in_range(_second, max, min, true)}
                     on:click={on_time_click.bind(null, _second)}
                 >
-                    {_second.toLocaleString(locale, {second})}
+                    {_second.toLocaleString(locale ?? DEFAULT_LOCALE, {
+                        second: second ?? "2-digit",
+                    })}
                 </WidgetButton>
             {/each}
         </WidgetSection>

--- a/src/lib/components/widgets/yearpicker/YearPicker.svelte
+++ b/src/lib/components/widgets/yearpicker/YearPicker.svelte
@@ -34,18 +34,18 @@
         once?: boolean;
         readonly?: boolean;
 
-        calendar: string;
-        locale: string;
+        calendar?: string;
+        locale?: string;
 
-        year: Intl.DateTimeFormatOptions["year"];
+        year?: Intl.DateTimeFormatOptions["year"];
 
-        disabled: boolean | readonly string[];
+        disabled?: boolean | readonly string[];
         max?: string;
         min?: string;
 
-        highlight: readonly string[];
-        timestamp: string;
-        value: readonly string[];
+        highlight?: readonly string[];
+        timestamp?: string;
+        value?: readonly string[];
 
         palette?: PROPERTY_PALETTE;
         sizing?: PROPERTY_SIZING;
@@ -60,47 +60,49 @@
     let _class = "";
     export {_class as class};
 
-    export let multiple: $$Props["multiple"] = false;
-    export let once: $$Props["once"] = false;
-    export let readonly: $$Props["readonly"] = false;
+    export let multiple: $$Props["multiple"] = undefined;
+    export let once: $$Props["once"] = undefined;
+    export let readonly: $$Props["readonly"] = undefined;
 
-    export let calendar: $$Props["calendar"] = DEFAULT_CALENDAR;
-    export let locale: $$Props["locale"] = DEFAULT_LOCALE;
+    export let calendar: $$Props["calendar"] = undefined;
+    export let locale: $$Props["locale"] = undefined;
 
-    export let year: $$Props["year"] = "numeric";
+    export let year: $$Props["year"] = undefined;
 
-    export let disabled: $$Props["disabled"] = [];
+    export let disabled: $$Props["disabled"] = undefined;
     export let max: $$Props["max"] = undefined;
     export let min: $$Props["min"] = undefined;
 
-    // HACK: We could do `highlight = [timestamp]`, however that would tie `highlight`'s
-    // default value to `timestamp`. Which might not be expected or wanted default behavior
-
-    const yearstamp = get_yearstamp(calendar);
-
-    export let highlight: $$Props["highlight"] = [yearstamp];
-    export let timestamp: $$Props["timestamp"] = yearstamp;
-    export let value: $$Props["value"] = [];
+    export let highlight: $$Props["highlight"] = undefined;
+    export let timestamp: $$Props["timestamp"] = undefined;
+    export let value: $$Props["value"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
 
     function on_year_click(year: Temporal.PlainYearMonth, event: MouseEvent): void {
         if (readonly) return;
 
-        if (!once && has_year(value, year)) {
-            value = multiple ? value.filter((entry) => !year.equals(entry)) : [];
+        if (!once && has_year(_value, year)) {
+            value = multiple ? _value.filter((entry) => !year.equals(entry)) : [];
 
             dispatch("change");
         } else {
             value = multiple
-                ? [...value, year.toString({calendarName: "always"})]
+                ? [..._value, year.toString({calendarName: "always"})]
                 : [year.toString({calendarName: "always"})];
 
             dispatch("change");
         }
     }
 
-    $: _halfs = get_decade_halves(timestamp);
+    // HACK: We could do `_highlight = [_timestamp]`, however that would tie `highlight`'s
+    // default value to `timestamp`. Which might not be expected or wanted default behavior
+
+    const _yearstamp = get_yearstamp(calendar ?? DEFAULT_CALENDAR);
+
+    $: _highlight = highlight ?? [_yearstamp];
+    $: _halfs = get_decade_halves(timestamp ?? _yearstamp);
+    $: _value = value ?? [];
 </script>
 
 <WidgetContainer {...$$props} bind:element class="year-picker {_class}">
@@ -108,14 +110,16 @@
         <WidgetSection>
             {#each _half as _year (_year.year)}
                 <WidgetButton
-                    variation={has_year(highlight, _year) ? "outline" : undefined}
+                    variation={has_year(_highlight, _year) ? "outline" : undefined}
                     palette={_year.year % 10 === 0 || _year.year % 10 === 9 ? undefined : palette}
-                    active={has_year(value, _year)}
+                    active={has_year(_value, _year)}
                     disabled={!is_year_in_range(_year, max, min, true) ||
-                        (typeof disabled === "boolean" ? disabled : has_year(disabled, _year))}
+                        (disabled instanceof Array ? has_year(disabled, _year) : disabled)}
                     on:click={on_year_click.bind(null, _year)}
                 >
-                    {_year.toLocaleString(locale, {year}).toLocaleUpperCase(locale)}
+                    {_year
+                        .toLocaleString(locale ?? DEFAULT_LOCALE, {year: year ?? "numeric"})
+                        .toLocaleUpperCase(locale ?? DEFAULT_LOCALE)}
                 </WidgetButton>
             {/each}
         </WidgetSection>

--- a/src/lib/components/widgets/yearstepper/YearStepper.svelte
+++ b/src/lib/components/widgets/yearstepper/YearStepper.svelte
@@ -30,16 +30,16 @@
         disabled?: boolean;
         readonly?: boolean;
 
-        calendar: string;
-        locale: string;
+        calendar?: string;
+        locale?: string;
 
-        year: Intl.DateTimeFormatOptions["year"];
+        year?: Intl.DateTimeFormatOptions["year"];
 
         max?: string;
         min?: string;
-        step: number | string;
+        step?: number | string;
 
-        value: string;
+        value?: string;
 
         palette?: PROPERTY_PALETTE;
         sizing?: PROPERTY_SIZING;
@@ -60,19 +60,19 @@
     let _class = "";
     export {_class as class};
 
-    export let disabled: $$Props["disabled"] = false;
-    export let readonly: $$Props["readonly"] = false;
+    export let disabled: $$Props["disabled"] = undefined;
+    export let readonly: $$Props["readonly"] = undefined;
 
-    export let calendar: $$Props["calendar"] = DEFAULT_CALENDAR;
-    export let locale: $$Props["locale"] = DEFAULT_LOCALE;
+    export let calendar: $$Props["calendar"] = undefined;
+    export let locale: $$Props["locale"] = undefined;
 
-    export let year: $$Props["year"] = "numeric";
+    export let year: $$Props["year"] = undefined;
 
     export let max: $$Props["max"] = undefined;
     export let min: $$Props["min"] = undefined;
-    export let step: $$Props["step"] = 1;
+    export let step: $$Props["step"] = undefined;
 
-    export let value: $$Props["value"] = get_yearstamp(calendar);
+    export let value: $$Props["value"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
 
@@ -86,14 +86,16 @@
         dispatch("change");
     }
 
-    $: _step = typeof step === "string" ? Math.abs(parseInt(step)) : Math.abs(step);
-    $: _year = Temporal.PlainYearMonth.from(value);
+    const _yearstamp = get_yearstamp(calendar ?? DEFAULT_CALENDAR);
+
+    $: _step = step ? (typeof step === "string" ? Math.abs(parseInt(step)) : Math.abs(step)) : 1;
+    $: _year = Temporal.PlainYearMonth.from(value ?? _yearstamp);
 </script>
 
 <WidgetContainer {...$$props} bind:element class="year-stepper {_class}">
     <Stack orientation="horizontal" alignment_y="center">
         <WidgetHeader>
-            {_year.toLocaleString(locale, {year})}
+            {_year.toLocaleString(locale ?? DEFAULT_LOCALE, {year: year ?? "numeric"})}
         </WidgetHeader>
 
         <Spacer variation="inline" />

--- a/src/lib/util/datetime.ts
+++ b/src/lib/util/datetime.ts
@@ -104,7 +104,11 @@ export function get_clock_ranges(
     hour_12: boolean = false,
     period: PROPERTY_CLOCK_PERIOD = TOKENS_CLOCK_PERIOD.am
 ): [Temporal.PlainTime[], Temporal.PlainTime[], Temporal.PlainTime[]] {
-    const base = value ? Temporal.PlainTime.from(value) : new Temporal.PlainTime();
+    const base = (value ? Temporal.PlainTime.from(value) : new Temporal.PlainTime()).with({
+        millisecond: 0,
+        microsecond: 0,
+        nanosecond: 0,
+    });
 
     return [
         hour_12


### PR DESCRIPTION
# CHANGELOG

-   Added the following Components / Component Features

    -   Widgets

        -   `TimePicker`

            -   Respects system default for `<TimePicker hour_12={boolean}>` property.

-   Fixed the following Components / Component Features

    -   Widgets

        -   `TimePicker`

            -   Displayed range of clock times will now be flat `hh:mm:ss` values, stripping microsecond, minisecond, and nanosecond units.

-   Updated the following Components / Component Features

    -   Display

        -   `DateStamp` / `DateTimeStamp` / `TimeStamp`

            -   Updated typings to make `calendar` and `locale` properties optional as originally intended.

    -   Widgets

        -   `DayPicker` / `DayStepper` / `MonthPicker` / `MonthStepper` / `TimePicker` / `YearPicker` / `YearStepper`

            -   Updated typings to make `calendar`, `day`, `disabled`, `highlight`, `locale`, `month`, `step`, `timestamp`, `value`, and `weekday` properties optional.