### PR TITLE
[0.4.13] Add `<Scrollable on:scroll>` Event Binding + `overflow_clipping` Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Added the following Actions / Action Features
+
+    -   `overflow_clipping(element: HTMLElement, options: IOverflowClippingOptions): IOverflowClippingHandle` — Detects when the inner content is clipping the attached element's bounding box.
+
+        -   `overflow_clipping(..., {enabled: boolean})` — Enables content clipping detection.
+        -   `overflow_clipping(..., {on_clip: (entry: {horizontal: boolean, vertical: boolean}) => void})` — Dispatches whenever the content clipping changes.
+
+-   Added the following Components / Component Features
+
+    -   Layouts
+
+        -   `Scrollable`
+
+            -   `<Scrollable on:scroll>` — Dispatches the [scroll event](https://developer.mozilla.org/en-US/docs/Web/API/Document/scroll_event).
+
 ## v0.4.12 - 2021/11/28
 
 -   Vendored [`@js-temporal/polyfill`](https://github.com/js-temporal/temporal-polyfill) temporarily to fix edge case with PNPM + SvelteKit development server.

--- a/src/lib/actions/overflow_clipping.stories.svelte
+++ b/src/lib/actions/overflow_clipping.stories.svelte
@@ -1,0 +1,72 @@
+<script>
+    import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
+
+    import Check from "../components/interactables/check/Check.svelte";
+    import Scrollable from "../components/layouts/scrollable/Scrollable.svelte";
+    import Box from "../components/surfaces/box/Box.svelte";
+    import Heading from "../components/typography/heading/Heading.svelte";
+
+    import {overflow_clipping} from "./overflow_clipping";
+
+    let add_content = false;
+
+    let horizontal_clipping = false;
+    let vertical_clipping = false;
+
+    function on_clip_horizontal(entry) {
+        horizontal_clipping = entry.horizontal;
+    }
+
+    function on_clip_vertical(entry) {
+        vertical_clipping = entry.vertical;
+    }
+</script>
+
+<Meta title="Actions/overflow_clipping" />
+
+<Template>
+    <slot />
+</Template>
+
+<Story name="Default">
+    <Box palette="negative" margin_bottom="small">
+        resize the below boxes, then hit the check to add new content
+    </Box>
+
+    <Check bind:state={add_content} />
+
+    <Box palette={horizontal_clipping ? "negative" : "affirmative"} padding="small">
+        {horizontal_clipping
+            ? `I was clipped, horizontally!`
+            : "I am currently not clipped horizontally..."}
+    </Box>
+
+    <Scrollable
+        actions={[[overflow_clipping, {enabled: true, on_clip: on_clip_horizontal}]]}
+        style="border:1px solid rgb(var(--palette-inverse-boldest));width:12rem;resize:horizontal;"
+    >
+        <Heading style="white-space:nowrap;">
+            Hello World!
+            {#if add_content}
+                And again!
+            {/if}
+        </Heading>
+    </Scrollable>
+
+    <Box palette={vertical_clipping ? "negative" : "affirmative"} padding="small">
+        {vertical_clipping
+            ? `I was clipped, vertically!`
+            : "I am currently not clipped vertically..."}
+    </Box>
+
+    <Scrollable
+        actions={[[overflow_clipping, {enabled: true, on_clip: on_clip_vertical}]]}
+        style="border:1px solid rgb(var(--palette-inverse-boldest));height:3rem;resize:vertical;"
+    >
+        <Heading>Hello World!</Heading>
+
+        {#if add_content}
+            <Heading>And again!</Heading>
+        {/if}
+    </Scrollable>
+</Story>

--- a/src/lib/actions/overflow_clipping.ts
+++ b/src/lib/actions/overflow_clipping.ts
@@ -1,0 +1,126 @@
+import type {IActionHandle} from "./actions";
+
+/**
+ * Represents the Svelte Action handle returned by [[overflow_clipping]]
+ */
+export type IOverflowClippingHandle = Required<IActionHandle<IOverflowClippingOptions>>;
+
+/**
+ * Represents the typing for the [[IOverflowClippingOptions.on_clip]] callback
+ */
+export type IOverflowClippingCallback = (entry: IOverflowClippingEntry) => void;
+
+/**
+ * Represnts overflow content clipping information dispatched to [[IOverflowClippingOptions.on_clip]]
+ */
+export interface IOverflowClippingEntry {
+    /**
+     * Represents if the horizontal (left-to-right) content is clipping
+     */
+    horizontal: boolean;
+
+    /**
+     * Represents if the vertical (top-to-bottom) content is clipping
+     */
+    vertical: boolean;
+}
+
+/**
+ * Represents the options passable to the [[overflow_clipping]] Svelte Action
+ */
+export interface IOverflowClippingOptions {
+    /**
+     * Represents if overflow clipping is currently being tracked
+     */
+    enabled?: boolean;
+
+    /**
+     * Represents the event callback called whenever the attached element's
+     * overflow clipping values changes
+     */
+    on_clip: IOverflowClippingCallback;
+}
+
+/**
+ * Uses the [MutationObserver API]() and [ResizeObserver API]() to detect inner content changes and
+ * changes to the attached element's dimensions, checking if overflow clipping changes each time.
+ *
+ * @param element
+ * @param options
+ * @returns
+ */
+export function overflow_clipping(
+    element: HTMLElement,
+    options: IOverflowClippingOptions
+): IOverflowClippingHandle {
+    let {enabled, on_clip} = options;
+
+    let cache: IOverflowClippingEntry | null = null;
+    let mutation_observer: MutationObserver | null = null;
+    let resize_observer: ResizeObserver | null = null;
+
+    function update_clipping() {
+        const entry: IOverflowClippingEntry = {
+            horizontal: element.scrollWidth > element.clientWidth,
+            vertical: element.scrollHeight > element.clientHeight,
+        };
+
+        if (!cache || cache.horizontal !== entry.horizontal || cache.vertical !== entry.vertical) {
+            cache = entry;
+            on_clip(entry);
+        }
+    }
+
+    function on_mutate(entries: MutationRecord[]): void {
+        update_clipping();
+    }
+
+    function on_resize(entries: ResizeObserverEntry[]): void {
+        update_clipping();
+    }
+
+    function attach_events(): void {
+        detach_events();
+
+        mutation_observer = new MutationObserver(on_mutate);
+        mutation_observer.observe(element, {
+            childList: true,
+            subtree: true,
+        });
+
+        resize_observer = new ResizeObserver(on_resize);
+        resize_observer.observe(element);
+    }
+
+    function detach_events(): void {
+        if (mutation_observer) {
+            mutation_observer.disconnect();
+            mutation_observer = null;
+        }
+
+        if (resize_observer) {
+            resize_observer.unobserve(element);
+            resize_observer = null;
+        }
+    }
+
+    if (enabled) {
+        update_clipping();
+        attach_events();
+    }
+
+    return {
+        destroy() {
+            detach_events();
+        },
+
+        update(options: IOverflowClippingOptions) {
+            ({enabled, on_clip} = options);
+
+            if (enabled) {
+                update_clipping();
+                attach_events();
+            }
+        },
+    };
+}

--- a/src/lib/components/layouts/scrollable/Scrollable.svelte
+++ b/src/lib/components/layouts/scrollable/Scrollable.svelte
@@ -1,8 +1,4 @@
 <script lang="ts">
-    /**
-     * TODO: Stories (?)
-     */
-
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
@@ -13,7 +9,9 @@
 
     import {map_global_attributes} from "../../../util/attributes";
 
-    type $$Events = IHTML5Events;
+    type $$Events = {
+        scroll: Event;
+    } & IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;
@@ -54,6 +52,7 @@
     on:pointermove
     on:pointerout
     on:pointerup
+    on:scroll
 >
     <slot />
 </div>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -118,6 +118,7 @@ export * from "./actions/clipping";
 export * from "./actions/keybind";
 export * from "./actions/intersection_observer";
 export * from "./actions/mutation_observer";
+export * from "./actions/overflow_clipping";
 
 export * from "./stores/darkmode";
 export * from "./stores/htmlpalette";


### PR DESCRIPTION
## CHANGELOG

-   Added the following Actions / Action Features

    -   `overflow_clipping(element: HTMLElement, options: IOverflowClippingOptions): IOverflowClippingHandle` — Detects when the inner content is clipping the attached element's bounding box.

        -   `overflow_clipping(..., {enabled: boolean})` — Enables content clipping detection.
        -   `overflow_clipping(..., {on_clip: (entry: {horizontal: boolean, vertical: boolean}) => void})` — Dispatches whenever the content clipping changes.

-   Added the following Components / Component Features

    -   Layouts

        -   `Scrollable`

            -   `<Scrollable on:scroll>` — Dispatches the [scroll event](https://developer.mozilla.org/en-US/docs/Web/API/Document/scroll_event).