### PR TITLE
[0.4.13] Add `<Offscreen/Overlay loading="lazy">` Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Added the following Components / Component Features
+
+    -   Overlays
+
+        -   `Offscreen` / `Overlay`
+
+            -   `<* loading="lazy">` — Disables rendering of inner content while the Component's state is inactive.
+
 ## v0.4.12 - 2021/11/28
 
 -   Vendored [`@js-temporal/polyfill`](https://github.com/js-temporal/temporal-polyfill) temporarily to fix edge case with PNPM + SvelteKit development server.

--- a/src/lib/components/overlays/offscreen/Offscreen.stories.svelte
+++ b/src/lib/components/overlays/offscreen/Offscreen.stories.svelte
@@ -1,10 +1,11 @@
 <script>
     import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
 
-    import Box from "../../surfaces/box/Box.svelte";
     import Button from "../../interactables/button/Button.svelte";
-    import ContextButton from "../../utilities/contextbutton/ContextButton.svelte";
     import Stack from "../../layouts/stack/Stack.svelte";
+    import Box from "../../surfaces/box/Box.svelte";
+    import Code from "../../typography/code/Code.svelte";
+    import ContextButton from "../../utilities/contextbutton/ContextButton.svelte";
 
     import Offscreen from "./Offscreen.svelte";
 
@@ -35,6 +36,23 @@
     </Offscreen>
 </Story>
 
+<Story name="Lazy">
+    <Box palette="negative" margin_bottom="medium">
+        To view this property in action, open devtools and watch the <Code>div</Code> elements' contents.
+    </Box>
+
+    <Button for="offscreen-once" palette="accent">Open LAZY Offscreen</Button>
+
+    <Offscreen logic_id="offscreen-once" placement="top" loading="lazy" hidden>
+        <Box palette="accent" padding="medium">
+            <Stack orientation="horizontal" alignment_y="center" spacing="medium">
+                <ContextButton palette="light" variation="clear">X</ContextButton>
+                Lazy Offscreen
+            </Stack>
+        </Box>
+    </Offscreen>
+</Story>
+
 <Story name="Once">
     <Button for="offscreen-once" palette="accent">Open ONCE Offscreen</Button>
 
@@ -42,7 +60,7 @@
         <Box palette="accent" padding="medium">
             <Stack orientation="horizontal" alignment_y="center" spacing="medium">
                 <ContextButton palette="light" variation="clear">X</ContextButton>
-                I am hidden on all Viewports!
+                Once Offscreen
             </Stack>
         </Box>
     </Offscreen>

--- a/src/lib/components/overlays/offscreen/Offscreen.svelte
+++ b/src/lib/components/overlays/offscreen/Offscreen.svelte
@@ -7,7 +7,7 @@
         PROPERTY_ALIGNMENT_Y_BREAKPOINT,
     } from "../../../types/alignments";
     import type {PROPERTY_BEHAVIOR_LOADING_LAZY} from "../../../types/behaviors";
-    import {TOKENS_BEHAVIOR_LOADING_LAZY} from "../../../types/behaviors";
+    import {TOKENS_BEHAVIOR_LOADING} from "../../../types/behaviors";
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PLACEMENT} from "../../../types/placements";
@@ -143,7 +143,7 @@
     on:pointerup
 >
     <!-- TODO: `Transition` support for `loading=lazy` -->
-    {#if $_offscreen_state || loading !== TOKENS_BEHAVIOR_LOADING_LAZY.lazy}
+    {#if $_offscreen_state || loading !== TOKENS_BEHAVIOR_LOADING.lazy}
         <slot />
     {/if}
 </div>

--- a/src/lib/components/overlays/offscreen/Offscreen.svelte
+++ b/src/lib/components/overlays/offscreen/Offscreen.svelte
@@ -6,6 +6,8 @@
         PROPERTY_ALIGNMENT_X_BREAKPOINT,
         PROPERTY_ALIGNMENT_Y_BREAKPOINT,
     } from "../../../types/alignments";
+    import type {PROPERTY_BEHAVIOR_LOADING_LAZY} from "../../../types/behaviors";
+    import {TOKENS_BEHAVIOR_LOADING_LAZY} from "../../../types/behaviors";
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PLACEMENT} from "../../../types/placements";
@@ -32,6 +34,7 @@
 
         captive?: boolean;
         dismissible?: boolean;
