### PR TITLE
[0.4.13] Add `escape` Keybind to Overlays + Revamp Overlays `<* dismissible once>` Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
         -   `*(..., {ignore: string})` — Ignores a given [CSS Selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) from triggering the `on_click_inside` / `on_click_outside` callbacks.
 
+-   Updated the following Components / Component Features
+
+    -   `Offscreen` / `Overlay` / `Popover`
+
+        -   `<* dismissible={boolean}>` — Now enables dismissing of Overlays via escape key.
+
 ## v0.4.12 - 2021/11/28
 
 -   Vendored [`@js-temporal/polyfill`](https://github.com/js-temporal/temporal-polyfill) temporarily to fix edge case with PNPM + SvelteKit development server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Added the following Actions / Action Features
+
+    -   `click_inside` — Listens to the `click` on the attached element, with optional CSS Selector for filtering.
+
+    -   `click_inside` / `click_outside`
+
+        -   `*(..., {ignore: string})` — Ignores a given [CSS Selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) from triggering the `on_click_inside` / `on_click_outside` callbacks.
+
 ## v0.4.12 - 2021/11/28
 
 -   Vendored [`@js-temporal/polyfill`](https://github.com/js-temporal/temporal-polyfill) temporarily to fix edge case with PNPM + SvelteKit development server.

--- a/src/lib/actions/click_inside.ts
+++ b/src/lib/actions/click_inside.ts
@@ -1,0 +1,63 @@
+import type {IActionHandle} from "./actions";
+
+/**
+ * Represents the Svelte Action handle returned by [[click_inside]]
+ */
+export type IClickInsideHandle = Required<IActionHandle<IClickInsideOptions>>;
+
+/**
+ * Represents the typing for the [[IClickOutsideOptions.on_click_inside]] callback
+ */
+export type IClickInsideCallback = (event: MouseEvent) => void;
+
+/**
+ * Represents the options passable to the [[click_inside]] Svelte Action
+ */
+export interface IClickInsideOptions {
+    /**
+     * Represents CSS selectors used as an ignore list of elements that can
+     * trigger the [[IClickInsideOptions.ignore]] callback
+     */
+    ignore?: string;
+
+    /**
+     * Represents the event callback called whenever target element
+     * was clicked inside of its inner content
+     */
+    on_click_inside: IClickInsideCallback;
+}
+
+/**
+ * Listens to the [`click`](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event) event
+ * in the attached element.
+ *
+ * @param element
+ * @param options
+ * @returns
+ */
+export function click_inside(
+    element: HTMLElement,
+    options: IClickInsideOptions
+): IClickInsideHandle {
+    let {ignore, on_click_inside} = options;
+
+    function on_click(event: MouseEvent): void {
+        const target = event.target as HTMLElement;
+
+        if (ignore && target.matches(ignore)) return;
+
+        on_click_inside(event);
+    }
+
+    element.addEventListener("click", on_click);
+
+    return {
+        destroy() {
+            element.removeEventListener("click", on_click);
+        },
+
+        update(options: IClickInsideOptions) {
+            ({ignore, on_click_inside} = options);
+        },
+    };
+}

--- a/src/lib/actions/click_outside.ts
+++ b/src/lib/actions/click_outside.ts
@@ -15,6 +15,12 @@ export type IClickOutsideCallback = (event: MouseEvent) => void;
  */
 export interface IClickOutsideOptions {
     /**
+     * Represents CSS selectors used as an ignore list of elements that can
+     * trigger the [[IClickOutsideOptions.ignore]] callback
+     */
+    ignore?: string;
+
+    /**
      * Represents the event callback called whenever target element
      * was clicked outside of its children
      */
@@ -34,23 +40,26 @@ export function click_outside(
     element: HTMLElement,
     options: IClickOutsideOptions
 ): IClickOutsideHandle {
-    let {on_click_outside} = options;
+    let {ignore, on_click_outside} = options;
 
-    function on_click(event: MouseEvent) {
-        const target = event.target as Node;
+    function on_click(event: MouseEvent): void {
+        const target = event.target as HTMLElement;
 
-        if (document.contains(target) && !element.contains(target)) on_click_outside(event);
+        if (ignore && target.matches(ignore)) return;
+        if (!document.contains(target) || element.contains(target)) return;
+
+        on_click_outside(event);
     }
 
     document.addEventListener("click", on_click);
 
     return {
-        update(options: IClickOutsideOptions) {
-            ({on_click_outside} = options);
-        },
-
         destroy() {
             document.removeEventListener("click", on_click);
+        },
+
+        update(options: IClickOutsideOptions) {
+            ({ignore, on_click_outside} = options);
         },
     };
 }

--- a/src/lib/actions/keybind.ts
+++ b/src/lib/actions/keybind.ts
@@ -188,7 +188,7 @@ function bindstate(binds: string | string[]): IBindState {
  * @param options
  * @returns
  */
-export function keybind(element: HTMLElement, options: IKeybindOptions): IKeybindHandle {
+export function keybind(element: Document | HTMLElement, options: IKeybindOptions): IKeybindHandle {
     let {binds, repeat = false, repeat_throttle = 0, on_bind} = options;
 
     let cache = false;
@@ -221,12 +221,16 @@ export function keybind(element: HTMLElement, options: IKeybindOptions): IKeybin
     const on_key_down = make_key_listener(true);
     const on_key_up = make_key_listener(false);
 
+    // @ts-expect-error - HACK: `Document` just doesn't have the event properly typed
     element.addEventListener("keydown", on_key_down);
+    // @ts-expect-error
     element.addEventListener("keyup", on_key_up);
 
     return {
         destroy() {
+            // @ts-expect-error
             element.removeEventListener("keydown", on_key_down);
+            // @ts-expect-error
             element.removeEventListener("keyup", on_key_up);
         },
 

--- a/src/lib/components/overlays/offscreen/Offscreen.stories.svelte
+++ b/src/lib/components/overlays/offscreen/Offscreen.stories.svelte
@@ -25,11 +25,24 @@
 <Story name="Default">
     <Button for="offscreen-default-story" palette="accent">Open Offscreen</Button>
 
-    <Offscreen logic_id="offscreen-default-story" placement="top" captive dismissible hidden>
+    <Offscreen logic_id="offscreen-default-story" placement="top" captive hidden>
         <Box palette="accent" padding="medium">
             <Stack orientation="horizontal" alignment_y="center" spacing="medium">
                 <ContextButton palette="light" variation="clear">X</ContextButton>
                 I am hidden on all Viewports!
+            </Stack>
+        </Box>
+    </Offscreen>
+</Story>
+
+<Story name="Dismissible">
+    <Button for="offscreen-dismissible" palette="accent">Open DISMISSIBLE Offscreen</Button>
+
+    <Offscreen logic_id="offscreen-dismissible" placement="top" dismissible hidden>
+        <Box palette="accent" padding="medium">
+            <Stack orientation="horizontal" alignment_y="center" spacing="medium">
+                <ContextButton palette="light" variation="clear">X</ContextButton>
+                DISMISSIBLE Offscreen
             </Stack>
         </Box>
     </Offscreen>
@@ -42,7 +55,7 @@
         <Box palette="accent" padding="medium">
             <Stack orientation="horizontal" alignment_y="center" spacing="medium">
                 <ContextButton palette="light" variation="clear">X</ContextButton>
-                I am hidden on all Viewports!
+                ONCE Offscreen
             </Stack>
         </Box>
     </Offscreen>

--- a/src/lib/components/overlays/offscreen/Offscreen.svelte
+++ b/src/lib/components/overlays/offscreen/Offscreen.svelte
@@ -10,6 +10,8 @@
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PLACEMENT} from "../../../types/placements";
 
+    import {click_inside} from "../../../actions/click_inside";
+    import {click_outside} from "../../../actions/click_outside";
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
@@ -17,6 +19,7 @@
     import {make_state_context} from "../../../stores/state";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+    import {action_exit} from "../../../util/keybind";
 
     import ContextBackdrop from "../../utilities/contextbackdrop/ContextBackdrop.svelte";
 
@@ -77,13 +80,12 @@
         state = (event.target as HTMLInputElement).checked;
     }
 
-    function on_click_inside(event: MouseEvent): void {
-        if (once) {
-            const target = event.target as HTMLElement;
-            if (target.tagName !== "LABEL" && target.getAttribute("for") !== logic_id) {
-                state = false;
-            }
-        }
+    function on_dismiss(): void {
+        if (dismissible && $_state) state = false;
+    }
+
+    function on_once(): void {
+        if (once && $_state) state = false;
     }
 
     $: $_state = state as boolean;
@@ -96,6 +98,8 @@
         }
     }
 </script>
+
+<svelte:window use:action_exit={{on_bind: on_dismiss}} />
 
 {#if $_logic_id}
     <input
@@ -121,7 +125,14 @@
         "alignment-y": alignment_y,
         placement,
     })}
-    on:click={on_click_inside}
+    use:click_inside={{
+        ignore: `label[for="${logic_id}"]`,
+        on_click_inside: on_once,
+    }}
+    use:click_outside={{
+        ignore: `label[for="${logic_id}"]`,
+        on_click_outside: on_dismiss,
+    }}
     use:forward_actions={{actions}}
     on:click
     on:contextmenu

--- a/src/lib/components/overlays/overlay/Overlay.stories.svelte
+++ b/src/lib/components/overlays/overlay/Overlay.stories.svelte
@@ -25,7 +25,7 @@
 <Story name="Default">
     <Button for="overlay-default-story" palette="accent">Open Modal</Button>
 
-    <Overlay logic_id="overlay-default-story" captive dismissible>
+    <Overlay logic_id="overlay-default-story" captive>
         <Card.Container palette="auto" max_width="viewport-75">
             <Card.Header>Are you sure?</Card.Header>
 
@@ -44,23 +44,29 @@
     </Overlay>
 </Story>
 
+<Story name="Dismissible">
+    <Button for="overlay-dismissible" palette="accent">Open DISMISSIBLE Modal</Button>
+
+    <Overlay logic_id="overlay-dismissible" dismissible>
+        <Card.Container palette="auto" max_width="viewport-75">
+            <Card.Header>Dismissible Overlay</Card.Header>
+
+            <Card.Footer>
+                <ContextButton palette="inverse" variation="clear">Close</ContextButton>
+            </Card.Footer>
+        </Card.Container>
+    </Overlay>
+</Story>
+
 <Story name="Once">
     <Button for="overlay-once" palette="accent">Open ONCE Modal</Button>
 
     <Overlay logic_id="overlay-once" once>
         <Card.Container palette="auto" max_width="viewport-75">
-            <Card.Header>Are you sure?</Card.Header>
-
-            <Card.Section>
-                <Text>
-                    Are you sure you want to delete:
-                    <Code>important-file.docx</Code>?
-                </Text>
-            </Card.Section>
+            <Card.Header>Once Overlay</Card.Header>
 
             <Card.Footer>
-                <ContextButton palette="inverse" variation="clear">Cancel</ContextButton>
-                <Button palette="negative">Delete</Button>
+                <ContextButton palette="inverse" variation="clear">Close</ContextButton>
             </Card.Footer>
         </Card.Container>
     </Overlay>

--- a/src/lib/components/overlays/overlay/Overlay.svelte
+++ b/src/lib/components/overlays/overlay/Overlay.svelte
@@ -11,6 +11,8 @@
     import type {PROPERTY_ORIENTATION_Y_BREAKPOINT} from "../../../types/orientations";
     import type {IPaddingProperties, PROPERTY_SPACING_BREAKPOINT} from "../../../types/spacings";
 
+    import {click_inside} from "../../../actions/click_inside";
+    import {click_outside} from "../../../actions/click_outside";
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
@@ -18,6 +20,7 @@
     import {make_state_context} from "../../../stores/state";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+    import {action_exit} from "../../../util/keybind";
 
     import ContextBackdrop from "../../utilities/contextbackdrop/ContextBackdrop.svelte";
 
@@ -87,13 +90,12 @@
         state = (event.target as HTMLInputElement).checked;
     }
 
-    function on_click_inside(event: MouseEvent): void {
-        if (once) {
-            const target = event.target as HTMLElement;
-            if (target.tagName !== "LABEL" && target.getAttribute("for") !== logic_id) {
-                state = false;
-            }
-        }
+    function on_dismiss(): void {
+        if (dismissible && $_state) state = false;
+    }
+
+    function on_once(): void {
+        if (once && $_state) state = false;
     }
 
     $: $_state = state as boolean;
@@ -106,6 +108,8 @@
         }
     }
 </script>
+
+<svelte:window use:action_exit={{on_bind: on_dismiss}} />
 
 {#if $_logic_id}
     <input
@@ -134,7 +138,14 @@
         "spacing-x": spacing_x,
         "spacing-y": spacing_y,
     })}
