### PR TITLE
[0.4.11] Add `<* once={boolean}>` Property to Overlay Components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Added the following Components / Component Features
+
+    -   Overlays
+
+        -   `Offscreen` / `Overlay` / `Popover`
+
+            -   `<* once={boolean}>` — Dismisses the Component whenever an element inside of the it is clicked.
+
 ## v0.4.10 - 2021/11/14
 
 -   Added CSS Theming Variables to the following Components: `Blockquote`, `Code`, `Heading`, `Text`.

--- a/src/lib/components/overlays/offscreen/Offscreen.stories.svelte
+++ b/src/lib/components/overlays/offscreen/Offscreen.stories.svelte
@@ -25,7 +25,20 @@
 <Story name="Default">
     <Button for="offscreen-default-story" palette="accent">Open Offscreen</Button>
 
-    <Offscreen logic_id="offscreen-default-story" placement="top" hidden captive dismissible>
+    <Offscreen logic_id="offscreen-default-story" placement="top" captive dismissible hidden>
+        <Box palette="accent" padding="medium">
+            <Stack orientation="horizontal" alignment_y="center" spacing="medium">
+                <ContextButton palette="light" variation="clear">X</ContextButton>
+                I am hidden on all Viewports!
+            </Stack>
+        </Box>
+    </Offscreen>
+</Story>
+
+<Story name="Once">
+    <Button for="offscreen-once" palette="accent">Open ONCE Offscreen</Button>
+
+    <Offscreen logic_id="offscreen-once" placement="top" hidden once>
         <Box palette="accent" padding="medium">
             <Stack orientation="horizontal" alignment_y="center" spacing="medium">
                 <ContextButton palette="light" variation="clear">X</ContextButton>
@@ -44,9 +57,9 @@
         <Offscreen
             logic_id="offscreen-placement-story-{placement}"
             {placement}
-            hidden
             captive
             dismissible
+            hidden
         >
             <Box palette="accent" padding="medium">
                 <Stack orientation="horizontal" alignment_y="center" spacing="medium">

--- a/src/lib/components/overlays/offscreen/Offscreen.svelte
+++ b/src/lib/components/overlays/offscreen/Offscreen.svelte
@@ -30,6 +30,7 @@
         captive?: boolean;
         dismissible?: boolean;
         logic_id?: string;
+        once?: boolean;
         state?: boolean;
 
         placement?: PROPERTY_PLACEMENT;
@@ -54,6 +55,7 @@
     export let captive: $$Props["captive"] = undefined;
     export let dismissible: $$Props["dismissible"] = undefined;
     export let logic_id: $$Props["logic_id"] = "";
+    export let once: $$Props["once"] = undefined;
     export let state: $$Props["state"] = undefined;
 
     export let placement: $$Props["placement"] = undefined;
@@ -67,8 +69,17 @@
 
     let _previous_state = state;
 
-    function on_change(event: Event) {
+    function on_change(event: Event): void {
         state = (event.target as HTMLInputElement).checked;
+    }
+
+    function on_click_inside(event: MouseEvent): void {
+        if (once) {
+            const target = event.target as HTMLElement;
+            if (target.tagName !== "LABEL" && target.getAttribute("for") !== logic_id) {
+                state = false;
+            }
+        }
     }
 
     $: $_state = state as boolean;
@@ -106,6 +117,7 @@
         "alignment-y": alignment_y,
         placement,
     })}
+    on:click={on_click_inside}
 >
     <slot />
 </div>

--- a/src/lib/components/overlays/overlay/Overlay.stories.svelte
+++ b/src/lib/components/overlays/overlay/Overlay.stories.svelte
@@ -44,6 +44,28 @@
     </Overlay>
 </Story>
 
