### PR TITLE
[0.4.13] Update `ContextBackdrop` / `Offscreen` / `Overlay` to use Absolute Positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Updated the following Components / Component Features
+
+    -   Overlays
+
+        -   `Offscreen` / `Overlay`
+
+            -   Changed from fixed positioning to absolute positioning to work with inner non-viewport situations.
+
+    -   Utilities
+
+        -   `ContextBackdrop`
+
+            -   Changed from fixed positioning to absolute positioning to work with inner non-viewport situations.
+
 ## v0.4.12 - 2021/11/28
 
 -   Vendored [`@js-temporal/polyfill`](https://github.com/js-temporal/temporal-polyfill) temporarily to fix edge case with PNPM + SvelteKit development server.

--- a/src/lib/components/overlays/offscreen/offscreen.css
+++ b/src/lib/components/overlays/offscreen/offscreen.css
@@ -1,5 +1,5 @@
 .offscreen {
-    @apply contents fixed h-screen pointer-events-none w-screen z-2;
+    @apply absolute contents h-full pointer-events-none w-full z-2;
 
     flex-direction: var(--placement-orientation, row);
 

--- a/src/lib/components/overlays/overlay/overlay.css
+++ b/src/lib/components/overlays/overlay/overlay.css
@@ -10,8 +10,8 @@
     --spacing-x: 0;
     --spacing-y: 0;
 
-    @apply fixed flex flex-col gap-x-[var(--spacing-x)] gap-y-[var(--spacing-y)] h-screen
-    left-0 pointer-events-none top-0 w-screen z-2;
+    @apply absolute flex flex-col gap-x-[var(--spacing-x)] gap-y-[var(--spacing-y)] h-full
+    left-0 pointer-events-none top-0 w-full z-2;
 
     align-items: var(--orientation-align);
     justify-content: var(--orientation-justify);

--- a/src/lib/components/utilities/contextbackdrop/contextbackdrop.css
+++ b/src/lib/components/utilities/contextbackdrop/contextbackdrop.css
@@ -1,5 +1,5 @@
 .context-backdrop {
-    @apply block bg-default-200 bg-opacity-0 fixed h-screen invisible left-0 top-0 w-screen z-1;
+    @apply absolute block bg-default-200 bg-opacity-0 h-full invisible left-0 top-0 w-full z-1;
 }
 
 label[for].context-backdrop {


### PR DESCRIPTION
# CHANGELOG

-   Updated the following Components / Component Features

    -   Overlays

        -   `Offscreen` / `Overlay`

            -   Changed from fixed positioning to absolute positioning to work with inner non-viewport situations.

    -   Utilities

        -   `ContextBackdrop`

            -   Changed from fixed positioning to absolute positioning to work with inner non-viewport situations.