### PR TITLE
[0.4.13] Last Minute Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 
     -   `keybind(element: HTMLElement, options: IKeybindOptions): IKeybindHandle`
 
+        -   `keybind(..., {on_bind: IKeybindCallback})` — Fixed inline defining of `on_bind` thrashing internal key state of the bind manager.
         -   Fixed calling `IKeybindEvent.preventDefault` / `IKeybindEvent.stopPropagation` not working.
 
 -   Updated the following Components / Component Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 
+-   Updated button-like `<label>`-based Components to emulate button-like behavior, e.g. Enter key activates element.
 -   Updated `svelte2tsx` -> `0.4.11`.
 
     -   Fixes Component properties not retaining comments / JSDoc flags.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
 
         -   `Offscreen` / `Overlay`
 
-            -   Changed from fixed positioning to absolute positioning to work with inner non-viewport situations.
+            -   Changed from viewport units to relative percentage units to work with inner non-viewport situations.
             -   `<* focus_target={HTMLElement | string | null}>` — Sets initial focus target element when first opened. Defaults to first focusable element.
             -   `<* focus_first={HTMLElement | string | null}>` — Sets the element treated as first in the focus tabbing order, which traps focus (`Offscreen` / `Overlay`) or dismisses (`Popover`). Defaults to first focusable element.
             -   `<* focus_last={HTMLElement | string | null}>` — Sets the element treated as last in the focus tabbing order, which traps focus `Offscreen` / `Overlay`. Defaults to last focusable element.
@@ -73,7 +73,7 @@
 
         -   `ContextBackdrop`
 
-            -   Changed from fixed positioning to absolute positioning to work with inner non-viewport situations.
+            -   Changed from viewport units to relative percentage units to work with inner non-viewport situations.
 
 ## v0.4.12 - 2021/11/28
 

