### PR TITLE
[0.4.11] Forward Actions to Components + Forward Set of Global Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@
 -   Updated all Components to support globally forwarding the following events: `click` , `contextmenu` , `dblclick` , `focusin` , `focusout` , `keydown` , `keyup` , `pointercancel` , `pointerdown` , `pointerenter` , `pointerleave` , `pointermove` , `pointerout` , `pointerup`.
 -   Updated all Components to support Svelte Action forwarding via `<* actions={[[action, options]]}>`, e.g.
 
+<!-- prettier-ignore -->
 ```svelte
 <script>
     import {click_outside} from "@kahi-ui/framework";
 </script>
 
-<!-- prettier-ignore -->
 <Box actions={[
     [click_outside, {on_click_outside: () => console.log("clicked!")}]
 ]}>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     ...
 </Box>
 ```
+
 -   Added the following Components / Component Features
 
     -   Overlays
@@ -24,6 +25,7 @@
         -   `Offscreen` / `Overlay` / `Popover`
 
             -   `<* once={boolean}>` — Dismisses the Component whenever an element inside of the it is clicked.
+
     -   Widgets
 
         -   `TimePicker`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Updated all Components to support globally forwarding the following events: `click` , `contextmenu` , `dblclick` , `focusin` , `focusout` , `keydown` , `keyup` , `pointercancel` , `pointerdown` , `pointerenter` , `pointerleave` , `pointermove` , `pointerout` , `pointerup`.
+-   Updated all Components to support Svelte Action forwarding via `<* actions={[[action, options]]}>`, e.g.
+
+```svelte
+<script>
+    import {click_outside} from "@kahi-ui/framework";
+</script>
+
+<!-- prettier-ignore -->
+<Box actions={[
+    [click_outside, {on_click_outside: () => console.log("clicked!")}]
+]}>
+    ...
+</Box>
+```
+
 ## v0.4.10 - 2021/11/14
 
 -   Added CSS Theming Variables to the following Components: `Blockquote`, `Code`, `Heading`, `Text`.

--- a/src/lib/actions/actions.ts
+++ b/src/lib/actions/actions.ts
@@ -1,14 +1,19 @@
 /**
- * Represents the handle object returned by Svelte Actions
+ * Represents the handle of an initialized Svelte Action
  */
 export interface IActionHandle<T = any> {
     /**
      * Destroys all bindings the Action was using
      */
-    destroy: () => void;
+    destroy?: () => void;
 
     /**
      * Replaces the options that was initially passed to the Action
      */
-    update: (options: T) => void;
+    update?: (options: T) => void;
 }
+
+/**
+ * Represents the constructor of a Svelte Action
+ */
+export type IAction<T = any> = (element: HTMLElement, options: T) => IActionHandle<T> | void;

