### PR TITLE
Bump `sveltetsx` `0.4.7` -> `0.4.11`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+-   Updated `svelte2tsx` -> `0.4.11`.
+
+    -   Fixes Component properties not retaining comments / JSDoc flags.
+
 -   Added the following Actions / Action Features
 
     -   `auto_focus(element: HTMLElement, options: IAutoFocusOptions): IAutoFocusHandle` — Focuses the first available focusable element within the attached `element` when enabled, restoring focus whenever disabled.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "storybook-builder-vite": "^0.1.10",
                 "svelte-check": "^2.2.7",
                 "svelte-preprocess": "^4.9.8",
-                "svelte2tsx": "^0.4.7",
+                "svelte2tsx": "^0.4.11",
                 "tslib": "^2.2.0",
                 "typescript": "^4.3.5",
                 "vite": "^2.3.8",
@@ -17015,9 +17015,9 @@
             }
         },
         "node_modules/svelte2tsx": {
-            "version": "0.4.7",
-            "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.4.7.tgz",
-            "integrity": "sha512-1HqRb8+I8H0Gli0+w8nTmyZgbtO/jJE3g27cNKYFyN0GMdpOh0CRmiWuMH1k9N2JugkviI7wqETanqJTR0SI+A==",
+            "version": "0.4.11",
+            "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.4.11.tgz",
+            "integrity": "sha512-y1mqNrxv3TzDHstM0qlHrbKwfWk+G/uB28yRH4JYMjJ7N3XZrfrLad+/+P6ITTawbUfLqfs/WlxJDKzl7F2CPw==",
             "dev": true,
             "dependencies": {
                 "dedent-js": "^1.0.1",
@@ -21170,7 +21170,8 @@
             "version": "1.6.22",
             "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
             "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@mdx-js/util": {
             "version": "1.6.22",
@@ -23115,7 +23116,8 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
             "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -23180,13 +23182,15 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
             "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ajv-keywords": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ansi-align": {
             "version": "3.0.1",
@@ -28723,7 +28727,8 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
             "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "md5.js": {
             "version": "1.3.5",
@@ -30176,7 +30181,8 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-8.0.1.tgz",
             "integrity": "sha512-cHPNhW5VvRQjszFDxmy16mis9qFQqQLBNw6KVmueLqqE3M182ZAk9+QoxGqbGVryzLVhannw2B5Yhosqq522fA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-replace": {
             "version": "1.1.3",
@@ -30270,7 +30276,8 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.3.1.tgz",
             "integrity": "sha512-F1/r6OYoBq8Zgurhs1MN25tdrhPw0JW5JjioPRqpxbYdmrZ3gY/DzHGs0B6zwd4DLyRsfGB2gqhxUCbHt/D1fw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "pretty-error": {
             "version": "2.1.2",
@@ -30566,7 +30573,8 @@
             "version": "5.5.1",
             "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.5.1.tgz",
             "integrity": "sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "react-dev-utils": {
             "version": "11.0.4",
@@ -32638,7 +32646,8 @@
             "version": "0.14.7",
             "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.7.tgz",
             "integrity": "sha512-pDrzgcWSoMaK6AJkBWkmgIsecW0GChxYZSZieIYfCP0v2oPyx2CYU/zm7TBIcjLVUPP714WxmViE9Thht4etog==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "svelte-preprocess": {
             "version": "4.9.8",
@@ -32655,9 +32664,9 @@
             }
         },
         "svelte2tsx": {
-            "version": "0.4.7",
-            "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.4.7.tgz",
-            "integrity": "sha512-1HqRb8+I8H0Gli0+w8nTmyZgbtO/jJE3g27cNKYFyN0GMdpOh0CRmiWuMH1k9N2JugkviI7wqETanqJTR0SI+A==",
+            "version": "0.4.11",
+            "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.4.11.tgz",
+            "integrity": "sha512-y1mqNrxv3TzDHstM0qlHrbKwfWk+G/uB28yRH4JYMjJ7N3XZrfrLad+/+P6ITTawbUfLqfs/WlxJDKzl7F2CPw==",
             "dev": true,
             "requires": {
                 "dedent-js": "^1.0.1",
@@ -33523,7 +33532,8 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
             "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "use-latest": {
             "version": "1.2.0",
@@ -34282,7 +34292,8 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
             "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "webpack-hot-middleware": {
             "version": "2.25.1",
@@ -34534,7 +34545,8 @@
             "version": "8.3.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.3.0.tgz",
             "integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "xtend": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         "storybook-builder-vite": "^0.1.10",
         "svelte-check": "^2.2.7",
         "svelte-preprocess": "^4.9.8",
-        "svelte2tsx": "^0.4.7",
+        "svelte2tsx": "^0.4.11",
         "tslib": "^2.2.0",
         "typescript": "^4.3.5",
         "vite": "^2.3.8",


### PR DESCRIPTION
# CHANGELOG

-   Updated `svelte2tsx` -> `0.4.11`.

    -   Fixes Component properties not retaining comments / JSDoc flags.