-    on:click={on_click_inside}
+    use:click_inside={{
+        ignore: `label[for="${logic_id}"]`,
+        on_click_inside: on_once,
+    }}
+    use:click_outside={{
+        ignore: `label[for="${logic_id}"]`,
+        on_click_outside: on_dismiss,
+    }}
     use:forward_actions={{actions}}
     on:click
     on:contextmenu

--- a/src/lib/components/overlays/popover/Popover.stories.svelte
+++ b/src/lib/components/overlays/popover/Popover.stories.svelte
@@ -73,7 +73,7 @@
     <Popover logic_id="popover-dismissible" alignment_x="right" dismissible hidden>
         <ContextButton palette="accent">Open DISMISSIBLE Popover</ContextButton>
 
-        <Box palette="inverse" elevation="high" padding="small">DISMISSIBLE Popover</Box>
+        <Box palette="inverse" elevation="high" padding="small">Open DISMISSIBLE Popover</Box>
     </Popover>
 </Story>
 
@@ -81,7 +81,7 @@
     <Popover logic_id="popover-once" alignment_x="right" hidden once>
         <ContextButton palette="accent">Open ONCE Popover</ContextButton>
 
-        <Box palette="inverse" elevation="high" padding="small">ONCE Popover</Box>
+        <Box palette="inverse" elevation="high" padding="small">Open ONCE Popover</Box>
     </Popover>
 </Story>
 