--- a/src/lib/actions/click_outside.ts
+++ b/src/lib/actions/click_outside.ts
@@ -34,7 +34,6 @@ export function click_outside(
     element: HTMLElement,
     options: IClickOutsideOptions
 ): IClickOutsideHandle {
-    console.log({element, options});
     let {on_click_outside} = options;
 
     function on_click(event: MouseEvent) {

--- a/src/lib/actions/click_outside.ts
+++ b/src/lib/actions/click_outside.ts
@@ -3,7 +3,7 @@ import type {IActionHandle} from "./actions";
 /**
  * Represents the Svelte Action handle returned by [[click_outside]]
  */
-export type IClickOutsideAction = IActionHandle<IClickOutsideOptions>;
+export type IClickOutsideHandle = Required<IActionHandle<IClickOutsideOptions>>;
 
 /**
  * Represents the typing for the [[IClickOutsideOptions.on_click_outside]] callback
@@ -33,7 +33,8 @@ export interface IClickOutsideOptions {
 export function click_outside(
     element: HTMLElement,
     options: IClickOutsideOptions
-): IClickOutsideAction {
+): IClickOutsideHandle {
+    console.log({element, options});
     let {on_click_outside} = options;
 
     function on_click(event: MouseEvent) {

--- a/src/lib/actions/clipping.ts
+++ b/src/lib/actions/clipping.ts
@@ -4,7 +4,7 @@ import {intersection_observer} from "./intersection_observer";
 /**
  * Represents the Svelte Action handle returned by [[clipping]]
  */
-export type IClippingAction = IActionHandle<IClippingOptions>;
+export type IClippingHandle = Required<IActionHandle<IClippingOptions>>;
 
 /**
  * Represents the typing for the [[IClippingOptions.on_clip]] callback
@@ -59,7 +59,7 @@ export interface IClippingOptions {
  * @param options
  * @returns
  */
-export function clipping(element: HTMLElement, options: IClippingOptions): IClippingAction {
+export function clipping(element: HTMLElement, options: IClippingOptions): IClippingHandle {
     let {on_clip} = options;
 
     function on_intersect(intersections: IntersectionObserverEntry[]): void {

--- a/src/lib/actions/forward_actions.stories.svelte
+++ b/src/lib/actions/forward_actions.stories.svelte
@@ -22,7 +22,7 @@
     <slot />
 </Template>
 
-<Story name="One">
+<Story name="Default">
     <Box
         palette={is_clicked ? "affirmative" : "negative"}
         padding="small"

--- a/src/lib/actions/forward_actions.stories.svelte
+++ b/src/lib/actions/forward_actions.stories.svelte
@@ -1,0 +1,34 @@
+<script>
+    import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
+
+    import Box from "../components/surfaces/box/Box.svelte";
+
+    import {click_outside} from "./click_outside";
+
+    function on_click(event) {
+        is_clicked = true;
+    }
+
+    function on_click_outside(event) {
+        is_clicked = false;
+    }
+
+    let is_clicked = false;
+</script>
+
+<Meta title="Actions/forward_actions" />
+
+<Template>
+    <slot />
+</Template>
+
+<Story name="One">
+    <Box
+        palette={is_clicked ? "affirmative" : "negative"}
+        padding="small"
+        on:click={on_click}
+        actions={[[click_outside, {on_click_outside}]]}
+    >
+        {is_clicked ? "I was clicked inside!" : "I am currently not clicked..."}
+    </Box>
+</Story>

--- a/src/lib/actions/forward_actions.ts
+++ b/src/lib/actions/forward_actions.ts
@@ -16,8 +16,6 @@ export function forward_actions(
 ): IForwardActionsHandle {
     const handles = initialize_actions(options.actions);
 
-    console.log({handles});
-
     function initialize_actions(actions: IForwardedActions = []): IInitializedActions {
         return actions.map((entry, index) => {
             if (Array.isArray(entry)) return entry[0](element, entry[1]);

--- a/src/lib/actions/forward_actions.ts
+++ b/src/lib/actions/forward_actions.ts
@@ -1,0 +1,58 @@
+import type {IAction, IActionHandle} from "./actions";
+
+export type IForwardActionsHandle = IActionHandle<IForwardActionsOptions>;
+
+export type IForwardedActions = (IAction | [IAction, any])[];
+
+type IInitializedActions = (IActionHandle | void)[];
+
+export interface IForwardActionsOptions {
+    actions: IForwardedActions;
+}
+
+export function forward_actions(
+    element: HTMLElement,
+    options: Partial<IForwardActionsOptions> = {}
+): IForwardActionsHandle {
+    const handles = initialize_actions(options.actions);
+
+    console.log({handles});
+
+    function initialize_actions(actions: IForwardedActions = []): IInitializedActions {
+        return actions.map((entry, index) => {
+            if (Array.isArray(entry)) return entry[0](element, entry[1]);
+            else return entry(element, undefined);
+        });
+    }
+
+    return {
+        destroy() {
+            for (const handle of handles) {
+                if (handle) {
+                    const {destroy} = handle;
+                    if (destroy) destroy();
+                }
+            }
+        },
+
+        update(options: Partial<IForwardActionsOptions> = {}) {
+            const {actions = []} = options;
+            if (actions.length !== handles.length) {
+                throw new ReferenceError(
+                    `bad argument #0 to 'forward_actions.update' (supplied actions must never change lengths)`
+                );
+            }
+
+            for (const index in actions) {
+                const entry = actions[index];
+                const options = Array.isArray(entry) ? entry[1] : undefined;
+
+                const handle = handles[index];
+                if (handle) {
+                    const {update} = handle;
+                    if (update) update(options);
+                }
+            }
+        },
+    };
+}

--- a/src/lib/actions/intersection_observer.ts
+++ b/src/lib/actions/intersection_observer.ts
@@ -3,7 +3,7 @@ import type {IActionHandle} from "./actions";
 /**
  * Represents the Svelte Action handle returned by [[intersection_observer]]
  */
-export type IIntersectionObserverAction = IActionHandle<IIntersectionObserverOptions>;
+export type IIntersectionObserverHandle = Required<IActionHandle<IIntersectionObserverOptions>>;
 
 /**
  * Represents the typing for the [[IIntersectionObserverOptions.on_intersect]] callback
@@ -50,7 +50,7 @@ export interface IIntersectionObserverOptions {
 export function intersection_observer(
     element: HTMLElement,
     options: IIntersectionObserverOptions
-): IIntersectionObserverAction {
+): IIntersectionObserverHandle {
     let {on_intersect, root, root_margin, threshold} = options;
 
     let observer = new IntersectionObserver(

--- a/src/lib/actions/keybind.ts
+++ b/src/lib/actions/keybind.ts
@@ -5,7 +5,7 @@ import type {IActionHandle} from "./actions";
 /**
  * Represents the Svelte Action handle returned by [[keybind]]
  */
-export type IKeybindAction = IActionHandle<IKeybindOptions>;
+export type IKeybindHandle = Required<IActionHandle<IKeybindOptions>>;
 
 /**
  * Represents the typing for the [[IKeybindOptions.on_bind]] callback
@@ -188,7 +188,7 @@ function bindstate(binds: string | string[]): IBindState {
  * @param options
  * @returns
  */
-export function keybind(element: HTMLElement, options: IKeybindOptions): IKeybindAction {
+export function keybind(element: HTMLElement, options: IKeybindOptions): IKeybindHandle {
     let {binds, repeat = false, repeat_throttle = 0, on_bind} = options;
 
     let cache = false;

--- a/src/lib/actions/mutation_observer.ts
+++ b/src/lib/actions/mutation_observer.ts
@@ -3,7 +3,7 @@ import type {IActionHandle} from "./actions";
 /**
  * Represents the Svelte Action handle returned by [[mutation_observer]]
  */
-export type IMutationObserverAction = IActionHandle<IMutationObserverOptions>;
+export type IMutationObserverHandle = Required<IActionHandle<IMutationObserverOptions>>;
 
 /**
  * Represents the typing for the [[IMutationObserverOptions.on_mutate]] callback
@@ -71,7 +71,7 @@ export interface IMutationObserverOptions {
 export function mutation_observer(
     element: HTMLElement,
     options: IMutationObserverOptions
-): IMutationObserverAction {
+): IMutationObserverHandle {
     let {
         attributes,
         attribute_filter,

--- a/src/lib/components/disclosure/accordion/AccordionContainer.svelte
+++ b/src/lib/components/disclosure/accordion/AccordionContainer.svelte
@@ -5,6 +5,9 @@
     import type {IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     import AccordionGroup from "./AccordionGroup.svelte";
@@ -14,6 +17,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         logic_name?: string;
@@ -28,6 +32,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -39,7 +44,26 @@
     export let behavior: $$Props["behavior"] = TOKENS_BEHAVIOR_TOGGLE.exclusive;
 </script>
 
-<div bind:this={element} {...map_global_attributes($$props)} class="accordion {_class}">
+<div
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    class="accordion {_class}"
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <AccordionGroup {behavior} {logic_name} {logic_state} on:change>
         <slot />
     </AccordionGroup>

--- a/src/lib/components/disclosure/accordion/AccordionContainer.svelte
+++ b/src/lib/components/disclosure/accordion/AccordionContainer.svelte
@@ -2,7 +2,7 @@
     import type {PROPERTY_BEHAVIOR_TOGGLE} from "../../../types/behaviors";
     import {TOKENS_BEHAVIOR_TOGGLE} from "../../../types/behaviors";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
@@ -14,7 +14,7 @@
 
     type $$Events = {
         change: CustomEvent<void>;
-    };
+    } & IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/disclosure/accordion/AccordionLabel.svelte
+++ b/src/lib/components/disclosure/accordion/AccordionLabel.svelte
@@ -5,6 +5,9 @@
     import type {IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {
         map_aria_attributes,
         map_data_attributes,
@@ -23,6 +26,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLLabelElement;
 
         active?: boolean;
@@ -40,6 +44,7 @@
         open: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = undefined;
@@ -121,7 +126,21 @@
     {...map_data_attributes({palette})}
     {...map_aria_attributes({disabled, pressed: active})}
     for={$_accordion_id}
+    use:forward_actions={{actions}}
     on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 

--- a/src/lib/components/disclosure/accordion/AccordionLabel.svelte
+++ b/src/lib/components/disclosure/accordion/AccordionLabel.svelte
@@ -2,7 +2,7 @@
     import {afterUpdate} from "svelte";
 
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
@@ -21,9 +21,7 @@
         CONTEXT_ACCORDION_STATE,
     } from "./AccordionGroup.svelte";
 
-    type $$Events = {
-        click: MouseEvent;
-    };
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/disclosure/accordion/AccordionSection.svelte
+++ b/src/lib/components/disclosure/accordion/AccordionSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_BEHAVIOR_LOADING_LAZY} from "../../../types/behaviors";
     import {TOKENS_BEHAVIOR_LOADING_LAZY} from "../../../types/behaviors";
     import type {ISizeProperties} from "../../../types/sizes";
@@ -12,6 +12,8 @@
     import {map_global_attributes} from "../../../util/attributes";
 
     import {CONTEXT_ACCORDION_ID, CONTEXT_ACCORDION_STATE} from "./AccordionGroup.svelte";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/disclosure/accordion/AccordionSection.svelte
+++ b/src/lib/components/disclosure/accordion/AccordionSection.svelte
@@ -6,11 +6,15 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     import {CONTEXT_ACCORDION_ID, CONTEXT_ACCORDION_STATE} from "./AccordionGroup.svelte";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
 
         loading?: PROPERTY_BEHAVIOR_LOADING_LAZY;
@@ -24,6 +28,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let loading: $$Props["loading"] = undefined;
@@ -38,7 +43,25 @@
         state = $_accordion_state.includes($_accordion_id);
 </script>
 
-<section bind:this={element} {...map_global_attributes($$props)}>
+<section
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     {#if state}
         <slot />
     {/if}

--- a/src/lib/components/disclosure/carousel/CarouselContainer.svelte
+++ b/src/lib/components/disclosure/carousel/CarouselContainer.svelte
@@ -9,9 +9,13 @@
         IPaddingProperties,
     } from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         orientation?: PROPERTY_ORIENTATION_X;
@@ -29,6 +33,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -46,6 +51,21 @@
     {...map_global_attributes($$props)}
     class="carousel {_class}"
     {...map_data_attributes({orientation, spacing, "spacing-x": spacing_x, "spacing-y": spacing_y})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </div>

--- a/src/lib/components/disclosure/carousel/CarouselContainer.svelte
+++ b/src/lib/components/disclosure/carousel/CarouselContainer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_ORIENTATION_X} from "../../../types/orientations";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {
@@ -13,6 +13,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/disclosure/carousel/CarouselSection.svelte
+++ b/src/lib/components/disclosure/carousel/CarouselSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/disclosure/carousel/CarouselSection.svelte
+++ b/src/lib/components/disclosure/carousel/CarouselSection.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,9 +22,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<section bind:this={element} {...map_global_attributes($$props)}>
+<section
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </section>

--- a/src/lib/components/disclosure/tab/TabAnchor.svelte
+++ b/src/lib/components/disclosure/tab/TabAnchor.svelte
@@ -4,6 +4,9 @@
     import type {IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {
         map_aria_attributes,
         map_data_attributes,
@@ -15,6 +18,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLAnchorElement;
 
         active?: boolean;
@@ -34,6 +38,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = undefined;
@@ -57,7 +62,21 @@
     {href}
     {rel}
     {target}
+    use:forward_actions={{actions}}
     on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </a>

--- a/src/lib/components/disclosure/tab/TabAnchor.svelte
+++ b/src/lib/components/disclosure/tab/TabAnchor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type {PROPERTY_ARIA_CURRENT} from "../../../types/aria";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
@@ -13,9 +13,7 @@
         map_global_attributes,
     } from "../../../util/attributes";
 
-    type $$Events = {
-        click: MouseEvent;
-    };
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/disclosure/tab/TabContainer.svelte
+++ b/src/lib/components/disclosure/tab/TabContainer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type {PROPERTY_ALIGNMENT_X} from "../../../types/alignments";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
 
@@ -14,7 +14,7 @@
 
     type $$Events = {
         change: CustomEvent<void>;
-    };
+    } & IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/disclosure/tab/TabContainer.svelte
+++ b/src/lib/components/disclosure/tab/TabContainer.svelte
@@ -5,6 +5,9 @@
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     import TabGroup from "./TabGroup.svelte";
@@ -14,6 +17,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         logic_name?: string;
@@ -30,6 +34,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -48,6 +53,21 @@
     {...map_global_attributes($$props)}
     class="tab {_class}"
     {...map_data_attributes({"alignment-x": alignment_x, sizing})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <TabGroup {logic_name} {logic_state} on:change>
         <slot />

--- a/src/lib/components/disclosure/tab/TabLabel.svelte
+++ b/src/lib/components/disclosure/tab/TabLabel.svelte
@@ -2,7 +2,7 @@
     import {afterUpdate} from "svelte";
 
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
@@ -16,9 +16,7 @@
 
     import {CONTEXT_TAB_ID, CONTEXT_TAB_NAME, CONTEXT_TAB_STATE} from "./TabGroup.svelte";
 
-    type $$Events = {
-        click: MouseEvent;
-    };
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/disclosure/tab/TabLabel.svelte
+++ b/src/lib/components/disclosure/tab/TabLabel.svelte
@@ -5,6 +5,9 @@
     import type {IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {
         map_aria_attributes,
         map_data_attributes,
@@ -18,6 +21,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLLabelElement;
 
         active?: boolean;
@@ -32,6 +36,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = undefined;
@@ -91,7 +96,21 @@
     {...map_data_attributes({palette})}
     {...map_aria_attributes({disabled, pressed: active})}
     for={$_tab_id}
+    use:forward_actions={{actions}}
     on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </label>

--- a/src/lib/components/disclosure/tab/TabSection.svelte
+++ b/src/lib/components/disclosure/tab/TabSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_BEHAVIOR_LOADING_LAZY} from "../../../types/behaviors";
     import {TOKENS_BEHAVIOR_LOADING_LAZY} from "../../../types/behaviors";
     import type {ISizeProperties} from "../../../types/sizes";
@@ -12,6 +12,8 @@
     import {map_global_attributes} from "../../../util/attributes";
 
     import {CONTEXT_TAB_ID, CONTEXT_TAB_STATE} from "./TabGroup.svelte";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/disclosure/tab/TabSection.svelte
+++ b/src/lib/components/disclosure/tab/TabSection.svelte
@@ -6,11 +6,15 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     import {CONTEXT_TAB_ID, CONTEXT_TAB_STATE} from "./TabGroup.svelte";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
 
         loading?: PROPERTY_BEHAVIOR_LOADING_LAZY;
@@ -24,6 +28,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let loading: $$Props["loading"] = undefined;
@@ -38,7 +43,25 @@
         state = $_tab_state === $_tab_id;
 </script>
 
-<section bind:this={element} {...map_global_attributes($$props)}>
+<section
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     {#if state}
         <slot />
     {/if}

--- a/src/lib/components/display/badge/Badge.svelte
+++ b/src/lib/components/display/badge/Badge.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {PROPERTY_POSITION} from "../../../types/positions";
     import type {PROPERTY_SHAPE} from "../../../types/shapes";
@@ -10,6 +10,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/display/badge/Badge.svelte
+++ b/src/lib/components/display/badge/Badge.svelte
@@ -6,9 +6,13 @@
     import type {PROPERTY_SHAPE} from "../../../types/shapes";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLSpanElement;
 
         palette?: PROPERTY_PALETTE;
@@ -23,6 +27,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -39,6 +44,21 @@
     {...map_global_attributes($$props)}
     class="badge {_class}"
     {...map_data_attributes({palette, position, shape})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </span>

--- a/src/lib/components/display/datestamp/DateStamp.svelte
+++ b/src/lib/components/display/datestamp/DateStamp.svelte
@@ -2,7 +2,7 @@
     import {Temporal} from "@js-temporal/polyfill";
 
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
@@ -11,6 +11,8 @@
     import {map_global_attributes} from "../../../util/attributes";
     import {defaultopt} from "../../../util/functional";
     import {DEFAULT_CALENDAR, DEFAULT_FORMAT_DATE, DEFAULT_LOCALE} from "../../../util/locale";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/display/datestamp/DateStamp.svelte
+++ b/src/lib/components/display/datestamp/DateStamp.svelte
@@ -5,11 +5,15 @@
     import type {IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
     import {defaultopt} from "../../../util/functional";
     import {DEFAULT_CALENDAR, DEFAULT_FORMAT_DATE, DEFAULT_LOCALE} from "../../../util/locale";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLTimeElement;
 
         calendar: string;
@@ -25,6 +29,7 @@
         IGlobalProperties &
         IMarginProperties;
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class = "";
@@ -52,6 +57,21 @@
     {...map_global_attributes($$props)}
     class="date-stamp {_class}"
     datetime={_date.toString({calendarName: "never"})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     {_date.toLocaleString(locale, {
         calendar,

--- a/src/lib/components/display/datetimestamp/DateTimeStamp.svelte
+++ b/src/lib/components/display/datetimestamp/DateTimeStamp.svelte
@@ -2,7 +2,7 @@
     import {Temporal} from "@js-temporal/polyfill";
 
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
@@ -12,6 +12,8 @@
     import {has_timezone} from "../../../util/datetime";
     import {defaultopt} from "../../../util/functional";
     import {DEFAULT_CALENDAR, DEFAULT_FORMAT_DATETIME, DEFAULT_LOCALE} from "../../../util/locale";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/display/datetimestamp/DateTimeStamp.svelte
+++ b/src/lib/components/display/datetimestamp/DateTimeStamp.svelte
@@ -5,12 +5,16 @@
     import type {IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
     import {has_timezone} from "../../../util/datetime";
     import {defaultopt} from "../../../util/functional";
     import {DEFAULT_CALENDAR, DEFAULT_FORMAT_DATETIME, DEFAULT_LOCALE} from "../../../util/locale";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLTimeElement;
 
         calendar: string;
@@ -31,6 +35,7 @@
         IGlobalProperties &
         IMarginProperties;
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class = "";
@@ -68,6 +73,21 @@
     {...map_global_attributes($$props)}
     class="date-time-stamp {_class}"
     datetime={_datetime.toString({calendarName: "never"})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     {_datetime.toLocaleString(locale, {
         calendar,

--- a/src/lib/components/display/list/ListContainer.svelte
+++ b/src/lib/components/display/list/ListContainer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/display/list/ListContainer.svelte
+++ b/src/lib/components/display/list/ListContainer.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLOListElement | HTMLUListElement;
 
         is?: "ol" | "ul";
@@ -20,17 +24,54 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let is: $$Props["is"] = "ul";
 </script>
 
 {#if is === "ol"}
-    <ol bind:this={element} {...map_global_attributes($$props)}>
+    <ol
+        bind:this={element}
+        {...map_global_attributes($$props)}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
+    >
         <slot />
     </ol>
 {:else}
-    <ul bind:this={element} {...map_global_attributes($$props)}>
+    <ul
+        bind:this={element}
+        {...map_global_attributes($$props)}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
+    >
         <slot />
     </ul>
 {/if}

--- a/src/lib/components/display/list/ListItem.svelte
+++ b/src/lib/components/display/list/ListItem.svelte
@@ -3,9 +3,13 @@
     import type {IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLLIElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -15,9 +19,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<li bind:this={element} {...map_global_attributes($$props)}>
+<li
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </li>

--- a/src/lib/components/display/list/ListItem.svelte
+++ b/src/lib/components/display/list/ListItem.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/display/table/TableColumn.svelte
+++ b/src/lib/components/display/table/TableColumn.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLTableCellElement;
 
         colspan?: number | string;
@@ -21,12 +25,32 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let colspan: $$Props["colspan"] = undefined;
     export let rowspan: $$Props["rowspan"] = undefined;
 </script>
 
-<td bind:this={element} {...map_global_attributes($$props)} {...map_attributes({colspan, rowspan})}>
+<td
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    {...map_attributes({colspan, rowspan})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </td>

--- a/src/lib/components/display/table/TableColumn.svelte
+++ b/src/lib/components/display/table/TableColumn.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/display/table/TableContainer.svelte
+++ b/src/lib/components/display/table/TableContainer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
@@ -11,6 +11,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/display/table/TableContainer.svelte
+++ b/src/lib/components/display/table/TableContainer.svelte
@@ -7,9 +7,13 @@
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
     import type {PROPERTY_VARIATION_TABLE} from "../../../types/variations";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLTableElement;
 
         palette?: PROPERTY_PALETTE;
@@ -25,6 +29,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
@@ -36,6 +41,21 @@
     bind:this={element}
     {...map_global_attributes($$props)}
     {...map_data_attributes({palette, sizing, variation})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </table>

--- a/src/lib/components/display/table/TableFooter.svelte
+++ b/src/lib/components/display/table/TableFooter.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/display/table/TableFooter.svelte
+++ b/src/lib/components/display/table/TableFooter.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLTableSectionElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,9 +22,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<tfoot bind:this={element} {...map_global_attributes($$props)}>
+<tfoot
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </tfoot>

--- a/src/lib/components/display/table/TableHeader.svelte
+++ b/src/lib/components/display/table/TableHeader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/display/table/TableHeader.svelte
+++ b/src/lib/components/display/table/TableHeader.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLTableSectionElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,9 +22,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<thead bind:this={element} {...map_global_attributes($$props)}>
+<thead
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </thead>

--- a/src/lib/components/display/table/TableHeading.svelte
+++ b/src/lib/components/display/table/TableHeading.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/display/table/TableHeading.svelte
+++ b/src/lib/components/display/table/TableHeading.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLTableCellElement;
 
         colspan?: number | string;
@@ -21,12 +25,32 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let colspan: $$Props["colspan"] = undefined;
     export let rowspan: $$Props["rowspan"] = undefined;
 </script>
 
-<th bind:this={element} {...map_global_attributes($$props)} {...map_attributes({colspan, rowspan})}>
+<th
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    {...map_attributes({colspan, rowspan})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </th>

--- a/src/lib/components/display/table/TableRow.svelte
+++ b/src/lib/components/display/table/TableRow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/display/table/TableRow.svelte
+++ b/src/lib/components/display/table/TableRow.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLTableRowElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,9 +22,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<tr bind:this={element} {...map_global_attributes($$props)}>
+<tr
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </tr>

--- a/src/lib/components/display/table/TableSection.svelte
+++ b/src/lib/components/display/table/TableSection.svelte
@@ -9,9 +9,7 @@
 
     import {map_global_attributes} from "../../../util/attributes";
 
-
     type $$Events = IHTML5Events;
-
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/display/table/TableSection.svelte
+++ b/src/lib/components/display/table/TableSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,10 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+
+    type $$Events = IHTML5Events;
+
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/display/table/TableSection.svelte
+++ b/src/lib/components/display/table/TableSection.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLTableSectionElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,9 +22,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<tbody bind:this={element} {...map_global_attributes($$props)}>
+<tbody
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </tbody>

--- a/src/lib/components/display/timestamp/TimeStamp.svelte
+++ b/src/lib/components/display/timestamp/TimeStamp.svelte
@@ -2,7 +2,7 @@
     import {Temporal} from "@js-temporal/polyfill";
 
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
     import {map_global_attributes} from "../../../util/attributes";
@@ -11,6 +11,8 @@
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/display/timestamp/TimeStamp.svelte
+++ b/src/lib/components/display/timestamp/TimeStamp.svelte
@@ -9,7 +9,11 @@
     import {defaultopt} from "../../../util/functional";
     import {DEFAULT_FORMAT_TIME, DEFAULT_LOCALE} from "../../../util/locale";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLTimeElement;
 
         locale: string;
@@ -24,6 +28,7 @@
         IGlobalProperties &
         IMarginProperties;
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class = "";
@@ -47,6 +52,21 @@
     {...map_global_attributes($$props)}
     class="time-stamp {_class}"
     datetime={_time.toString()}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     {_time.toLocaleString(locale, {
         hour: _options.hour,

--- a/src/lib/components/embedded/figure/Figure.svelte
+++ b/src/lib/components/embedded/figure/Figure.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type {PROPERTY_FIT} from "../../../types/fit";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_SHAPE} from "../../../types/shapes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {ISizeProperties} from "../../../types/sizes";
@@ -11,6 +11,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/embedded/figure/Figure.svelte
+++ b/src/lib/components/embedded/figure/Figure.svelte
@@ -7,9 +7,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
 
         fit?: PROPERTY_FIT;
@@ -26,6 +30,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let fit: $$Props["fit"] = undefined;
@@ -38,6 +43,21 @@
     bind:this={element}
     {...map_global_attributes($$props)}
     {...map_data_attributes({fit, shape, size, variation})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </figure>

--- a/src/lib/components/feedback/dot/Dot.svelte
+++ b/src/lib/components/feedback/dot/Dot.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type {PROPERTY_ANIMATION_FEEDBACK} from "../../../types/animations";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {PROPERTY_POSITION} from "../../../types/positions";
     import type {IMarginProperties} from "../../../types/spacings";
@@ -10,6 +10,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/feedback/dot/Dot.svelte
+++ b/src/lib/components/feedback/dot/Dot.svelte
@@ -6,9 +6,13 @@
     import type {PROPERTY_POSITION} from "../../../types/positions";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLSpanElement;
 
         animation?: PROPERTY_ANIMATION_FEEDBACK;
@@ -19,6 +23,7 @@
         IGlobalProperties &
         IMarginProperties;
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -35,4 +40,19 @@
     {...map_global_attributes($$props)}
     class="dot {_class}"
     {...map_data_attributes({animation, palette, position})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 />

--- a/src/lib/components/feedback/ellipsis/Ellipsis.svelte
+++ b/src/lib/components/feedback/ellipsis/Ellipsis.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/feedback/ellipsis/Ellipsis.svelte
+++ b/src/lib/components/feedback/ellipsis/Ellipsis.svelte
@@ -3,9 +3,13 @@
     import type {IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLSpanElement;
 
         character?: string;
@@ -13,6 +17,7 @@
         IGlobalProperties &
         IMarginProperties;
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -30,6 +35,21 @@
     {...map_global_attributes($$props)}
     class="ellipsis {_class}"
     style={character ? `${style}--character:"${_character}";` : style}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <span />
     <span />

--- a/src/lib/components/feedback/progress/Progress.svelte
+++ b/src/lib/components/feedback/progress/Progress.svelte
@@ -11,6 +11,9 @@
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {
         map_aria_attributes,
         map_data_attributes,
@@ -18,6 +21,7 @@
     } from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         value?: number | string;
@@ -29,6 +33,7 @@
         IGlobalProperties &
         IMarginProperties;
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let style: $$Props["style"] = undefined;
@@ -49,6 +54,21 @@
     role="progressbar"
     {...map_aria_attributes({valuemax: 1, valuemin: 0, valuenow: value})}
     {...map_data_attributes({palette, size})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     {#if shape === "circle"}
         <svg viewBox="0 0 32 32">

--- a/src/lib/components/feedback/progress/Progress.svelte
+++ b/src/lib/components/feedback/progress/Progress.svelte
@@ -6,7 +6,7 @@
     // rules, we can drop the `--value` scheme
 
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
@@ -19,6 +19,8 @@
         map_data_attributes,
         map_global_attributes,
     } from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/feedback/spinner/Spinner.svelte
+++ b/src/lib/components/feedback/spinner/Spinner.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
@@ -9,6 +9,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/feedback/spinner/Spinner.svelte
+++ b/src/lib/components/feedback/spinner/Spinner.svelte
@@ -5,9 +5,13 @@
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLSpanElement;
 
         palette?: PROPERTY_PALETTE;
@@ -16,6 +20,7 @@
         IGlobalProperties &
         IMarginProperties;
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -30,4 +35,19 @@
     {...map_global_attributes($$props)}
     class="spinner {_class}"
     {...map_data_attributes({palette, size})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 />

--- a/src/lib/components/feedback/wave/Wave.svelte
+++ b/src/lib/components/feedback/wave/Wave.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {IMarginProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/feedback/wave/Wave.svelte
+++ b/src/lib/components/feedback/wave/Wave.svelte
@@ -4,9 +4,13 @@
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLSpanElement;
 
         palette?: PROPERTY_PALETTE;
@@ -14,6 +18,7 @@
         IGlobalProperties &
         IMarginProperties;
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -27,6 +32,21 @@
     {...map_global_attributes($$props)}
     class="wave {_class}"
     {...map_data_attributes({palette})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <span />
     <span />

--- a/src/lib/components/interactables/button/Button.svelte
+++ b/src/lib/components/interactables/button/Button.svelte
@@ -6,6 +6,9 @@
     import type {IMarginProperties} from "../../../types/spacings";
     import type {PROPERTY_VARIATION_BUTTON} from "../../../types/variations";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {
         map_aria_attributes,
         map_attributes,
@@ -18,6 +21,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLAnchorElement | HTMLButtonElement | HTMLInputElement | HTMLLabelElement;
 
         active?: boolean;
@@ -44,6 +48,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -80,7 +85,21 @@
         {href}
         {rel}
         {target}
+        use:forward_actions={{actions}}
         on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </a>
@@ -93,7 +112,21 @@
         for={_for}
         {...map_data_attributes({palette, size, variation})}
         {...map_aria_attributes({disabled, pressed: active})}
+        use:forward_actions={{actions}}
         on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </label>
@@ -106,7 +139,21 @@
             {...map_data_attributes({palette, size, variation})}
             {...map_aria_attributes({pressed: active})}
             {...map_attributes({disabled, value})}
+            use:forward_actions={{actions}}
             on:click
+            on:contextmenu
+            on:dblclick
+            on:focusin
+            on:focusout
+            on:keydown
+            on:keyup
+            on:pointercancel
+            on:pointerdown
+            on:pointerenter
+            on:pointerleave
+            on:pointermove
+            on:pointerout
+            on:pointerup
         />
     {:else if type === "submit"}
         <input
@@ -116,7 +163,21 @@
             {...map_data_attributes({palette, size, variation})}
             {...map_aria_attributes({pressed: active})}
             {...map_attributes({disabled, value})}
+            use:forward_actions={{actions}}
             on:click
+            on:contextmenu
+            on:dblclick
+            on:focusin
+            on:focusout
+            on:keydown
+            on:keyup
+            on:pointercancel
+            on:pointerdown
+            on:pointerenter
+            on:pointerleave
+            on:pointermove
+            on:pointerout
+            on:pointerup
         />
     {:else}
         <input
@@ -126,7 +187,21 @@
             {...map_data_attributes({palette, size, variation})}
             {...map_aria_attributes({pressed: active})}
             {...map_attributes({disabled, value})}
+            use:forward_actions={{actions}}
             on:click
+            on:contextmenu
+            on:dblclick
+            on:focusin
+            on:focusout
+            on:keydown
+            on:keyup
+            on:pointercancel
+            on:pointerdown
+            on:pointerenter
+            on:pointerleave
+            on:pointermove
+            on:pointerout
+            on:pointerup
         />
     {/if}
 {:else}
@@ -136,7 +211,21 @@
         {...map_data_attributes({palette, size, variation})}
         {...map_aria_attributes({pressed: active})}
         {...map_attributes({disabled})}
+        use:forward_actions={{actions}}
         on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </button>

--- a/src/lib/components/interactables/button/Button.svelte
+++ b/src/lib/components/interactables/button/Button.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
@@ -16,9 +16,7 @@
         map_global_attributes,
     } from "../../../util/attributes";
 
-    type $$Events = {
-        click: MouseEvent;
-    };
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/interactables/check/Check.svelte
+++ b/src/lib/components/interactables/check/Check.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
@@ -29,13 +29,12 @@
          */
         blur: FocusEvent;
         change: InputEvent;
-        click: MouseEvent;
         /**
          * @deprecated Use `on:focusin` instead.
          */
         focus: FocusEvent;
         input: InputEvent;
-    };
+    } & IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/interactables/check/Check.svelte
+++ b/src/lib/components/interactables/check/Check.svelte
@@ -6,6 +6,9 @@
     import type {IMarginProperties} from "../../../types/spacings";
     import type {PROPERTY_VARIATION_TOGGLE} from "../../../types/variations";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {
         map_aria_attributes,
         map_attributes,
@@ -21,14 +24,21 @@
     } from "../form/FormGroup.svelte";
 
     type $$Events = {
+        /**
+         * @deprecated Use `on:focusout` instead.
+         */
         blur: FocusEvent;
         change: InputEvent;
         click: MouseEvent;
+        /**
+         * @deprecated Use `on:focusin` instead.
+         */
         focus: FocusEvent;
         input: InputEvent;
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLInputElement;
 
         active?: boolean;
@@ -47,6 +57,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let id: $$Props["id"] = "";
@@ -96,10 +107,24 @@
                     value,
                 })}
                 checked={state}
+                use:forward_actions={{actions}}
+                on:click
+                on:contextmenu
+                on:dblclick
+                on:focusin
+                on:focusout
+                on:keydown
+                on:keyup
+                on:pointercancel
+                on:pointerdown
+                on:pointerenter
+                on:pointerleave
+                on:pointermove
+                on:pointerout
+                on:pointerup
                 on:change={on_change}
                 on:blur
                 on:change
-                on:click
                 on:focus
                 on:input
             />
@@ -121,10 +146,24 @@
             value,
         })}
         checked={state}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
         on:change={on_change}
         on:blur
         on:change
-        on:click
         on:focus
         on:input
     />

--- a/src/lib/components/interactables/filedropinput/FileDropInput.svelte
+++ b/src/lib/components/interactables/filedropinput/FileDropInput.svelte
@@ -5,6 +5,9 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {
         map_attributes,
         map_data_attributes,
@@ -20,6 +23,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         disabled?: boolean;
@@ -38,6 +42,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -65,6 +70,21 @@
     {...map_global_attributes($$props)}
     class="file-drop-input {_class}"
     {...map_data_attributes({palette})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 
@@ -78,7 +98,6 @@
             name: _name,
         })}
         on:change
-        on:click
         on:input
     />
 </div>

--- a/src/lib/components/interactables/filedropinput/FileDropInput.svelte
+++ b/src/lib/components/interactables/filedropinput/FileDropInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
@@ -18,9 +18,8 @@
 
     type $$Events = {
         change: InputEvent;
-        click: MouseEvent;
         input: InputEvent;
-    };
+    } & IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/interactables/form/FormControl.svelte
+++ b/src/lib/components/interactables/form/FormControl.svelte
@@ -5,11 +5,15 @@
     import type {IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     import FormGroup from "../form/FormGroup.svelte";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         logic_id?: string;
@@ -22,6 +26,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -31,7 +36,26 @@
     export let logic_name: $$Props["logic_name"] = undefined;
 </script>
 
-<div bind:this={element} {...map_global_attributes($$props)} class="form-control {_class}">
+<div
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    class="form-control {_class}"
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <FormGroup {logic_id} {logic_name}>
         <slot />
     </FormGroup>

--- a/src/lib/components/interactables/form/FormControl.svelte
+++ b/src/lib/components/interactables/form/FormControl.svelte
@@ -2,7 +2,7 @@
     // TODO: Stories (?)
 
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
@@ -11,6 +11,8 @@
     import {map_global_attributes} from "../../../util/attributes";
 
     import FormGroup from "../form/FormGroup.svelte";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/interactables/form/FormHelpText.svelte
+++ b/src/lib/components/interactables/form/FormHelpText.svelte
@@ -5,9 +5,13 @@
     import type {IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -17,12 +21,32 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
     export {_class as class};
 </script>
 
-<small bind:this={element} {...map_global_attributes($$props)} class="form-help-text {_class}">
+<small
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    class="form-help-text {_class}"
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </small>

--- a/src/lib/components/interactables/form/FormHelpText.svelte
+++ b/src/lib/components/interactables/form/FormHelpText.svelte
@@ -2,13 +2,15 @@
     // TODO: Stories (?)
 
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/interactables/form/FormLabel.svelte
+++ b/src/lib/components/interactables/form/FormLabel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {IPaddingProperties} from "../../../types/spacings";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
@@ -10,9 +10,7 @@
 
     import FormGroup, {CONTEXT_FORM_ID} from "./FormGroup.svelte";
 
-    type $$Events = {
-        click: MouseEvent;
-    };
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/interactables/form/FormLabel.svelte
+++ b/src/lib/components/interactables/form/FormLabel.svelte
@@ -3,6 +3,9 @@
     import type {IHTML5Properties} from "../../../types/html5";
     import type {IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_aria_attributes, map_global_attributes} from "../../../util/attributes";
 
     import FormGroup, {CONTEXT_FORM_ID} from "./FormGroup.svelte";
@@ -12,6 +15,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLLabelElement;
 
         active?: boolean;
@@ -26,6 +30,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = undefined;
@@ -44,7 +49,21 @@
     {...map_global_attributes($$props)}
     {...map_aria_attributes({disabled, pressed: active})}
     for={_logic_for}
+    use:forward_actions={{actions}}
     on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     {#if !_form_id && _for}
         <FormGroup logic_id={_for}>

--- a/src/lib/components/interactables/radio/Radio.svelte
+++ b/src/lib/components/interactables/radio/Radio.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
@@ -29,13 +29,12 @@
          */
         blur: FocusEvent;
         change: InputEvent;
-        click: MouseEvent;
         /**
          * @deprecated Use `on:focusin` instead.
          */
         focus: FocusEvent;
         input: InputEvent;
-    };
+    } & IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/interactables/radio/Radio.svelte
+++ b/src/lib/components/interactables/radio/Radio.svelte
@@ -6,6 +6,9 @@
     import type {IMarginProperties} from "../../../types/spacings";
     import type {PROPERTY_VARIATION_TOGGLE} from "../../../types/variations";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {
         map_aria_attributes,
         map_attributes,
@@ -21,14 +24,21 @@
     } from "../form/FormGroup.svelte";
 
     type $$Events = {
+        /**
+         * @deprecated Use `on:focusout` instead.
+         */
         blur: FocusEvent;
         change: InputEvent;
         click: MouseEvent;
+        /**
+         * @deprecated Use `on:focusin` instead.
+         */
         focus: FocusEvent;
         input: InputEvent;
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLInputElement;
 
         active?: boolean;
@@ -47,6 +57,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let id: $$Props["id"] = "";
@@ -96,10 +107,24 @@
                     value,
                 })}
                 checked={state}
+                use:forward_actions={{actions}}
+                on:click
+                on:contextmenu
+                on:dblclick
+                on:focusin
+                on:focusout
+                on:keydown
+                on:keyup
+                on:pointercancel
+                on:pointerdown
+                on:pointerenter
+                on:pointerleave
+                on:pointermove
+                on:pointerout
+                on:pointerup
                 on:change={on_change}
                 on:blur
                 on:change
-                on:click
                 on:focus
                 on:input
             />
@@ -121,10 +146,24 @@
             value,
         })}
         checked={state}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
         on:change={on_change}
         on:blur
         on:change
