### PR TITLE
[0.4.13] Last Minute Typography Typing Fixes

### DIFF
--- a/src/lib/components/typography/blockquote/BlockquoteCite.svelte
+++ b/src/lib/components/typography/blockquote/BlockquoteCite.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
-    import type {IMarginProperties} from "../../../types/spacings";
+    import type {ISizeProperties} from "../../../types/sizes";
+    import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
@@ -15,7 +16,9 @@
         element?: HTMLElement;
     } & IHTML5Properties &
         IGlobalProperties &
-        IMarginProperties;
+        IMarginProperties &
+        IPaddingProperties &
+        ISizeProperties;
 
     type $$Slots = {
         default: {};

--- a/src/lib/components/typography/code/Code.svelte
+++ b/src/lib/components/typography/code/Code.svelte
@@ -2,7 +2,8 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
-    import type {IMarginProperties} from "../../../types/spacings";
+    import type {ISizeProperties} from "../../../types/sizes";
+    import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
@@ -20,7 +21,9 @@
         palette?: PROPERTY_PALETTE;
     } & IHTML5Properties &
         IGlobalProperties &
-        IMarginProperties;
+        IMarginProperties &
+        IPaddingProperties &
+        ISizeProperties;
 
     type $$Slots = {
         default: {};

--- a/src/lib/components/typography/heading/Heading.svelte
+++ b/src/lib/components/typography/heading/Heading.svelte
@@ -2,7 +2,8 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
-    import type {IMarginProperties} from "../../../types/spacings";
+    import type {ISizeProperties} from "../../../types/sizes";
+    import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
     import type {
         PROPERTY_TEXT_ALIGNMENT,
         PROPERTY_TEXT_TRANSFORM,
@@ -29,7 +30,9 @@
         variation?: PROPERTY_TEXT_VARIATION;
     } & IHTML5Properties &
         IGlobalProperties &
-        IMarginProperties;
+        IMarginProperties &
+        IPaddingProperties &
+        ISizeProperties;
 
     type $$Slots = {
         default: {};

--- a/src/lib/components/typography/text/Text.svelte
+++ b/src/lib/components/typography/text/Text.svelte
@@ -2,8 +2,9 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
+    import type {ISizeProperties} from "../../../types/sizes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
-    import type {IMarginProperties} from "../../../types/spacings";
+    import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
     import type {
         PROPERTY_TEXT_ALIGNMENT,
         PROPERTY_TEXT_TRANSFORM,
@@ -49,7 +50,9 @@
         variation?: PROPERTY_TEXT_VARIATION;
     } & IHTML5Properties &
         IGlobalProperties &
-        IMarginProperties;
+        IMarginProperties &
+        IPaddingProperties &
+        ISizeProperties;
 
     type $$Slots = {
         default: {};


### PR DESCRIPTION
# CHANGELOG

- Fixed the following Components / Component Features

    - Typography

        - `*`

            - Fixed Components not having intrinsic sizing / padding global attribute typings.