--- a/src/lib/actions/actions.ts
+++ b/src/lib/actions/actions.ts
@@ -17,7 +17,7 @@ export interface IActionHandle<T = any> {
  * Represents the constructor of a Svelte Action
  */
 export type IAction<
-    NodeType extends Node = Node,
+    NodeType extends Node,
     OptionsType = any,
     HandleType extends IActionHandle = IActionHandle<OptionsType>
 > = (node: NodeType, options: OptionsType) => HandleType;

--- a/src/lib/actions/behavior_button.ts
+++ b/src/lib/actions/behavior_button.ts
@@ -1,0 +1,73 @@
+import {action_activate} from "../util/keybind";
+import type {IAction, IActionHandle} from "./actions";
+import type {IKeybindEvent, IKeybindHandle} from "./keybind";
+
+/**
+ * Represents the Svelte Action initializer signature for [[behavior_button]]
+ */
+export type IBehaviorButtonAction = IAction<
+    HTMLElement,
+    IBehaviorButtonOptions,
+    IBehaviorButtonHandle
+>;
+
+/**
+ * Represents the Svelte Action handle returned by [[behavior_button]]
+ */
+export type IBehaviorButtonHandle = Required<IActionHandle<IBehaviorButtonOptions>>;
+
+/**
+ * Represents the options passable to the [[behavior_button]] Svelte Action
+ */
+export interface IBehaviorButtonOptions {
+    /**
+     * Represents if button behavior is to be emulated
+     */
+    enabled?: boolean;
+}
+
+/**
+ * Emulates Button behavior on the given element, e.g. spacebar to click
+ *
+ * @param element
+ * @param options
+ * @returns
+ */
+export const behavior_button: IBehaviorButtonAction = (element, options) => {
+    let {enabled} = options;
+
+    let activate_handle: IKeybindHandle | null = null;
+
+    function on_bind(event: IKeybindEvent): void {
+        if (!event.detail.active) return;
+
+        event.preventDefault();
+        element.click();
+    }
+
+    function attach_events(): void {
+        if (!activate_handle) activate_handle = action_activate(element, {on_bind});
+    }
+
+    function detach_events(): void {
+        if (activate_handle) {
+            activate_handle.destroy();
+            activate_handle = null;
+        }
+    }
+
+    if (enabled) attach_events();
+
+    return {
+        destroy() {
+            if (enabled) detach_events();
+        },
+
+        update(options: IBehaviorButtonOptions) {
+            ({enabled} = options);
+
+            if (enabled) attach_events();
+            else detach_events();
+        },
+    };
+};

--- a/src/lib/actions/click_inside.ts
+++ b/src/lib/actions/click_inside.ts
@@ -15,7 +15,7 @@ export type IClickInsideAction = IAction<
 export type IClickInsideHandle = Required<IActionHandle<IClickInsideOptions>>;
 
 /**
- * Represents the typing for the [[IClickOutsideOptions.on_click_inside]] callback
+ * Represents the typing for the [[IClickInsideOptions.on_click_inside]] callback
  */
 export type IClickInsideCallback = (event: MouseEvent) => void;
 

--- a/src/lib/actions/click_inside.ts
+++ b/src/lib/actions/click_inside.ts
@@ -1,4 +1,13 @@
-import type {IActionHandle} from "./actions";
+import type {IAction, IActionHandle} from "./actions";
+
+/**
+ * Represents the Svelte Action initializer signature for [[click_inside]]
+ */
+export type IClickInsideAction = IAction<
+    Document | HTMLElement,
+    IClickInsideOptions,
+    IClickInsideHandle
+>;
 
 /**
  * Represents the Svelte Action handle returned by [[click_inside]]
@@ -35,24 +44,23 @@ export interface IClickInsideOptions {
  * @param options
  * @returns
  */
-export function click_inside(
-    element: HTMLElement,
-    options: IClickInsideOptions
-): IClickInsideHandle {
+export const click_inside: IClickInsideAction = (element, options) => {
     let {ignore, on_click_inside} = options;
 
     function on_click(event: MouseEvent): void {
-        const target = event.target as HTMLElement;
+        const target = event.target as Element;
 
         if (ignore && target.matches(ignore)) return;
 
         on_click_inside(event);
     }
 
+    // @ts-expect-error - HACK: `Document` typing just doesn't have it typed properly
     element.addEventListener("click", on_click);
 
     return {
         destroy() {
+            // @ts-expect-error - HACK: `Document` typing just doesn't have it typed properly
             element.removeEventListener("click", on_click);
         },
 
@@ -60,4 +68,4 @@ export function click_inside(
             ({ignore, on_click_inside} = options);
         },
     };
-}
+};

--- a/src/lib/actions/click_outside.ts
+++ b/src/lib/actions/click_outside.ts
@@ -3,7 +3,7 @@ import type {IAction, IActionHandle} from "./actions";
 /**
  * Represents the Svelte Action initializer signature for [[click_outside]]
  */
-export type IClickOutsideAction = IAction<HTMLElement, IClickOutsideOptions, IClickOutsideHandle>;
+export type IClickOutsideAction = IAction<Element, IClickOutsideOptions, IClickOutsideHandle>;
 
 /**
  * Represents the Svelte Action handle returned by [[click_outside]]

--- a/src/lib/actions/clipping.ts
+++ b/src/lib/actions/clipping.ts
@@ -102,12 +102,12 @@ export const clipping: IClippingAction = (element, options) => {
     });
 
     return {
-        update(options: IClippingOptions) {
-            ({on_clip} = options);
-        },
-
         destroy() {
             action.destroy();
+        },
+
+        update(options: IClippingOptions) {
+            ({on_clip} = options);
         },
     };
 };

--- a/src/lib/actions/forward_actions.ts
+++ b/src/lib/actions/forward_actions.ts
@@ -3,11 +3,7 @@ import type {IAction, IActionHandle} from "./actions";
 /**
  * Represents the Svelte Action initializer signature for [[forward_actions]]
  */
-export type IForwardActionsAction = IAction<
-    Document | HTMLElement,
-    IForwardActionsOptions,
-    IForwardActionsHandle
->;
+export type IForwardActionsAction = IAction<Node, IForwardActionsOptions, IForwardActionsHandle>;
 
 /**
  * Represents the Svelte Action handle returned by [[forward_actions]]
@@ -18,7 +14,7 @@ export type IForwardActionsHandle = Required<IActionHandle<IForwardActionsOption
  * Represents an array of forwarded Svelte Actions, optionally
  * associated with their options
  */
-export type IForwardedActions = (IAction | [IAction, any])[];
+export type IForwardedActions = (IAction<any> | [IAction<any>, any])[];
 
 /**
  * Represents an array forwarded Svelte Action handles
@@ -32,27 +28,24 @@ export interface IForwardActionsOptions {
     /**
      * Represents Svelte Actions that will be attached to the targeted element
      */
-    actions: IForwardedActions;
+    actions?: IForwardedActions;
 }
 
 /**
  * Attaches the provided array of Svelte Actions to the target element, handling
  * lifecycle events automatically
  *
- * @param element
+ * @param node
  * @param options
  * @returns
  */