-        on:click
         on:focus
         on:input
     />

--- a/src/lib/components/interactables/switch/Switch.svelte
+++ b/src/lib/components/interactables/switch/Switch.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
@@ -28,13 +28,12 @@
          */
         blur: FocusEvent;
         change: InputEvent;
-        click: MouseEvent;
         /**
          * @deprecated Use `on:focusin` instead.
          */
         focus: FocusEvent;
         input: InputEvent;
-    };
+    } & IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/interactables/switch/Switch.svelte
+++ b/src/lib/components/interactables/switch/Switch.svelte
@@ -5,6 +5,9 @@
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {
         map_aria_attributes,
         map_attributes,
@@ -20,14 +23,21 @@
     } from "../form/FormGroup.svelte";
 
     type $$Events = {
+        /**
+         * @deprecated Use `on:focusout` instead.
+         */
         blur: FocusEvent;
         change: InputEvent;
         click: MouseEvent;
+        /**
+         * @deprecated Use `on:focusin` instead.
+         */
         focus: FocusEvent;
         input: InputEvent;
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLInputElement;
 
         active?: boolean;
@@ -45,6 +55,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let id: $$Props["id"] = "";
@@ -94,10 +105,24 @@
                     value,
                 })}
                 checked={state}
+                use:forward_actions={{actions}}
+                on:click
+                on:contextmenu
+                on:dblclick
+                on:focusin
+                on:focusout
+                on:keydown
+                on:keyup
+                on:pointercancel
+                on:pointerdown
+                on:pointerenter
+                on:pointerleave
+                on:pointermove
+                on:pointerout
+                on:pointerup
                 on:change={on_change}
                 on:blur
                 on:change