+<Story name="Once">
+    <Button for="overlay-once" palette="accent">Open ONCE Modal</Button>
+
+    <Overlay logic_id="overlay-once" once>
+        <Card.Container palette="auto" max_width="viewport-75">
+            <Card.Header>Are you sure?</Card.Header>
+
+            <Card.Section>
+                <Text>
+                    Are you sure you want to delete:
+                    <Code>important-file.docx</Code>?
+                </Text>
+            </Card.Section>
+
+            <Card.Footer>
+                <ContextButton palette="inverse" variation="clear">Cancel</ContextButton>
+                <Button palette="negative">Delete</Button>
+            </Card.Footer>
+        </Card.Container>
+    </Overlay>
+</Story>
+
 <Story name="Orientation">
     {#each ORIENTATIONS as [orientation, is_default] (orientation)}
         <Button for="overlay-orientation-story-{orientation}" palette="accent">

--- a/src/lib/components/overlays/overlay/Overlay.svelte
+++ b/src/lib/components/overlays/overlay/Overlay.svelte
@@ -31,6 +31,7 @@
         captive?: boolean;
         dismissible?: boolean;
         logic_id?: string;
+        once?: boolean;
         state?: boolean;
 
         orientation?: PROPERTY_ORIENTATION_Y_BREAKPOINT;
@@ -60,6 +61,7 @@
     export let captive: $$Props["captive"] = undefined;
     export let dismissible: $$Props["dismissible"] = undefined;
     export let logic_id: $$Props["logic_id"] = "";
+    export let once: $$Props["once"] = undefined;
     export let state: $$Props["state"] = undefined;
 
     export let orientation: $$Props["orientation"] = undefined;
@@ -77,8 +79,17 @@
 
     let _previous_state = state;
 
-    function on_change(event: Event) {
+    function on_change(event: Event): void {
         state = (event.target as HTMLInputElement).checked;
+    }
+
+    function on_click_inside(event: MouseEvent): void {
+        if (once) {
+            const target = event.target as HTMLElement;
+            if (target.tagName !== "LABEL" && target.getAttribute("for") !== logic_id) {
+                state = false;
+            }
+        }
     }
 
     $: $_state = state as boolean;
@@ -119,6 +130,7 @@
         "spacing-x": spacing_x,
         "spacing-y": spacing_y,
     })}
+    on:click={on_click_inside}
 >
     <slot />
 </div>

--- a/src/lib/components/overlays/popover/Popover.stories.svelte
+++ b/src/lib/components/overlays/popover/Popover.stories.svelte
@@ -74,6 +74,38 @@
     </Popover>
 </Story>
 
+<Story name="Once">
+    <Popover logic_id="popover-once" alignment_x="right" spacing="medium" hidden once>
+        <ContextButton palette="accent">Open ONCE Popover</ContextButton>
+
+        <Card.Container palette="inverse" elevation="high" max_width="content-max">
+            <Card.Section>
+                <Menu.Container>
+                    <Menu.Button>
+                        Copy
+                        <Spacer variation="inline" spacing="medium" />
+                        <Text is="kbd">CTRL+C</Text>
+                    </Menu.Button>
+
+                    <Menu.Button>
+                        Cut
+                        <Spacer variation="inline" spacing="medium" />
+                        <Text is="kbd">CTRL+X</Text>
+                    </Menu.Button>
+
+                    <Menu.Divider />
+
+                    <Menu.Button>
+                        Delete
+                        <Spacer variation="inline" spacing="medium" />
+                        <Text is="kbd">DEL</Text>
+                    </Menu.Button>
+                </Menu.Container>
+            </Card.Section>
+        </Card.Container>
+    </Popover>
+</Story>
+
 <Story name="Placement">
     <div data-padding-x="huge" data-padding-y="huge">
         <Stack orientation="horizontal" spacing="medium" variation="wrap">

--- a/src/lib/components/overlays/popover/Popover.svelte
+++ b/src/lib/components/overlays/popover/Popover.svelte
@@ -31,6 +31,7 @@
 
         dismissible?: boolean;
         logic_id?: string;
+        once?: boolean;
         state?: boolean;
 
         placement?: PROPERTY_PLACEMENT;
@@ -55,6 +56,7 @@
 
     export let dismissible: $$Props["dismissible"] = undefined;
     export let logic_id: $$Props["logic_id"] = "";
+    export let once: $$Props["once"] = undefined;
     export let state: $$Props["state"] = undefined;
 
     export let placement: $$Props["placement"] = undefined;
@@ -69,11 +71,20 @@
 
     let _previous_state = state;
 
-    function on_change(event: Event) {
+    function on_change(event: Event): void {
         state = (event.target as HTMLInputElement).checked;
     }
 
-    function on_click_outside(event: MouseEvent) {
+    function on_click_inside(event: MouseEvent): void {
+        if (once) {
+            const target = event.target as HTMLElement;
+            if (target.tagName !== "LABEL" && target.getAttribute("for") !== logic_id) {
+                state = false;
+            }
+        }
+    }
+
+    function on_click_outside(event: MouseEvent): void {
         if (state && dismissible) state = false;
     }
 
@@ -108,6 +119,7 @@
         placement,
         spacing,
     })}
+    on:click={on_click_inside}
     use:click_outside={{on_click_outside}}
 >
     <slot />


### PR DESCRIPTION
# CHANGELOG

-   Added the following Components / Component Features

    -   Overlays

        -   `Offscreen` / `Overlay` / `Popover`

            -   `<* once={boolean}>` — Dismisses the Component whenever an element inside of the it is clicked.