--- a/src/lib/components/overlays/popover/Popover.stories.svelte
+++ b/src/lib/components/overlays/popover/Popover.stories.svelte
@@ -4,6 +4,7 @@
     import Spacer from "../../layouts/spacer/Spacer.svelte";
     import Stack from "../../layouts/stack/Stack.svelte";
     import * as Menu from "../../navigation/menu";
+    import Box from "../../surfaces/box/Box.svelte";
     import * as Card from "../../surfaces/card";
     import Text from "../../typography/text/Text.svelte";
     import ContextButton from "../../utilities/contextbutton/ContextButton.svelte";
@@ -37,13 +38,7 @@
 </Template>
 
 <Story name="Default">
-    <Popover
-        logic_id="popover-default-story"
-        alignment_x="right"
-        spacing="medium"
-        dismissible
-        hidden
-    >
+    <Popover logic_id="popover-default-story" alignment_x="right" spacing="medium" hidden>
         <ContextButton palette="accent">Open Popover</ContextButton>
 
         <Card.Container palette="inverse" elevation="high" max_width="content-max">
@@ -74,35 +69,19 @@
     </Popover>
 </Story>
 
+<Story name="Dismissible">
+    <Popover logic_id="popover-dismissible" alignment_x="right" dismissible hidden>
+        <ContextButton palette="accent">Open DISMISSIBLE Popover</ContextButton>
+
+        <Box palette="inverse" elevation="high" padding="small">DISMISSIBLE Popover</Box>
+    </Popover>
+</Story>
+
 <Story name="Once">