-                on:click
                 on:focus
                 on:input
             />
@@ -120,10 +145,24 @@
             value,
         })}
         checked={state}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
         on:change={on_change}
         on:blur
         on:change
-        on:click
         on:focus
         on:input
     />

--- a/src/lib/components/interactables/textinput/TextInput.svelte
+++ b/src/lib/components/interactables/textinput/TextInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {PROPERTY_RESIZEABLE} from "../../../types/resizable";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
@@ -25,13 +25,12 @@
          */
         blur: FocusEvent;
         change: InputEvent;
-        click: MouseEvent;
         /**
          * @deprecated Use `on:focusin` instead.
          */
         focus: FocusEvent;
         input: InputEvent;
-    };
+    } & IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/interactables/textinput/TextInput.svelte
+++ b/src/lib/components/interactables/textinput/TextInput.svelte
@@ -8,6 +8,9 @@
     import type {PROPERTY_TEXT_ALIGNMENT, PROPERTY_TEXT_TRANSFORM} from "../../../types/typography";
     import type {PROPERTY_VARIATION_INPUT} from "../../../types/variations";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {
         map_attributes,
         map_data_attributes,
@@ -17,14 +20,21 @@
     import {CONTEXT_FORM_ID, CONTEXT_FORM_NAME} from "../form/FormGroup.svelte";
 
     type $$Events = {
+        /**
+         * @deprecated Use `on:focusout` instead.
+         */
         blur: FocusEvent;
         change: InputEvent;
         click: MouseEvent;
+        /**
+         * @deprecated Use `on:focusin` instead.
+         */
         focus: FocusEvent;
         input: InputEvent;
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLInputElement | HTMLTextAreaElement;
 
         is?: "input" | "textarea";
@@ -56,6 +66,7 @@
         IGlobalProperties &
         IMarginProperties;
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let id: $$Props["id"] = "";
@@ -115,9 +126,23 @@
             spellcheck: spell_check === undefined ? undefined : spell_check.toString(),
         })}
         bind:value
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
         on:blur
         on:change
-        on:click
         on:focus
         on:input
     />
@@ -141,9 +166,23 @@
             value,
         })}
         bind:value
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
         on:blur
         on:change