+        loading?: PROPERTY_BEHAVIOR_LOADING_LAZY;
         logic_id?: string;
         once?: boolean;
         state?: boolean;
@@ -58,6 +61,7 @@
 
     export let captive: $$Props["captive"] = undefined;
     export let dismissible: $$Props["dismissible"] = undefined;
+    export let loading: $$Props["loading"] = undefined;
     export let logic_id: $$Props["logic_id"] = "";
     export let once: $$Props["once"] = undefined;
     export let state: $$Props["state"] = undefined;
@@ -68,8 +72,8 @@
     export let alignment_x: $$Props["alignment_x"] = undefined;
     export let alignment_y: $$Props["alignment_y"] = undefined;
 
-    const _logic_id = make_id_context(logic_id as string);
-    const _state = make_state_context(state as boolean);
+    const _offscreen_id = make_id_context(logic_id as string);
+    const _offscreen_state = make_state_context(state as boolean);
 
     let _previous_state = state;
 
@@ -86,7 +90,7 @@
         }
     }
 
-    $: $_state = state as boolean;
+    $: $_offscreen_state = state as boolean;
 
     $: {
         if (_previous_state !== state) {
@@ -97,12 +101,12 @@
     }
 </script>
 
-{#if $_logic_id}
+{#if $_offscreen_id}
     <input
         role="presentation"
-        id={$_logic_id}
+        id={$_offscreen_id}
         type="checkbox"
-        bind:checked={$_state}
+        bind:checked={$_offscreen_state}
         on:change={on_change}
     />
 
@@ -138,5 +142,8 @@
     on:pointerout
     on:pointerup
 >
-    <slot />
+    <!-- TODO: `Transition` support for `loading=lazy` -->
+    {#if $_offscreen_state || loading !== TOKENS_BEHAVIOR_LOADING_LAZY.lazy}
+        <slot />
+    {/if}
 </div>

--- a/src/lib/components/overlays/overlay/Overlay.stories.svelte
+++ b/src/lib/components/overlays/overlay/Overlay.stories.svelte
@@ -44,23 +44,33 @@
     </Overlay>
 </Story>
 
+<Story name="Lazy">
+    <Box palette="negative" margin_bottom="medium">
+        To view this property in action, open devtools and watch the <Code>div</Code> elements' contents.
+    </Box>
+
+    <Button for="overlay-lazy" palette="accent">Open LAZY Modal</Button>
+
+    <Overlay logic_id="overlay-lazy" loading="lazy">
+        <Card.Container palette="auto" max_width="viewport-75">
+            <Card.Header>Lazy Modal</Card.Header>
+
+            <Card.Footer>
+                <ContextButton palette="inverse" variation="clear">Close</ContextButton>
+            </Card.Footer>
+        </Card.Container>
+    </Overlay>
+</Story>
+
 <Story name="Once">
     <Button for="overlay-once" palette="accent">Open ONCE Modal</Button>
 
     <Overlay logic_id="overlay-once" once>
         <Card.Container palette="auto" max_width="viewport-75">
-            <Card.Header>Are you sure?</Card.Header>
-
-            <Card.Section>
-                <Text>
-                    Are you sure you want to delete:
-                    <Code>important-file.docx</Code>?
-                </Text>
-            </Card.Section>
+            <Card.Header>Once Modal</Card.Header>
 
             <Card.Footer>
-                <ContextButton palette="inverse" variation="clear">Cancel</ContextButton>
-                <Button palette="negative">Delete</Button>
+                <ContextButton palette="inverse" variation="clear">Close</ContextButton>
             </Card.Footer>
         </Card.Container>
     </Overlay>

--- a/src/lib/components/overlays/overlay/Overlay.svelte
+++ b/src/lib/components/overlays/overlay/Overlay.svelte
@@ -6,6 +6,8 @@
         PROPERTY_ALIGNMENT_X_BREAKPOINT,
         PROPERTY_ALIGNMENT_Y_BREAKPOINT,
     } from "../../../types/alignments";
+    import type {PROPERTY_BEHAVIOR_LOADING_LAZY} from "../../../types/behaviors";
+    import {TOKENS_BEHAVIOR_LOADING_LAZY} from "../../../types/behaviors";
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_ORIENTATION_Y_BREAKPOINT} from "../../../types/orientations";
@@ -33,6 +35,7 @@
 
         captive?: boolean;
         dismissible?: boolean;
+        loading?: PROPERTY_BEHAVIOR_LOADING_LAZY;
         logic_id?: string;
         once?: boolean;
         state?: boolean;
@@ -64,6 +67,7 @@
 
     export let captive: $$Props["captive"] = undefined;
     export let dismissible: $$Props["dismissible"] = undefined;
+    export let loading: $$Props["loading"] = undefined;
     export let logic_id: $$Props["logic_id"] = "";
     export let once: $$Props["once"] = undefined;
     export let state: $$Props["state"] = undefined;
@@ -78,8 +82,8 @@
     export let spacing_x: $$Props["spacing_x"] = undefined;
     export let spacing_y: $$Props["spacing_y"] = undefined;
 
-    const _logic_id = make_id_context(logic_id as string);
-    const _state = make_state_context(state as boolean);
+    const _overlay_id = make_id_context(logic_id as string);
+    const _overlay_state = make_state_context(state as boolean);
 
     let _previous_state = state;
 
@@ -96,7 +100,7 @@
         }
     }
 