-    <Popover logic_id="popover-once" alignment_x="right" spacing="medium" hidden once>
+    <Popover logic_id="popover-once" alignment_x="right" hidden once>
         <ContextButton palette="accent">Open ONCE Popover</ContextButton>
 
-        <Card.Container palette="inverse" elevation="high" max_width="content-max">
-            <Card.Section>
-                <Menu.Container>
-                    <Menu.Button>
-                        Copy
-                        <Spacer variation="inline" spacing="medium" />
-                        <Text is="kbd">CTRL+C</Text>
-                    </Menu.Button>
-
-                    <Menu.Button>
-                        Cut
-                        <Spacer variation="inline" spacing="medium" />
-                        <Text is="kbd">CTRL+X</Text>
-                    </Menu.Button>
-
-                    <Menu.Divider />
-
-                    <Menu.Button>
-                        Delete
-                        <Spacer variation="inline" spacing="medium" />
-                        <Text is="kbd">DEL</Text>
-                    </Menu.Button>
-                </Menu.Container>
-            </Card.Section>
-        </Card.Container>
+        <Box palette="inverse" elevation="high" padding="small">ONCE Popover</Box>
     </Popover>
 </Story>
 

--- a/src/lib/components/overlays/popover/Popover.svelte
+++ b/src/lib/components/overlays/popover/Popover.svelte
@@ -12,15 +12,16 @@
     import type {PROPERTY_PLACEMENT} from "../../../types/placements";
     import type {PROPERTY_SPACING} from "../../../types/spacings";
 