-        on:click
         on:focus
         on:input
     />
@@ -167,9 +206,23 @@
             value,
         })}
         bind:value
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
         on:blur
         on:change
-        on:click
         on:focus
         on:input
     />
@@ -193,9 +246,23 @@
             value,
         })}
         bind:value
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
         on:blur
         on:change
-        on:click
         on:focus
         on:input
     />
@@ -219,9 +286,23 @@
             value,
         })}
         bind:value
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
         on:blur
         on:change
-        on:click
         on:focus
         on:input
     />
@@ -245,9 +326,23 @@
             value,
         })}
         bind:value
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
         on:blur
         on:change
-        on:click
         on:focus
         on:input
     />

--- a/src/lib/components/layouts/center/Center.svelte
+++ b/src/lib/components/layouts/center/Center.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/layouts/center/Center.svelte
+++ b/src/lib/components/layouts/center/Center.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,12 +22,32 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
     export {_class as class};
 </script>
 
-<div bind:this={element} {...map_global_attributes($$props)} class="center {_class}">
+<div
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    class="center {_class}"
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </div>

--- a/src/lib/components/layouts/container/Container.svelte
+++ b/src/lib/components/layouts/container/Container.svelte
@@ -5,9 +5,13 @@
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
     import type {PROPERTY_VIEWPORT_BREAKPOINT} from "../../../types/viewports";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement | HTMLDivElement;
 
         is?: "div" | "main";
@@ -23,6 +27,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -39,6 +44,21 @@
         {...map_global_attributes($$props)}
         class="container {_class}"
         {...map_data_attributes({viewport})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </main>
@@ -48,6 +68,21 @@
         {...map_global_attributes($$props)}
         class="container {_class}"
         {...map_data_attributes({viewport})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </div>

--- a/src/lib/components/layouts/container/Container.svelte
+++ b/src/lib/components/layouts/container/Container.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
     import type {PROPERTY_VIEWPORT_BREAKPOINT} from "../../../types/viewports";
@@ -9,6 +9,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/layouts/divider/Divider.svelte
+++ b/src/lib/components/layouts/divider/Divider.svelte
@@ -6,9 +6,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLHRElement | HTMLSpanElement;
 
         palette?: PROPERTY_PALETTE;
@@ -22,6 +26,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
@@ -34,6 +39,20 @@
         {...map_global_attributes($$props)}
         role="separator"
         {...map_data_attributes({orientation, palette})}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </span>
@@ -42,5 +61,20 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         {...map_data_attributes({orientation, palette})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     />
 {/if}

--- a/src/lib/components/layouts/divider/Divider.svelte
+++ b/src/lib/components/layouts/divider/Divider.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_ORIENTATION_X_BREAKPOINT} from "../../../types/orientations";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {ISizeProperties} from "../../../types/sizes";
@@ -10,6 +10,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/layouts/grid/GridContainer.svelte
+++ b/src/lib/components/layouts/grid/GridContainer.svelte
@@ -14,9 +14,13 @@
         IPaddingProperties,
     } from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         points?: PROPERTY_POINTS_BREAKPOINT;
@@ -38,6 +42,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -67,6 +72,21 @@
         "spacing-x": spacing_x,
         "spacing-y": spacing_y,
     })}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </div>

--- a/src/lib/components/layouts/grid/GridContainer.svelte
+++ b/src/lib/components/layouts/grid/GridContainer.svelte
@@ -5,7 +5,7 @@
         PROPERTY_ALIGNMENT_Y_BREAKPOINT,
     } from "../../../types/alignments";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_POINTS_BREAKPOINT} from "../../../types/points";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {
@@ -18,6 +18,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/layouts/grid/GridItem.svelte
+++ b/src/lib/components/layouts/grid/GridItem.svelte
@@ -3,9 +3,13 @@
     import type {IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_POINTS_BREAKPOINT} from "../../../types/points";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         span?: PROPERTY_POINTS_BREAKPOINT;
@@ -18,6 +22,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -37,6 +42,21 @@
         span_x,
         span_y,
     })}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </div>

--- a/src/lib/components/layouts/grid/GridItem.svelte
+++ b/src/lib/components/layouts/grid/GridItem.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_POINTS_BREAKPOINT} from "../../../types/points";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/layouts/group/Group.svelte
+++ b/src/lib/components/layouts/group/Group.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_ORIENTATION_X_BREAKPOINT} from "../../../types/orientations";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
@@ -9,6 +9,10 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+
+    type $$Events = IHTML5Events;
+
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/layouts/group/Group.svelte
+++ b/src/lib/components/layouts/group/Group.svelte
@@ -10,9 +10,7 @@
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
-
     type $$Events = IHTML5Events;
-
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/layouts/group/Group.svelte
+++ b/src/lib/components/layouts/group/Group.svelte
@@ -5,9 +5,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         orientation?: PROPERTY_ORIENTATION_X_BREAKPOINT;
@@ -22,6 +26,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let orientation: $$Props["orientation"] = undefined;
@@ -33,6 +38,21 @@
     role="group"
     {...map_global_attributes($$props)}
     {...map_data_attributes({orientation, variation})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </div>

--- a/src/lib/components/layouts/mosaic/Mosaic.svelte
+++ b/src/lib/components/layouts/mosaic/Mosaic.svelte
@@ -24,9 +24,7 @@
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
-
     type $$Events = IHTML5Events;
-
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/layouts/mosaic/Mosaic.svelte
+++ b/src/lib/components/layouts/mosaic/Mosaic.svelte
@@ -19,9 +19,13 @@
         IPaddingProperties,
     } from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         sizing?: PROPERTY_SIZING_BREAKPOINT;
@@ -43,6 +47,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -72,6 +77,21 @@
         "spacing-x": spacing_x,
         "spacing-y": spacing_y,
     })}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </div>

--- a/src/lib/components/layouts/mosaic/Mosaic.svelte
+++ b/src/lib/components/layouts/mosaic/Mosaic.svelte
@@ -10,7 +10,7 @@
         PROPERTY_ALIGNMENT_Y_BREAKPOINT,
     } from "../../../types/alignments";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {PROPERTY_SIZING_BREAKPOINT} from "../../../types/sizings";
     import type {
@@ -23,6 +23,10 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+
+    type $$Events = IHTML5Events;
+
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/layouts/position/Position.svelte
+++ b/src/lib/components/layouts/position/Position.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type {PROPERTY_ALIGNMENT_X} from "../../../types/alignments";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PLACEMENT} from "../../../types/placements";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
@@ -10,6 +10,10 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+
+    type $$Events = IHTML5Events;
+
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/layouts/position/Position.svelte
+++ b/src/lib/components/layouts/position/Position.svelte
@@ -11,9 +11,7 @@
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
-
     type $$Events = IHTML5Events;
-
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/layouts/position/Position.svelte
+++ b/src/lib/components/layouts/position/Position.svelte
@@ -6,9 +6,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
 
         variation?: "floated" | "raised";
@@ -25,6 +29,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -45,6 +50,21 @@
         placement,
         variation,
     })}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </div>

--- a/src/lib/components/layouts/scrollable/Scrollable.svelte
+++ b/src/lib/components/layouts/scrollable/Scrollable.svelte
@@ -8,9 +8,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -22,12 +26,32 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
     export {_class as class};
 </script>
 
-<div bind:this={element} {...map_global_attributes($$props)} class="scrollable {_class}">
+<div
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    class="scrollable {_class}"
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </div>

--- a/src/lib/components/layouts/scrollable/Scrollable.svelte
+++ b/src/lib/components/layouts/scrollable/Scrollable.svelte
@@ -4,7 +4,7 @@
      */
 
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -12,6 +12,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/layouts/spacer/Spacer.svelte
+++ b/src/lib/components/layouts/spacer/Spacer.svelte
@@ -4,9 +4,13 @@
     import type {PROPERTY_ORIENTATION_BREAKPOINT} from "../../../types/orientations";
     import type {PROPERTY_SPACING_BREAKPOINT} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement | HTMLSpanElement;
 
         is?: "div" | "span";
@@ -30,6 +34,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let is: $$Props["is"] = "div";
@@ -61,6 +66,21 @@
             "spacing-x": spacing_x,
             "spacing-y": spacing_y,
         })}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </span>
@@ -74,6 +94,21 @@
             "spacing-x": spacing_x,
             "spacing-y": spacing_y,
         })}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </div>

--- a/src/lib/components/layouts/spacer/Spacer.svelte
+++ b/src/lib/components/layouts/spacer/Spacer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_ORIENTATION_BREAKPOINT} from "../../../types/orientations";
     import type {PROPERTY_SPACING_BREAKPOINT} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/layouts/stack/Stack.svelte
+++ b/src/lib/components/layouts/stack/Stack.svelte
@@ -5,7 +5,7 @@
         PROPERTY_ALIGNMENT_Y_BREAKPOINT,
     } from "../../../types/alignments";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_ORIENTATION_Y_BREAKPOINT} from "../../../types/orientations";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {
@@ -19,6 +19,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/layouts/stack/Stack.svelte
+++ b/src/lib/components/layouts/stack/Stack.svelte
@@ -15,9 +15,13 @@
     } from "../../../types/spacings";
     import type {PROPERTY_VARIATION_FLEX} from "../../../types/variations";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         orientation?: PROPERTY_ORIENTATION_Y_BREAKPOINT;
@@ -40,6 +44,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -71,6 +76,21 @@
         "spacing-y": spacing_y,
         variation,
     })}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </div>

--- a/src/lib/components/navigation/anchor/Anchor.svelte
+++ b/src/lib/components/navigation/anchor/Anchor.svelte
@@ -5,7 +5,7 @@
 
     import type {PROPERTY_ARIA_CURRENT} from "../../../types/aria";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {IMarginProperties} from "../../../types/spacings";
 
@@ -18,9 +18,7 @@
         map_global_attributes,
     } from "../../../util/attributes";
 
-    type $$Events = {
-        click: MouseEvent;
-    };
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/navigation/anchor/Anchor.svelte
+++ b/src/lib/components/navigation/anchor/Anchor.svelte
@@ -9,6 +9,9 @@
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {
         map_aria_attributes,
         map_data_attributes,
@@ -20,6 +23,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLAnchorElement;
 
         active?: boolean;
@@ -40,6 +44,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = undefined;
@@ -63,7 +68,21 @@
     {href}
     {rel}
     {target}
+    use:forward_actions={{actions}}
     on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </a>

--- a/src/lib/components/navigation/breadcrumb/BreadcrumbAnchor.svelte
+++ b/src/lib/components/navigation/breadcrumb/BreadcrumbAnchor.svelte
@@ -3,6 +3,9 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_aria_attributes, map_global_attributes} from "../../../util/attributes";
 
     import BreadcrumbItem from "./BreadcrumbItem.svelte";
@@ -12,6 +15,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLLIElement;
 
         active?: boolean;
@@ -28,6 +32,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let active: boolean = false;
@@ -46,7 +51,21 @@
         {href}
         {rel}
         {target}
+        use:forward_actions={{actions}}
         on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </a>

--- a/src/lib/components/navigation/breadcrumb/BreadcrumbAnchor.svelte
+++ b/src/lib/components/navigation/breadcrumb/BreadcrumbAnchor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {IGlobalProperties} from "../../../types/global";
     import type {IMarginProperties} from "../../../types/spacings";
 
@@ -10,9 +10,7 @@
 
     import BreadcrumbItem from "./BreadcrumbItem.svelte";
 
-    type $$Events = {
-        click: MouseEvent;
-    };
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/navigation/breadcrumb/BreadcrumbContainer.svelte
+++ b/src/lib/components/navigation/breadcrumb/BreadcrumbContainer.svelte
@@ -2,7 +2,7 @@
     import type {SvelteComponent} from "svelte";
 
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -12,6 +12,8 @@
     import {map_aria_attributes, map_global_attributes} from "../../../util/attributes";
 
     import BreadcrumbGroup from "./BreadcrumbGroup.svelte";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/navigation/breadcrumb/BreadcrumbContainer.svelte