-    $: $_state = state as boolean;
+    $: $_overlay_state = state as boolean;
 
     $: {
         if (_previous_state !== state) {
@@ -107,12 +111,12 @@
     }
 </script>
 
-{#if $_logic_id}
+{#if $_overlay_id}
     <input
         role="presentation"
-        id={$_logic_id}
+        id={$_overlay_id}
         type="checkbox"
-        bind:checked={$_state}
+        bind:checked={$_overlay_state}
         on:change={on_change}
     />
 
@@ -151,5 +155,8 @@
     on:pointerout
     on:pointerup
 >
-    <slot />
+    <!-- TODO: `Transition` support for `loading=lazy` -->
+    {#if $_overlay_state || loading !== TOKENS_BEHAVIOR_LOADING_LAZY.lazy}
+        <slot />
+    {/if}
 </div>

--- a/src/lib/components/overlays/overlay/Overlay.svelte
+++ b/src/lib/components/overlays/overlay/Overlay.svelte
@@ -7,7 +7,7 @@
         PROPERTY_ALIGNMENT_Y_BREAKPOINT,
     } from "../../../types/alignments";
     import type {PROPERTY_BEHAVIOR_LOADING_LAZY} from "../../../types/behaviors";
-    import {TOKENS_BEHAVIOR_LOADING_LAZY} from "../../../types/behaviors";
+    import {TOKENS_BEHAVIOR_LOADING} from "../../../types/behaviors";
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_ORIENTATION_Y_BREAKPOINT} from "../../../types/orientations";
@@ -156,7 +156,7 @@
     on:pointerup
 >
     <!-- TODO: `Transition` support for `loading=lazy` -->
-    {#if $_overlay_state || loading !== TOKENS_BEHAVIOR_LOADING_LAZY.lazy}
+    {#if $_overlay_state || loading !== TOKENS_BEHAVIOR_LOADING.lazy}
         <slot />
     {/if}
 </div>


### PR DESCRIPTION
# CHANGELOG

-   Added the following Components / Component Features

    -   Overlays

        -   `Offscreen` / `Overlay`

            -   `<* loading="lazy">` — Disables rendering of inner content while the Component's state is inactive.