+    import {click_inside} from "../../../actions/click_inside";
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
-
     import {click_outside} from "../../../actions/click_outside";
 
     import {make_id_context} from "../../../stores/id";
     import {make_state_context} from "../../../stores/state";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
+    import {action_exit} from "../../../util/keybind";
 
     type $$Events = {
         active: CustomEvent<void>;
@@ -79,17 +80,12 @@
         state = (event.target as HTMLInputElement).checked;
     }
 
-    function on_click_inside(event: MouseEvent): void {
-        if (once) {
-            const target = event.target as HTMLElement;
-            if (target.tagName !== "LABEL" && target.getAttribute("for") !== logic_id) {
-                state = false;
-            }
-        }
+    function on_dismiss(): void {
+        if (dismissible && $_state) state = false;
     }
 
-    function on_click_outside(event: MouseEvent): void {
-        if (state && dismissible) state = false;
+    function on_once(): void {
+        if (once && $_state) state = false;
     }
 
     $: $_state = state as boolean;
@@ -102,6 +98,8 @@
         }
     }
 </script>
+
+<svelte:window use:action_exit={{on_bind: on_dismiss}} />
 
 {#if $_logic_id}
     <input
@@ -123,8 +121,14 @@
         placement,
         spacing,
     })}
-    on:click={on_click_inside}
-    use:click_outside={{on_click_outside}}
+    use:click_inside={{
+        ignore: `label[for="${logic_id}"]`,
+        on_click_inside: on_once,
+    }}
+    use:click_outside={{
+        ignore: `label[for="${logic_id}"]`,
+        on_click_outside: on_dismiss,
+    }}
     use:forward_actions={{actions}}
     on:click
     on:contextmenu

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -113,6 +113,7 @@ export {Widget};
 export * from "./components/widgets/yearpicker";
 export * from "./components/widgets/yearstepper";
 
+export * from "./actions/click_inside";
 export * from "./actions/click_outside";
 export * from "./actions/clipping";
 export * from "./actions/keybind";

--- a/src/lib/util/keybind.ts
+++ b/src/lib/util/keybind.ts
@@ -1,0 +1,41 @@
+import type {IKeybindCallback, IKeybindHandle, IKeybindOptions} from "../actions/keybind";
+import {keybind} from "../actions/keybind";
+
+/**
+ * Represents an already predefined shortcut keybind
+ */
+type IKeybindShortcut = (
+    element: Document | HTMLElement,
+    {on_bind}: {on_bind: IKeybindCallback}
+) => IKeybindHandle;
+
+/**
+ * Returns a `keybind`-like factory with preconfigured options
+ * @param factory_options
+ * @returns
+ */
+function make_shortcut_factory(
+    factory_options: Omit<IKeybindOptions, "on_bind">
+): IKeybindShortcut {
+    return (element, {on_bind}) => {
+        const {destroy, update} = keybind(element, {...factory_options, on_bind});
+
+        return {
+            destroy,
+
+            update({on_bind}) {
+                update({...factory_options, on_bind});
+            },
+        };
+    };
+}
+
+/**
+ * Represents a keybind used for closing / exiting the currently active Component
+ * @param element
+ * @param options
+ * @returns
+ */
+export const action_exit = make_shortcut_factory({
+    binds: ["escape"],
+});


### PR DESCRIPTION
# CHANGELOG

-   Added the following Actions / Action Features

    -   `click_inside` — Listens to the `click` on the attached element, with optional CSS Selector for filtering.

    -   `click_inside` / `click_outside`

        -   `*(..., {ignore: string})` — Ignores a given [CSS Selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) from triggering the `on_click_inside` / `on_click_outside` callbacks.

-   Updated the following Components / Component Features

    -   `Offscreen` / `Overlay` / `Popover`

        -   `<* dismissible={boolean}>` — Now enables dismissing of Overlays via escape key.