+++ b/src/lib/components/navigation/breadcrumb/BreadcrumbContainer.svelte
@@ -6,11 +6,15 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_aria_attributes, map_global_attributes} from "../../../util/attributes";
 
     import BreadcrumbGroup from "./BreadcrumbGroup.svelte";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
 
         separator?: string | typeof SvelteComponent;
@@ -24,6 +28,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -37,6 +42,21 @@
     {...map_global_attributes($$props)}
     class="breadcrumb {_class}"
     {...map_aria_attributes({label: "breadcrumb"})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <ol>
         <BreadcrumbGroup {separator}>

--- a/src/lib/components/navigation/breadcrumb/BreadcrumbItem.svelte
+++ b/src/lib/components/navigation/breadcrumb/BreadcrumbItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
@@ -9,6 +9,8 @@
     import {map_global_attributes} from "../../../util/attributes";
 
     import {CONTEXT_BREADCRUMB_SEPARATOR} from "./BreadcrumbGroup.svelte";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/navigation/breadcrumb/BreadcrumbItem.svelte
+++ b/src/lib/components/navigation/breadcrumb/BreadcrumbItem.svelte
@@ -3,11 +3,15 @@
     import type {IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     import {CONTEXT_BREADCRUMB_SEPARATOR} from "./BreadcrumbGroup.svelte";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLLIElement;
 
         active?: boolean;
@@ -19,6 +23,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = undefined;
@@ -32,7 +37,25 @@
     }
 </script>
 
-<li bind:this={element} {...map_global_attributes($$props)}>
+<li
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 
     {#if !active}

--- a/src/lib/components/navigation/menu/MenuAnchor.svelte
+++ b/src/lib/components/navigation/menu/MenuAnchor.svelte
@@ -9,6 +9,9 @@
         map_global_attributes,
     } from "../../../util/attributes";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import MenuItem from "./MenuItem.svelte";
 
     type $$Events = {
@@ -16,6 +19,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLLIElement;
 
         active?: boolean;
@@ -34,6 +38,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = undefined;
@@ -56,7 +61,21 @@
         {href}
         {rel}
         {target}
+        use:forward_actions={{actions}}
         on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </a>

--- a/src/lib/components/navigation/menu/MenuAnchor.svelte
+++ b/src/lib/components/navigation/menu/MenuAnchor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
 
     import {
@@ -14,9 +14,7 @@
 
     import MenuItem from "./MenuItem.svelte";
 
-    type $$Events = {
-        click: MouseEvent;
-    };
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/navigation/menu/MenuButton.svelte
+++ b/src/lib/components/navigation/menu/MenuButton.svelte
@@ -9,6 +9,9 @@
         map_global_attributes,
     } from "../../../util/attributes";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import MenuItem from "./MenuItem.svelte";
 
     type $$Events = {
@@ -16,6 +19,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLLIElement;
 
         active?: boolean;
@@ -29,6 +33,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = undefined;
@@ -43,7 +48,21 @@
         {...map_data_attributes({palette})}
         {...map_aria_attributes({pressed: active})}
         {...map_attributes({disabled})}
+        use:forward_actions={{actions}}
         on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </button>

--- a/src/lib/components/navigation/menu/MenuButton.svelte
+++ b/src/lib/components/navigation/menu/MenuButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import {
         map_aria_attributes,
@@ -14,9 +14,7 @@
 
     import MenuItem from "./MenuItem.svelte";
 
-    type $$Events = {
-        click: MouseEvent;
-    };
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/navigation/menu/MenuContainer.svelte
+++ b/src/lib/components/navigation/menu/MenuContainer.svelte
@@ -6,9 +6,13 @@
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
 
         sizing?: PROPERTY_SIZING;
@@ -24,6 +28,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -39,6 +44,21 @@
     bind:this={element}
     {...map_global_attributes($$props)}
     {...map_data_attributes({orientation, sizing})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <ul>
         <slot />

--- a/src/lib/components/navigation/menu/MenuContainer.svelte
+++ b/src/lib/components/navigation/menu/MenuContainer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_ORIENTATION_Y_BREAKPOINT} from "../../../types/orientations";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
@@ -10,6 +10,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/navigation/menu/MenuDivider.svelte
+++ b/src/lib/components/navigation/menu/MenuDivider.svelte
@@ -2,11 +2,13 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
 
-    import Divider from "../../layouts/divider/Divider.svelte";
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
 
     import MenuItem from "./MenuItem.svelte";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLLIElement;
     } & IHTML5Properties &
         IGlobalProperties;
@@ -17,16 +19,50 @@
         "sub-menu": {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
 <MenuItem bind:element {...$$props}>
     {#if $$slots["default"]}
-        <Divider>
+        <span
+            role="separator"
+            use:forward_actions={{actions}}
+            on:click
+            on:contextmenu
+            on:dblclick
+            on:focusin
+            on:focusout
+            on:keydown
+            on:keyup
+            on:pointercancel
+            on:pointerdown
+            on:pointerenter
+            on:pointerleave
+            on:pointermove
+            on:pointerout
+            on:pointerup
+        >
             <slot />
-        </Divider>
+        </span>
     {:else}
-        <Divider />
+        <hr
+            use:forward_actions={{actions}}
+            on:click
+            on:contextmenu
+            on:dblclick
+            on:focusin
+            on:focusout
+            on:keydown
+            on:keyup
+            on:pointercancel
+            on:pointerdown
+            on:pointerenter
+            on:pointerleave
+            on:pointermove
+            on:pointerout
+            on:pointerup
+        />
     {/if}
 
     <slot name="sub-menu" />

--- a/src/lib/components/navigation/menu/MenuDivider.svelte
+++ b/src/lib/components/navigation/menu/MenuDivider.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
     import MenuItem from "./MenuItem.svelte";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/navigation/menu/MenuHeading.svelte
+++ b/src/lib/components/navigation/menu/MenuHeading.svelte
@@ -2,11 +2,13 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
 
-    import Text from "../../typography/text/Text.svelte";
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
 
     import MenuItem from "./MenuItem.svelte";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLLIElement;
     } & IHTML5Properties &
         IGlobalProperties;
@@ -17,13 +19,30 @@
         "sub-menu": {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
 <MenuItem bind:element {...$$props}>
-    <Text is="small">
+    <small
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
+    >
         <slot />
-    </Text>
+    </small>
 
     <slot name="sub-menu" />
 </MenuItem>

--- a/src/lib/components/navigation/menu/MenuHeading.svelte
+++ b/src/lib/components/navigation/menu/MenuHeading.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
     import MenuItem from "./MenuItem.svelte";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/navigation/menu/MenuItem.svelte
+++ b/src/lib/components/navigation/menu/MenuItem.svelte
@@ -2,9 +2,13 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLLIElement;
     } & IHTML5Properties &
         IGlobalProperties;
@@ -13,9 +17,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<li bind:this={element} {...map_global_attributes($$props)}>
+<li
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </li>

--- a/src/lib/components/navigation/menu/MenuItem.svelte
+++ b/src/lib/components/navigation/menu/MenuItem.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/navigation/menu/MenuLabel.svelte
+++ b/src/lib/components/navigation/menu/MenuLabel.svelte
@@ -8,6 +8,9 @@
         map_global_attributes,
     } from "../../../util/attributes";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import FormGroup from "../../interactables/form/FormGroup.svelte";
 
     import MenuItem from "./MenuItem.svelte";
@@ -17,6 +20,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLLIElement;
 
         active?: boolean;
@@ -32,6 +36,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = undefined;
@@ -50,7 +55,21 @@
             {...map_data_attributes({palette})}
             {...map_aria_attributes({disabled, pressed: active})}
             for={_for}
+            use:forward_actions={{actions}}
             on:click
+            on:contextmenu
+            on:dblclick
+            on:focusin
+            on:focusout
+            on:keydown
+            on:keyup
+            on:pointercancel
+            on:pointerdown
+            on:pointerenter
+            on:pointerleave
+            on:pointermove
+            on:pointerout
+            on:pointerup
         >
             <slot />
         </label>

--- a/src/lib/components/navigation/menu/MenuLabel.svelte
+++ b/src/lib/components/navigation/menu/MenuLabel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import {
         map_aria_attributes,
@@ -15,9 +15,7 @@
 
     import MenuItem from "./MenuItem.svelte";
 
-    type $$Events = {
-        click: MouseEvent;
-    };
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/navigation/menu/MenuSubMenu.svelte
+++ b/src/lib/components/navigation/menu/MenuSubMenu.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/navigation/menu/MenuSubMenu.svelte
+++ b/src/lib/components/navigation/menu/MenuSubMenu.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLUListElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,9 +22,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<ul bind:this={element} {...map_global_attributes($$props)}>
+<ul
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </ul>

--- a/src/lib/components/overlays/clickable/ClickableAnchor.svelte
+++ b/src/lib/components/overlays/clickable/ClickableAnchor.svelte
@@ -1,16 +1,14 @@
 <script lang="ts">
     import type {PROPERTY_ARIA_CURRENT} from "../../../types/aria";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_aria_attributes, map_global_attributes} from "../../../util/attributes";
 
-    type $$Events = {
-        click: MouseEvent;
-    };
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/overlays/clickable/ClickableAnchor.svelte
+++ b/src/lib/components/overlays/clickable/ClickableAnchor.svelte
@@ -3,6 +3,9 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_aria_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Events = {
@@ -10,6 +13,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLAnchorElement;
 
         active?: boolean;
@@ -27,6 +31,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -51,7 +56,21 @@
     {href}
     {rel}
     {target}
+    use:forward_actions={{actions}}
     on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </a>

--- a/src/lib/components/overlays/clickable/ClickableContainer.svelte
+++ b/src/lib/components/overlays/clickable/ClickableContainer.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,12 +22,32 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
     export {_class as class};
 </script>
 
-<div bind:this={element} {...map_global_attributes($$props)} class="clickable {_class}">
+<div
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    class="clickable {_class}"
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </div>

--- a/src/lib/components/overlays/clickable/ClickableContainer.svelte
+++ b/src/lib/components/overlays/clickable/ClickableContainer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/overlays/clickable/ClickableLabel.svelte
+++ b/src/lib/components/overlays/clickable/ClickableLabel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
@@ -9,9 +9,7 @@
 
     import FormGroup from "../../interactables/form/FormGroup.svelte";
 
-    type $$Events = {
-        click: MouseEvent;
-    };
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/overlays/clickable/ClickableLabel.svelte
+++ b/src/lib/components/overlays/clickable/ClickableLabel.svelte
@@ -2,6 +2,9 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_aria_attributes, map_global_attributes} from "../../../util/attributes";
 
     import FormGroup from "../../interactables/form/FormGroup.svelte";
@@ -11,6 +14,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLLabelElement;
 
         active?: boolean;
@@ -24,6 +28,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -42,7 +47,21 @@
     class="clickable-item {_class}"
     {...map_aria_attributes({disabled, pressed: active})}
     for={_for}
+    use:forward_actions={{actions}}
     on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <FormGroup logic_id={_for}>
         <slot />

--- a/src/lib/components/overlays/offscreen/Offscreen.svelte
+++ b/src/lib/components/overlays/offscreen/Offscreen.svelte
@@ -6,10 +6,12 @@
         PROPERTY_ALIGNMENT_X_BREAKPOINT,
         PROPERTY_ALIGNMENT_Y_BREAKPOINT,
     } from "../../../types/alignments";
-
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PLACEMENT} from "../../../types/placements";
+
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
 
     import {make_id_context} from "../../../stores/id";
     import {make_state_context} from "../../../stores/state";
@@ -25,6 +27,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         captive?: boolean;
@@ -46,6 +49,7 @@
 
     const dispatch = createEventDispatcher();
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -106,6 +110,21 @@
         "alignment-y": alignment_y,
         placement,
     })}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </div>

--- a/src/lib/components/overlays/offscreen/Offscreen.svelte
+++ b/src/lib/components/overlays/offscreen/Offscreen.svelte
@@ -121,8 +121,8 @@
         "alignment-y": alignment_y,
         placement,
     })}