-export function forward_actions(
-    element: HTMLElement,
-    options: Partial<IForwardActionsOptions> = {}
-): IForwardActionsHandle {
+export const forward_actions: IForwardActionsAction = (node, options) => {
     const handles = initialize_actions(options.actions);
 
     function initialize_actions(actions: IForwardedActions = []): IInitializedActions {
         return actions.map((entry, index) => {
-            if (Array.isArray(entry)) return entry[0](element, entry[1]);
-            else return entry(element, undefined);
+            if (Array.isArray(entry)) return entry[0](node, entry[1]);
+            else return entry(node, undefined);
         });
     }
 
@@ -66,7 +59,7 @@ export function forward_actions(
             }
         },
 
-        update(options: Partial<IForwardActionsOptions> = {}) {
+        update(options) {
             const {actions = []} = options;
             if (actions.length !== handles.length) {
                 throw new ReferenceError(
@@ -86,4 +79,4 @@ export function forward_actions(
             }
         },
     };
-}
+};

--- a/src/lib/actions/intersection_observer.ts
+++ b/src/lib/actions/intersection_observer.ts
@@ -4,7 +4,7 @@ import type {IAction, IActionHandle} from "./actions";
  * Represents the Svelte Action initializer signature for [[intersection_observer]]
  */
 export type IIntersectionObserverAction = IAction<
-    HTMLElement,
+    Element,
     IIntersectionObserverOptions,
     IIntersectionObserverHandle
 >;
@@ -73,6 +73,10 @@ export const intersection_observer: IIntersectionObserverAction = (element, opti
     observer.observe(element);
 
     return {
+        destroy() {
+            observer.disconnect();
+        },
+
         update(options: IIntersectionObserverOptions) {
             ({on_intersect, root, root_margin, threshold} = options);
 
@@ -91,10 +95,6 @@ export const intersection_observer: IIntersectionObserverAction = (element, opti
             );
 
             observer.observe(element);
-        },
-
-        destroy() {
-            observer.disconnect();
         },
     };
 };

--- a/src/lib/actions/keybind.ts
+++ b/src/lib/actions/keybind.ts
@@ -3,7 +3,7 @@ import type {IAction, IActionHandle} from "./actions";
 /**
  * Represents the Svelte Action initializer signature for [[keybind]]
  */
-export type IKeybindAction = IAction<Document | HTMLElement, IKeybindOptions, IKeybindHandle>;
+export type IKeybindAction = IAction<Document | Element, IKeybindOptions, IKeybindHandle>;
 
 /**
  * Represents the Svelte Action handle returned by [[keybind]]
@@ -41,7 +41,7 @@ export interface IKeybindEvent extends CustomEvent {
 }
 
 /**
- * Represents the options passable to the [[click_outside]] Svelte Action
+ * Represents the options passable to the [[keybind]] Svelte Action
  */
 export interface IKeybindOptions {
     /**

--- a/src/lib/actions/mutation_observer.ts
+++ b/src/lib/actions/mutation_observer.ts
@@ -4,7 +4,7 @@ import type {IAction, IActionHandle} from "./actions";
  * Represents the Svelte Action initializer signature for [[mutation_observer]]
  */
 export type IMutationObserverAction = IAction<
-    HTMLElement,
+    Node,
     IMutationObserverOptions,
     IMutationObserverHandle
 >;
@@ -73,11 +73,11 @@ export interface IMutationObserverOptions {
  * Represents a Svelte Action that encapsulates the [`MutationObserver`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
  * Web API to easily integrate into Svelte
  *
- * @param element
+ * @param node
  * @param options
  * @returns
  */
-export const mutation_observer: IMutationObserverAction = (element, options) => {
+export const mutation_observer: IMutationObserverAction = (node, options) => {
     let {
         attributes,
         attribute_filter,
@@ -93,7 +93,7 @@ export const mutation_observer: IMutationObserverAction = (element, options) => 
         on_mutate(mutations);
     });
 
-    observer.observe(element, {
+    observer.observe(node, {
         attributes,
         attributeFilter: attribute_filter,
         attributeOldValue: attribute_old_value,
@@ -104,6 +104,10 @@ export const mutation_observer: IMutationObserverAction = (element, options) => 
     });
 
     return {
+        destroy() {
+            observer.disconnect();
+        },
+
         update(options: IMutationObserverOptions) {
             ({
                 attributes,
@@ -117,7 +121,7 @@ export const mutation_observer: IMutationObserverAction = (element, options) => 
             } = options);
 
             observer.disconnect();
-            observer.observe(element, {
+            observer.observe(node, {
                 attributes,
                 attributeFilter: attribute_filter,
                 attributeOldValue: attribute_old_value,
@@ -126,10 +130,6 @@ export const mutation_observer: IMutationObserverAction = (element, options) => 
                 childList: child_list,
                 subtree,
             });
-        },
-
-        destroy() {
-            observer.disconnect();
         },
     };
 };

--- a/src/lib/actions/overflow_clipping.ts
+++ b/src/lib/actions/overflow_clipping.ts
@@ -86,16 +86,18 @@ export const overflow_clipping: IOverflowClippingAction = (element, options) => 
     }
 
     function attach_events(): void {
-        detach_events();
+        if (!mutation_observer) {
+            mutation_observer = new MutationObserver(on_mutate);
+            mutation_observer.observe(element, {
+                childList: true,
+                subtree: true,
+            });
+        }
 
-        mutation_observer = new MutationObserver(on_mutate);
-        mutation_observer.observe(element, {
-            childList: true,
-            subtree: true,
-        });
-
-        resize_observer = new ResizeObserver(on_resize);
-        resize_observer.observe(element);
+        if (!resize_observer) {
+            resize_observer = new ResizeObserver(on_resize);
+            resize_observer.observe(element);
+        }
     }
 
     function detach_events(): void {
@@ -126,7 +128,7 @@ export const overflow_clipping: IOverflowClippingAction = (element, options) => 
             if (enabled) {
                 update_clipping();
                 attach_events();
-            }
+            } else detach_events();
         },
     };
 };

--- a/src/lib/actions/overflow_clipping.ts
+++ b/src/lib/actions/overflow_clipping.ts
@@ -4,7 +4,7 @@ import type {IAction, IActionHandle} from "./actions";
  * Represents the Svelte Action initializer signature for [[overflow_clipping]]
  */
 export type IOverflowClippingAction = IAction<
-    HTMLElement,
+    Element,
     IOverflowClippingOptions,
     IOverflowClippingHandle
 >;

--- a/src/lib/actions/trap_focus.ts
+++ b/src/lib/actions/trap_focus.ts
@@ -46,6 +46,17 @@ export interface ITrapFocusOptions {
 export const trap_focus: ITrapFocusAction = (element, options) => {
     let {first, enabled, last} = options;
 
+    function on_focus_in(event: FocusEvent): void {
+        const target = event.target as HTMLElement | null;
+        if (!event.isTrusted || element.contains(target)) return;
+
+        const first_element = query_target(false);
+        if (!first_element) return;
+
+        event.preventDefault();
+        first_element.focus();
+    }
+
     function on_key_down(event: KeyboardEvent): void {
         if (event.key !== "Tab") return;
 
@@ -78,10 +89,12 @@ export const trap_focus: ITrapFocusAction = (element, options) => {
     }
 
     function detach_events(): void {
+        window.removeEventListener("focusin", on_focus_in);
         window.removeEventListener("keydown", on_key_down);
     }
 
     function attach_events(): void {
+        window.addEventListener("focusin", on_focus_in);
         window.addEventListener("keydown", on_key_down);
     }
 

--- a/src/lib/actions/trap_focus.ts
+++ b/src/lib/actions/trap_focus.ts
@@ -47,7 +47,7 @@ export const trap_focus: ITrapFocusAction = (element, options) => {
     let {first, enabled, last} = options;
 
     function on_key_down(event: KeyboardEvent): void {
-        if (!enabled || event.key !== "Tab") return;
+        if (event.key !== "Tab") return;
 
         const first_element = query_target(false);
         const last_element = query_target(true);
@@ -77,15 +77,26 @@ export const trap_focus: ITrapFocusAction = (element, options) => {
         return query_focusable_element(element, {last: is_last});
     }
 
-    window.addEventListener("keydown", on_key_down);
+    function detach_events(): void {
+        window.removeEventListener("keydown", on_key_down);
+    }
+
+    function attach_events(): void {
+        window.addEventListener("keydown", on_key_down);
+    }
+
+    if (enabled) attach_events();
 
     return {
         destroy() {
-            window.removeEventListener("keydown", on_key_down);
+            detach_events();
         },
 
         update(options) {
             ({first, enabled, last} = options);
+
+            if (enabled) attach_events();
+            else detach_events();
         },
     };
 };

--- a/src/lib/actions/trap_focus.ts
+++ b/src/lib/actions/trap_focus.ts
@@ -5,7 +5,7 @@ import type {IAction, IActionHandle} from "./actions";
 /**
  * Represents the Svelte Action initializer signature for [[trap_focus]]
  */
-export type ITrapFocusAction = IAction<Document | HTMLElement, ITrapFocusOptions, ITrapFocusHandle>;
+export type ITrapFocusAction = IAction<Document | Element, ITrapFocusOptions, ITrapFocusHandle>;
 
 /**
  * Represents the Svelte Action handle returned by [[trap_focus]]

--- a/src/lib/components/disclosure/accordion/AccordionLabel.svelte
+++ b/src/lib/components/disclosure/accordion/AccordionLabel.svelte
@@ -5,6 +5,7 @@
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
 
+    import {behavior_button} from "../../../actions/behavior_button";
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
@@ -126,11 +127,13 @@
 
 <label
     bind:this={element}
+    role="button"
     {...map_global_attributes($$props)}
     {...map_data_attributes({palette})}
     {...map_aria_attributes({disabled, pressed: active})}
     for={$_accordion_id}
     tabindex={_tabindex}
+    use:behavior_button={{enabled: true}}
     use:forward_actions={{actions}}
     on:click
     on:contextmenu

--- a/src/lib/components/disclosure/tab/TabLabel.svelte
+++ b/src/lib/components/disclosure/tab/TabLabel.svelte
@@ -5,6 +5,7 @@
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
 
+    import {behavior_button} from "../../../actions/behavior_button";
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
@@ -97,10 +98,12 @@
 <label
     bind:this={element}
     {...map_global_attributes($$props)}
+    role="button"
     {...map_data_attributes({palette})}
     {...map_aria_attributes({disabled, pressed: active})}
     for={$_tab_id}
     tabindex={_tabindex}
+    use:behavior_button={{enabled: true}}
     use:forward_actions={{actions}}
     on:click
     on:contextmenu

--- a/src/lib/components/interactables/button/Button.svelte
+++ b/src/lib/components/interactables/button/Button.svelte
@@ -6,6 +6,7 @@
     import type {IMarginProperties} from "../../../types/spacings";
     import type {PROPERTY_VARIATION_BUTTON} from "../../../types/variations";
 
+    import {behavior_button} from "../../../actions/behavior_button";
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
@@ -116,6 +117,7 @@
         tabindex={_tabindex}
         {...map_data_attributes({palette, size, variation})}
         {...map_aria_attributes({disabled, pressed: active})}
+        use:behavior_button={{enabled: true}}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu

--- a/src/lib/components/navigation/menu/MenuLabel.svelte
+++ b/src/lib/components/navigation/menu/MenuLabel.svelte
@@ -2,14 +2,16 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
+
+    import {behavior_button} from "../../../actions/behavior_button";
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {
         map_aria_attributes,
         map_data_attributes,
         map_global_attributes,
     } from "../../../util/attributes";
-
-    import type {IForwardedActions} from "../../../actions/forward_actions";
-    import {forward_actions} from "../../../actions/forward_actions";
 
     import FormGroup from "../../interactables/form/FormGroup.svelte";
 
@@ -56,10 +58,12 @@
     <FormGroup logic_id={_for}>
         <label
             {...map_global_attributes($$props)}
+            role="button"
             {...map_data_attributes({palette})}
             {...map_aria_attributes({disabled, pressed: active})}
             for={_for}
             tabindex={_tabindex}
+            use:behavior_button={{enabled: true}}
             use:forward_actions={{actions}}
             on:click
             on:contextmenu

--- a/src/lib/components/overlays/clickable/ClickableLabel.svelte
+++ b/src/lib/components/overlays/clickable/ClickableLabel.svelte
@@ -2,6 +2,7 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
 
+    import {behavior_button} from "../../../actions/behavior_button";
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
@@ -47,10 +48,12 @@
 <label
     bind:this={element}
     {...map_global_attributes($$props)}
+    role="button"
     class="clickable-item {_class}"
     {...map_aria_attributes({disabled, pressed: active})}
     for={_for}
     tabindex={_tabindex}
+    use:behavior_button={{enabled: true}}
     use:forward_actions={{actions}}
     on:click
     on:contextmenu

--- a/src/lib/components/overlays/offscreen/Offscreen.svelte
+++ b/src/lib/components/overlays/offscreen/Offscreen.svelte
@@ -14,7 +14,6 @@
 
     import {auto_focus} from "../../../actions/auto_focus";
     import {click_inside} from "../../../actions/click_inside";
-    import {click_outside} from "../../../actions/click_outside";
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
     import {trap_focus} from "../../../actions/trap_focus";
@@ -142,10 +141,6 @@
     use:click_inside={{
         ignore: `label[for="${$_offscreen_id}"]`,
         on_click_inside: on_once,
-    }}
-    use:click_outside={{
-        ignore: `label[for="${$_offscreen_id}"]`,
-        on_click_outside: on_dismiss,
     }}
     use:trap_focus={{enabled: $_offscreen_state, first: focus_first, last: focus_last}}
     use:auto_focus={{enabled: $_offscreen_state, target: focus_target}}

--- a/src/lib/components/overlays/offscreen/offscreen.css
+++ b/src/lib/components/overlays/offscreen/offscreen.css
@@ -1,5 +1,5 @@
 .offscreen {
-    @apply absolute contents h-full pointer-events-none w-full z-2;
+    @apply contents fixed h-full pointer-events-none w-full z-2;
 
     flex-direction: var(--placement-orientation, row);
 

--- a/src/lib/components/overlays/overlay/Overlay.svelte
+++ b/src/lib/components/overlays/overlay/Overlay.svelte
@@ -15,7 +15,6 @@
 
     import {auto_focus} from "../../../actions/auto_focus";
     import {click_inside} from "../../../actions/click_inside";
-    import {click_outside} from "../../../actions/click_outside";
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
     import {trap_focus} from "../../../actions/trap_focus";
@@ -155,10 +154,6 @@
     use:click_inside={{
         ignore: `label[for="${$_overlay_id}"]`,
         on_click_inside: on_once,
-    }}
-    use:click_outside={{
-        ignore: `label[for="${$_overlay_id}"]`,
-        on_click_outside: on_dismiss,
     }}
     use:trap_focus={{enabled: $_overlay_state, first: focus_first, last: focus_last}}
     use:auto_focus={{enabled: $_overlay_state, target: focus_target}}

--- a/src/lib/components/overlays/overlay/overlay.css
+++ b/src/lib/components/overlays/overlay/overlay.css
@@ -10,7 +10,7 @@
     --spacing-x: 0;
     --spacing-y: 0;
 
-    @apply absolute flex flex-col gap-x-[var(--spacing-x)] gap-y-[var(--spacing-y)] h-full
+    @apply fixed flex flex-col gap-x-[var(--spacing-x)] gap-y-[var(--spacing-y)] h-full
     left-0 pointer-events-none top-0 w-full z-2;
 
     align-items: var(--orientation-align);

--- a/src/lib/components/utilities/contextbackdrop/ContextBackdrop.svelte
+++ b/src/lib/components/utilities/contextbackdrop/ContextBackdrop.svelte
@@ -7,6 +7,8 @@
     import type {IHTML5Properties} from "../../../types/html5";
     import type {ISizeProperties} from "../../../types/sizes";
 
+    import {behavior_button} from "../../../actions/behavior_button";
+
     import {get_id_context} from "../../../stores/id";
     import {get_state_context} from "../../../stores/state";
     import {scrolllock} from "../../../stores/scrolllock";
@@ -56,8 +58,10 @@
     <label
         bind:this={element}
         {...map_global_attributes($$props)}
+        role="button"
         class="context-backdrop {_class}"
         for={_logic_id ? $_logic_id : ""}
+        use:behavior_button={{enabled: true}}
         on:click
     />
 {:else}

--- a/src/lib/components/utilities/contextbackdrop/contextbackdrop.css
+++ b/src/lib/components/utilities/contextbackdrop/contextbackdrop.css
@@ -1,5 +1,5 @@
 .context-backdrop {
-    @apply absolute block bg-default-200 bg-opacity-0 h-full invisible left-0 top-0 w-full z-1;
+    @apply block bg-default-200 bg-opacity-0 fixed h-full invisible left-0 top-0 w-full z-1;
 }
 
 label[for].context-backdrop {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -114,6 +114,7 @@ export * from "./components/widgets/yearpicker";
 export * from "./components/widgets/yearstepper";
 
 export * from "./actions/auto_focus";
+export * from "./actions/behavior_button";
 export * from "./actions/click_inside";
 export * from "./actions/click_outside";
 export * from "./actions/clipping";

--- a/src/lib/util/element.ts
+++ b/src/lib/util/element.ts
@@ -29,18 +29,18 @@ function get_scroll_top(
     return y - container_element.offsetTop;
 }
 
-export function can_focus(element: HTMLElement): boolean {
+export function can_focus(element: Element): boolean {
     return !is_hidden(element) && element.matches(FOCUSABLE_SELECTOR);
 }
 
-export function is_hidden(element: HTMLElement): boolean {
+export function is_hidden(element: Element): boolean {
     const style = window.getComputedStyle(element);
 
     return style.display === "none";
 }
 
-export function query_focusable_element<T extends HTMLElement>(
-    element: Document | HTMLElement,
+export function query_focusable_element<T extends Element>(
+    element: Document | Element,
     options: {last?: boolean} = {}
 ): T | null {
     // NOTE: Would be a lot faster to run `querySelector` instead of `querySelectorAll` and manual
@@ -50,9 +50,7 @@ export function query_focusable_element<T extends HTMLElement>(
     return children[options.last ? children.length - 1 : 0] ?? null;
 }
 
-export function query_focusable_elements<T extends HTMLElement>(
-    element: Document | HTMLElement
-): T[] {
+export function query_focusable_elements<T extends Element>(element: Document | Element): T[] {
     const children = element.querySelectorAll<T>(FOCUSABLE_SELECTOR);
 
     return Array.from<T>(children).filter((child) => !is_hidden(child));

--- a/src/lib/util/functional.ts
+++ b/src/lib/util/functional.ts
@@ -37,6 +37,16 @@ export function fill<T>(generator: (index: number) => T, length: number): T[] {
     return new Array(length).fill(null).map((_, index) => generator(index));
 }
 
+export function pick<T>(
+    map: Map<string, T>,
+    keys: string[] | IterableIterator<string> | Set<string>
+): Map<string, T> {
+    const lookup = new Set(keys);
+    const entries = Array.from(map.entries()).filter(([key, value], index) => lookup.has(key));
+
+    return new Map(entries);
+}
+
 export function throttle<F extends (...args: any[]) => void | Promise<void>>(
     func: F,
     duration: number = 0

--- a/src/lib/util/keybind.ts
+++ b/src/lib/util/keybind.ts
@@ -37,7 +37,7 @@ function make_shortcut_factory(
  * @returns
  */
 export const action_activate = make_shortcut_factory({
-    binds: ["enter", "space"],
+    binds: ["enter", " "],
 });
 
 /**

--- a/src/lib/util/keybind.ts
+++ b/src/lib/util/keybind.ts
@@ -31,6 +31,16 @@ function make_shortcut_factory(
 }
 
 /**
+ * Represents a keybind used for activating the currently focused element
+ * @param element
+ * @param options
+ * @returns
+ */
+export const action_activate = make_shortcut_factory({
+    binds: ["enter", "space"],
+});
+
+/**
  * Represents a keybind used for closing / exiting the currently active Component
  * @param element
  * @param options


### PR DESCRIPTION
# CHANGELOG


-   Updated button-like `<label>`-based Components to emulate button-like behavior, e.g. Enter key activates element.

- Fixed the following Actions / Action Features

    - `keybind(element: HTMLElement, options: IKeybindOptions): IKeybindHandle`

        -   `keybind(..., {on_bind: IKeybindCallback})` — Fixed inline defining of `on_bind` thrashing internal key state of the bind manager.

- Updated the following Components / Component Features

    - Overlays

        -   `Offscreen` / `Overlay`

            -   Changed from viewport units to relative percentage units to work with inner non-viewport situations.

        -   `ContextBackdrop`

            -   Changed from viewport units to relative percentage units to work with inner non-viewport situations.