-    use:forward_actions={{actions}}
     on:click={on_click_inside}
+    use:forward_actions={{actions}}
     on:click
     on:contextmenu
     on:dblclick

--- a/src/lib/components/overlays/offscreen/Offscreen.svelte
+++ b/src/lib/components/overlays/offscreen/Offscreen.svelte
@@ -7,7 +7,7 @@
         PROPERTY_ALIGNMENT_Y_BREAKPOINT,
     } from "../../../types/alignments";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PLACEMENT} from "../../../types/placements";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
@@ -24,7 +24,7 @@
         active: CustomEvent<void>;
 
         dismiss: CustomEvent<void>;
-    };
+    } & IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/overlays/overlay/Overlay.svelte
+++ b/src/lib/components/overlays/overlay/Overlay.svelte
@@ -7,7 +7,7 @@
         PROPERTY_ALIGNMENT_Y_BREAKPOINT,
     } from "../../../types/alignments";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_ORIENTATION_Y_BREAKPOINT} from "../../../types/orientations";
     import type {IPaddingProperties, PROPERTY_SPACING_BREAKPOINT} from "../../../types/spacings";
 
@@ -25,7 +25,7 @@
         active: CustomEvent<void>;
 
         dismiss: CustomEvent<void>;
-    };
+    } & IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/overlays/overlay/Overlay.svelte
+++ b/src/lib/components/overlays/overlay/Overlay.svelte
@@ -6,11 +6,13 @@
         PROPERTY_ALIGNMENT_X_BREAKPOINT,
         PROPERTY_ALIGNMENT_Y_BREAKPOINT,
     } from "../../../types/alignments";
-
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_ORIENTATION_Y_BREAKPOINT} from "../../../types/orientations";
     import type {IPaddingProperties, PROPERTY_SPACING_BREAKPOINT} from "../../../types/spacings";
+
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
 
     import {make_id_context} from "../../../stores/id";
     import {make_state_context} from "../../../stores/state";
@@ -26,6 +28,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         captive?: boolean;
@@ -52,6 +55,7 @@
 
     const dispatch = createEventDispatcher();
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -119,6 +123,21 @@
         "spacing-x": spacing_x,
         "spacing-y": spacing_y,
     })}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </div>

--- a/src/lib/components/overlays/overlay/Overlay.svelte
+++ b/src/lib/components/overlays/overlay/Overlay.svelte
@@ -134,8 +134,8 @@
         "spacing-x": spacing_x,
         "spacing-y": spacing_y,
     })}
-    use:forward_actions={{actions}}
     on:click={on_click_inside}
+    use:forward_actions={{actions}}
     on:click
     on:contextmenu
     on:dblclick

--- a/src/lib/components/overlays/popover/Popover.svelte
+++ b/src/lib/components/overlays/popover/Popover.svelte
@@ -7,11 +7,13 @@
     import {createEventDispatcher} from "svelte";
 
     import type {PROPERTY_ALIGNMENT_X, PROPERTY_ALIGNMENT_Y} from "../../../types/alignments";
-
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PLACEMENT} from "../../../types/placements";
     import type {PROPERTY_SPACING} from "../../../types/spacings";
+
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
 
     import {click_outside} from "../../../actions/click_outside";
 
@@ -27,6 +29,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         dismissible?: boolean;
@@ -48,6 +51,7 @@
 
     const dispatch = createEventDispatcher();
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -109,6 +113,21 @@
         spacing,
     })}
     use:click_outside={{on_click_outside}}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </div>

--- a/src/lib/components/overlays/popover/Popover.svelte
+++ b/src/lib/components/overlays/popover/Popover.svelte
@@ -8,7 +8,7 @@
 
     import type {PROPERTY_ALIGNMENT_X, PROPERTY_ALIGNMENT_Y} from "../../../types/alignments";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PLACEMENT} from "../../../types/placements";
     import type {PROPERTY_SPACING} from "../../../types/spacings";
 
@@ -26,7 +26,7 @@
         active: CustomEvent<void>;
 
         dismiss: CustomEvent<void>;
-    };
+    } & IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/box/Box.svelte
+++ b/src/lib/components/surfaces/box/Box.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import type {PROPERTY_ELEVATION} from "../../../types/elevations";
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Properties} from "../../../types/html5";
@@ -10,6 +13,7 @@
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions: IForwardedActions;
         element?: HTMLDivElement;
 
         elevation?: PROPERTY_ELEVATION;
@@ -25,6 +29,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = [];
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -40,6 +45,8 @@
     {...map_global_attributes($$props)}
     class="box {_class}"
     {...map_data_attributes({elevation, palette, shape})}
+    use:forward_actions={{actions}}
+    on:click
 >
     <slot />
 </div>

--- a/src/lib/components/surfaces/box/Box.svelte
+++ b/src/lib/components/surfaces/box/Box.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-    import type {IForwardedActions} from "../../../actions/forward_actions";
-    import {forward_actions} from "../../../actions/forward_actions";
-
     import type {PROPERTY_ELEVATION} from "../../../types/elevations";
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
@@ -10,12 +7,15 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Events = IHTML5Events;
 
     type $$Props = {
-        actions: IForwardedActions;
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         elevation?: PROPERTY_ELEVATION;
@@ -31,7 +31,7 @@
         default: {};
     };
 
-    export let actions: $$Props["actions"] = [];
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";

--- a/src/lib/components/surfaces/box/Box.svelte
+++ b/src/lib/components/surfaces/box/Box.svelte
@@ -4,13 +4,15 @@
 
     import type {PROPERTY_ELEVATION} from "../../../types/elevations";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {PROPERTY_SHAPE} from "../../../types/shapes";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions: IForwardedActions;
@@ -47,6 +49,19 @@
     {...map_data_attributes({elevation, palette, shape})}
     use:forward_actions={{actions}}
     on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </div>

--- a/src/lib/components/surfaces/card/CardContainer.svelte
+++ b/src/lib/components/surfaces/card/CardContainer.svelte
@@ -8,9 +8,13 @@
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
     import type {PROPERTY_VARIATION_SURFACE} from "../../../types/variations";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         elevation?: PROPERTY_ELEVATION;
@@ -27,6 +31,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -43,6 +48,21 @@
     {...map_global_attributes($$props)}
     class="card {_class}"
     {...map_data_attributes({elevation, palette, sizing, variation})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </div>

--- a/src/lib/components/surfaces/card/CardContainer.svelte
+++ b/src/lib/components/surfaces/card/CardContainer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type {PROPERTY_ELEVATION} from "../../../types/elevations";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
@@ -12,6 +12,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/card/CardFigure.svelte
+++ b/src/lib/components/surfaces/card/CardFigure.svelte
@@ -11,9 +11,7 @@
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
-
     type $$Events = IHTML5Events;
-
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/card/CardFigure.svelte
+++ b/src/lib/components/surfaces/card/CardFigure.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type {PROPERTY_FIT} from "../../../types/fit";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_SHAPE} from "../../../types/shapes";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
@@ -10,6 +10,10 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+
+    type $$Events = IHTML5Events;
+
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/card/CardFigure.svelte
+++ b/src/lib/components/surfaces/card/CardFigure.svelte
@@ -6,12 +6,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
-    import Figure from "../../embedded/figure/Figure.svelte";
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
 
-    // NOTE: We could just use `Figure["$$props_def"]` and alias `$$Props` to it. But
-    // it's marked as internal, and we might as well write it all out here anyway for clarity
+    import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
 
         fit?: PROPERTY_FIT;
@@ -26,12 +27,32 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let fit: $$Props["fit"] = undefined;
     export let shape: $$Props["shape"] = undefined;
 </script>
 
-<Figure bind:element {...$$props} {fit} {shape}>
+<figure
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    {...map_data_attributes({fit, shape})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
-</Figure>
+</figure>

--- a/src/lib/components/surfaces/card/CardFooter.svelte
+++ b/src/lib/components/surfaces/card/CardFooter.svelte
@@ -10,9 +10,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
 
         orientation?: PROPERTY_ORIENTATION_X_BREAKPOINT;
@@ -30,6 +34,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let orientation: $$Props["orientation"] = undefined;
@@ -48,6 +53,21 @@
         "alignment-y": alignment_y,
         orientation,
     })}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </footer>

--- a/src/lib/components/surfaces/card/CardFooter.svelte
+++ b/src/lib/components/surfaces/card/CardFooter.svelte
@@ -5,7 +5,7 @@
         PROPERTY_ALIGNMENT_Y_BREAKPOINT,
     } from "../../../types/alignments";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_ORIENTATION_X_BREAKPOINT} from "../../../types/orientations";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
@@ -14,6 +14,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/card/CardHeader.svelte
+++ b/src/lib/components/surfaces/card/CardHeader.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,9 +22,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<header bind:this={element} {...map_global_attributes($$props)}>
+<header
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </header>

--- a/src/lib/components/surfaces/card/CardHeader.svelte
+++ b/src/lib/components/surfaces/card/CardHeader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/card/CardSection.svelte
+++ b/src/lib/components/surfaces/card/CardSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/card/CardSection.svelte
+++ b/src/lib/components/surfaces/card/CardSection.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,9 +22,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<section bind:this={element} {...map_global_attributes($$props)}>
+<section
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </section>

--- a/src/lib/components/surfaces/hero/HeroContainer.svelte
+++ b/src/lib/components/surfaces/hero/HeroContainer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
@@ -9,6 +9,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/hero/HeroContainer.svelte
+++ b/src/lib/components/surfaces/hero/HeroContainer.svelte
@@ -5,9 +5,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         palette?: PROPERTY_PALETTE;
@@ -21,6 +25,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -34,6 +39,21 @@
     {...map_global_attributes($$props)}
     class="hero {_class}"
     {...map_data_attributes({palette})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </div>

--- a/src/lib/components/surfaces/hero/HeroFooter.svelte
+++ b/src/lib/components/surfaces/hero/HeroFooter.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/hero/HeroFooter.svelte
+++ b/src/lib/components/surfaces/hero/HeroFooter.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,9 +22,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<footer bind:this={element} {...map_global_attributes($$props)}>
+<footer
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </footer>

--- a/src/lib/components/surfaces/hero/HeroHeader.svelte
+++ b/src/lib/components/surfaces/hero/HeroHeader.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,9 +22,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<header bind:this={element} {...map_global_attributes($$props)}>
+<header
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </header>

--- a/src/lib/components/surfaces/hero/HeroHeader.svelte
+++ b/src/lib/components/surfaces/hero/HeroHeader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/hero/HeroSection.svelte
+++ b/src/lib/components/surfaces/hero/HeroSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/hero/HeroSection.svelte
+++ b/src/lib/components/surfaces/hero/HeroSection.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,9 +22,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<section bind:this={element} {...map_global_attributes($$props)}>
+<section
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </section>

--- a/src/lib/components/surfaces/tile/TileContainer.svelte
+++ b/src/lib/components/surfaces/tile/TileContainer.svelte
@@ -8,9 +8,13 @@
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
     import type {PROPERTY_VARIATION_SURFACE} from "../../../types/variations";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLDivElement;
 
         elevation?: PROPERTY_ELEVATION;
@@ -27,6 +31,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -43,6 +48,21 @@
     {...map_global_attributes($$props)}
     class="tile {_class}"
     {...map_data_attributes({elevation, palette, sizing, variation})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </div>

--- a/src/lib/components/surfaces/tile/TileContainer.svelte
+++ b/src/lib/components/surfaces/tile/TileContainer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type {PROPERTY_ELEVATION} from "../../../types/elevations";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
@@ -12,6 +12,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/tile/TileFigure.svelte
+++ b/src/lib/components/surfaces/tile/TileFigure.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type {PROPERTY_FIT} from "../../../types/fit";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_SHAPE} from "../../../types/shapes";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
@@ -10,6 +10,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/tile/TileFigure.svelte
+++ b/src/lib/components/surfaces/tile/TileFigure.svelte
@@ -6,12 +6,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
-    import Figure from "../../embedded/figure/Figure.svelte";
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
 
-    // NOTE: We could just use `Figure["$$props_def"]` and alias `$$Props` to it. But
-    // it's marked as internal, and we might as well write it all out here anyway for clarity
+    import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
 
         fit?: PROPERTY_FIT;
@@ -26,12 +27,32 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let fit: $$Props["fit"] = undefined;
     export let shape: $$Props["shape"] = undefined;
 </script>
 
-<Figure bind:element {...$$props} {fit} {shape}>
+<figure
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    {...map_data_attributes({fit, shape})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
-</Figure>
+</figure>

--- a/src/lib/components/surfaces/tile/TileFooter.svelte
+++ b/src/lib/components/surfaces/tile/TileFooter.svelte
@@ -10,9 +10,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
 
         orientation?: PROPERTY_ORIENTATION_Y_BREAKPOINT;
@@ -30,6 +34,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let orientation: $$Props["orientation"] = undefined;
@@ -48,6 +53,21 @@
         "alignment-y": alignment_y,
         orientation,
     })}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </footer>

--- a/src/lib/components/surfaces/tile/TileFooter.svelte
+++ b/src/lib/components/surfaces/tile/TileFooter.svelte
@@ -5,7 +5,7 @@
         PROPERTY_ALIGNMENT_Y_BREAKPOINT,
     } from "../../../types/alignments";
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_ORIENTATION_Y_BREAKPOINT} from "../../../types/orientations";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
@@ -14,6 +14,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/tile/TileHeader.svelte
+++ b/src/lib/components/surfaces/tile/TileHeader.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,9 +22,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<header bind:this={element} {...map_global_attributes($$props)}>
+<header
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </header>

--- a/src/lib/components/surfaces/tile/TileHeader.svelte
+++ b/src/lib/components/surfaces/tile/TileHeader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/tile/TileSection.svelte
+++ b/src/lib/components/surfaces/tile/TileSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/surfaces/tile/TileSection.svelte
+++ b/src/lib/components/surfaces/tile/TileSection.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,9 +22,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<section bind:this={element} {...map_global_attributes($$props)}>
+<section
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </section>

--- a/src/lib/components/typography/blockquote/BlockquoteCite.svelte
+++ b/src/lib/components/typography/blockquote/BlockquoteCite.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/typography/blockquote/BlockquoteCite.svelte
+++ b/src/lib/components/typography/blockquote/BlockquoteCite.svelte
@@ -3,9 +3,13 @@
     import type {IHTML5Properties} from "../../../types/html5";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -15,9 +19,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<cite bind:this={element} {...map_global_attributes($$props)}>
+<cite
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </cite>

--- a/src/lib/components/typography/blockquote/BlockquoteContainer.svelte
+++ b/src/lib/components/typography/blockquote/BlockquoteContainer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
@@ -9,6 +9,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/typography/blockquote/BlockquoteContainer.svelte
+++ b/src/lib/components/typography/blockquote/BlockquoteContainer.svelte
@@ -5,9 +5,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
 
         palette?: PROPERTY_PALETTE;
@@ -21,6 +25,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -34,6 +39,21 @@
     {...map_global_attributes($$props)}
     class="blockquote {_class}"
     {...map_data_attributes({palette})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </blockquote>

--- a/src/lib/components/typography/code/Code.svelte
+++ b/src/lib/components/typography/code/Code.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {IMarginProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/typography/code/Code.svelte
+++ b/src/lib/components/typography/code/Code.svelte
@@ -4,9 +4,13 @@
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {IMarginProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement | HTMLPreElement;
 
         is?: "code" | "pre";
@@ -20,6 +24,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -37,17 +42,44 @@
         class="code {_class}"
         {...map_data_attributes({
             palette,
-        })}>
-        <code >
-            <slot />
-        </code>
-    </pre>
+        })}><code
+            use:forward_actions={{actions}}
+            on:click
+            on:contextmenu
+            on:dblclick
+            on:focusin
+            on:focusout
+            on:keydown
+            on:keyup
+            on:pointercancel
+            on:pointerdown
+            on:pointerenter
+            on:pointerleave
+            on:pointermove
+            on:pointerout
+        on:pointerup
+        ><slot /></code></pre>
 {:else}
     <code
         bind:this={element}
         {...map_global_attributes($$props)}
         class="code {_class}"
         {...map_data_attributes({palette})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </code>

--- a/src/lib/components/typography/heading/Heading.svelte
+++ b/src/lib/components/typography/heading/Heading.svelte
@@ -9,9 +9,13 @@
         PROPERTY_TEXT_VARIATION,
     } from "../../../types/typography";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLHeadingElement;
 
         is?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
@@ -29,6 +33,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -49,6 +54,21 @@
         {...map_global_attributes($$props)}
         class="heading {_class}"
         {...map_data_attributes({align, palette, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </h6>
@@ -58,6 +78,21 @@
         {...map_global_attributes($$props)}
         class="heading {_class}"
         {...map_data_attributes({align, palette, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </h5>
@@ -67,6 +102,21 @@
         {...map_global_attributes($$props)}
         class="heading {_class}"
         {...map_data_attributes({align, palette, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </h4>
@@ -76,6 +126,21 @@
         {...map_global_attributes($$props)}
         class="heading {_class}"
         {...map_data_attributes({align, palette, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </h3>
@@ -85,6 +150,21 @@
         {...map_global_attributes($$props)}
         class="heading {_class}"
         {...map_data_attributes({align, palette, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </h2>
@@ -94,6 +174,21 @@
         {...map_global_attributes($$props)}
         class="heading {_class}"
         {...map_data_attributes({align, palette, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </h1>

--- a/src/lib/components/typography/heading/Heading.svelte
+++ b/src/lib/components/typography/heading/Heading.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {IMarginProperties} from "../../../types/spacings";
     import type {
@@ -13,6 +13,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/typography/text/Text.svelte
+++ b/src/lib/components/typography/text/Text.svelte
@@ -10,9 +10,13 @@
         PROPERTY_TEXT_VARIATION,
     } from "../../../types/typography";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement | HTMLParagraphElement | HTMLPreElement | HTMLSpanElement;
 
         is?:
@@ -49,6 +53,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -70,6 +75,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </abbr>
@@ -79,6 +99,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </b>
@@ -88,6 +123,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </del>
@@ -97,6 +147,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </em>
@@ -106,6 +171,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </i>
@@ -115,6 +195,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </ins>
@@ -124,6 +219,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </kbd>
@@ -133,6 +243,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </mark>
@@ -146,7 +271,22 @@
             palette,
             transform,
             variation,
-        })}>
+        })}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup>
             <slot />
     </pre>
 {:else if is === "s"}
@@ -155,6 +295,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </s>
@@ -164,6 +319,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </samp>
@@ -173,6 +343,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </small>
@@ -182,6 +367,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </span>
@@ -191,6 +391,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </strong>
@@ -200,6 +415,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </sub>
@@ -209,6 +439,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </sup>
@@ -218,6 +463,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </u>
@@ -227,6 +487,21 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({align, palette, size, transform, variation})}
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
     >
         <slot />
     </p>

--- a/src/lib/components/typography/text/Text.svelte
+++ b/src/lib/components/typography/text/Text.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
@@ -14,6 +14,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/widgets/widget/WidgetButton.svelte
+++ b/src/lib/components/widgets/widget/WidgetButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {PROPERTY_VARIATION_INTERACTIVE} from "../../../types/variations";
 
@@ -14,9 +14,7 @@
         map_global_attributes,
     } from "../../../util/attributes";
 
-    type $$Events = {
-        click: MouseEvent;
-    };
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/widgets/widget/WidgetButton.svelte
+++ b/src/lib/components/widgets/widget/WidgetButton.svelte
@@ -4,6 +4,9 @@
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {PROPERTY_VARIATION_INTERACTIVE} from "../../../types/variations";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {
         map_aria_attributes,
         map_attributes,
@@ -16,6 +19,7 @@
     };
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLButtonElement;
 
         active?: boolean;
@@ -30,6 +34,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let active: $$Props["active"] = undefined;
@@ -45,7 +50,21 @@
     {...map_data_attributes({palette, variation})}
     {...map_aria_attributes({pressed: active})}
     {...map_attributes({disabled})}
+    use:forward_actions={{actions}}
     on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </button>

--- a/src/lib/components/widgets/widget/WidgetContainer.svelte
+++ b/src/lib/components/widgets/widget/WidgetContainer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_ORIENTATION_Y} from "../../../types/orientations";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
@@ -14,6 +14,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/widgets/widget/WidgetContainer.svelte
+++ b/src/lib/components/widgets/widget/WidgetContainer.svelte
@@ -10,9 +10,13 @@
         PROPERTY_SPACING_BREAKPOINT,
     } from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
 
         orientation?: PROPERTY_ORIENTATION_Y;
@@ -30,6 +34,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -53,6 +58,21 @@
         "spacing-x": spacing_x,
         "spacing-y": spacing_y,
     })}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </div>

--- a/src/lib/components/widgets/widget/WidgetHeader.svelte
+++ b/src/lib/components/widgets/widget/WidgetHeader.svelte
@@ -4,9 +4,13 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -18,9 +22,28 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 </script>
 
-<header bind:this={element} {...map_global_attributes($$props)}>
+<header
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
     <slot />
 </header>

--- a/src/lib/components/widgets/widget/WidgetHeader.svelte
+++ b/src/lib/components/widgets/widget/WidgetHeader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
@@ -8,6 +8,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/components/widgets/widget/WidgetSection.svelte
+++ b/src/lib/components/widgets/widget/WidgetSection.svelte
@@ -9,9 +9,13 @@
         PROPERTY_SPACING_BREAKPOINT,
     } from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
 
         orientation?: PROPERTY_ORIENTATION_X;
@@ -28,6 +32,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     export let orientation: $$Props["orientation"] = undefined;
@@ -40,6 +45,21 @@
     bind:this={element}
     {...map_global_attributes($$props)}
     {...map_data_attributes({orientation, spacing, "spacing-x": spacing_x, "spacing-y": spacing_y})}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
 >
     <slot />
 </section>

--- a/src/lib/components/widgets/widget/WidgetSection.svelte
+++ b/src/lib/components/widgets/widget/WidgetSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
-    import type {IHTML5Properties} from "../../../types/html5";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_ORIENTATION_X} from "../../../types/orientations";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {
@@ -13,6 +13,8 @@
     import {forward_actions} from "../../../actions/forward_actions";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+
+    type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;

--- a/src/lib/types/html5.ts
+++ b/src/lib/types/html5.ts
@@ -1,3 +1,20 @@
+export interface IHTML5Events {
+    click: MouseEvent;
+    contextmenu: MouseEvent;
+    dblclick: MouseEvent;
+    focusin: FocusEvent;
+    focusout: FocusEvent;
+    keydown: KeyboardEvent;
+    keyup: KeyboardEvent;
+    pointercancel: PointerEvent;
+    pointerdown: PointerEvent;
+    pointerenter: PointerEvent;
+    pointerleave: PointerEvent;
+    pointermove: PointerEvent;
+    pointerout: PointerEvent;
+    pointerup: PointerEvent;
+}
+
 export interface IHTML5Properties {
     class?: string;
     id?: string;


### PR DESCRIPTION
# CHANGELOG

-   Updated all Components to support globally forwarding the following events: `click` , `contextmenu` , `dblclick` , `focusin` , `focusout` , `keydown` , `keyup` , `pointercancel` , `pointerdown` , `pointerenter` , `pointerleave` , `pointermove` , `pointerout` , `pointerup`.
-   Updated all Components to support Svelte Action forwarding via `<* actions={[[action, options]]}>`, e.g.

```svelte
<script>
    import {click_outside} from "@kahi-ui/framework";
</script>

<!-- prettier-ignore -->
<Box actions={[
    [click_outside, {on_click_outside: () => console.log("clicked!")}]
]}>
    ...
</Box>
```