### PR TITLE
[0.4.14] Add `<TextInput mask={boolean}>` / `<NumberInput>` Support / Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Added the following Components / Component Features
+
+    -   Interactables
+
+        -   `NumberInput` — Subset of `TextInput` that only accepts numbers into its text field.
+
+            -   `<NumberInput value={number}>` — Accepts / Returns `number` types instead of strings.
+
+        -   `TextInput`
+
+            -   `<TextInput mask={boolean}>` — When enabled, user input into the text field will drop alterations that are invalid.
+
+                -   `<TextInput on:mask={(event: CustomEvent<{value: string}>) => void}>` — Fires whenever `<TextInput mask={boolean}>` is `true`. Whenever `event.preventDefault` is called, the new `value` alteration will be dropped.
+                -   `<TextInput pattern={string | RegExp}>` — Is used whenever `<TextInput mask={boolean}>` is `true`, this property is used to mask user input. Dropping any new values that don't match the expression.
+
 ## v0.4.13 - 2021/12/13
 
 -   Updated button-like `<label>`-based Components to emulate button-like behavior, e.g. Enter key activates element.

--- a/src/lib/actions/mask_input.stories.svelte
+++ b/src/lib/actions/mask_input.stories.svelte
@@ -26,7 +26,7 @@
 
     const EXPRESSION_STRING = "[0-9a-fA-F]+";
 
-    function on_mask_input(event) {
+    function on_mask(event) {
         for (const character of event.detail.value) {
             if (!CHARACTERS_HEXADECIMAL.has(character.toLowerCase())) {
                 event.preventDefault();
@@ -51,5 +51,5 @@
 </Story>
 
 <Story name="Preview - Event">
-    <input type="text" use:mask_input={{enabled: true, on_mask_input}} />
+    <input type="text" use:mask_input={{enabled: true, on_mask}} />
 </Story>

--- a/src/lib/actions/mask_input.stories.svelte
+++ b/src/lib/actions/mask_input.stories.svelte
@@ -1,0 +1,55 @@
+<script>
+    import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
+
+    import {mask_input} from "./mask_input";
+
+    const CHARACTERS_HEXADECIMAL = new Set([
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+    ]);
+
+    const EXPRESSION_COMPILED = /^[0-9a-fA-F]+$/;
+
+    const EXPRESSION_STRING = "[0-9a-fA-F]+";
+
+    function on_mask_input(event) {
+        for (const character of event.detail.value) {
+            if (!CHARACTERS_HEXADECIMAL.has(character.toLowerCase())) {
+                event.preventDefault();
+                return;
+            }
+        }
+    }
+</script>
+
+<Meta title="Actions/mask_input" />
+
+<Template>
+    <slot />
+</Template>
+
+<Story name="Preview - String Expression">
+    <input type="text" use:mask_input={{enabled: true, pattern: EXPRESSION_STRING}} />
+</Story>
+
+<Story name="Preview - Compiled Expression">
+    <input type="text" use:mask_input={{enabled: true, pattern: EXPRESSION_COMPILED}} />
+</Story>
+
+<Story name="Preview - Event">
+    <input type="text" use:mask_input={{enabled: true, on_mask_input}} />
+</Story>

--- a/src/lib/actions/mask_input.ts
+++ b/src/lib/actions/mask_input.ts
@@ -100,11 +100,7 @@ export const mask_input: IMaskInputAction = (element, options) => {
             if (custom_event.defaultPrevented) mask_value(new_value);
         }
 
-        if (expression && new_value && !expression.test(new_value)) {
-            event.preventDefault();
-
-            mask_value(new_value);
-        }
+        if (expression && new_value && !expression.test(new_value)) mask_value(new_value);
 
         value = element.value;
     }
@@ -129,8 +125,6 @@ export const mask_input: IMaskInputAction = (element, options) => {
 
             expression = compile_pattern(pattern);
             value = element.value;
-
-            console.log("mask_input::update", {enabled, pattern});
 
             if (enabled) attach_events();
             else detach_events();

--- a/src/lib/actions/mask_input.ts
+++ b/src/lib/actions/mask_input.ts
@@ -70,13 +70,18 @@ export const mask_input: IMaskInputAction = (element, options) => {
     let value = element.value;
 
     function mask_value(new_value: string): void {
+        const length_difference = new_value.length - value.length;
         const selection_end = element.selectionEnd ?? 0;
         const selection_start = element.selectionStart ?? 0;
 
         element.value = value;
 
-        element.selectionEnd = selection_end - (new_value.length - value.length);
-        element.selectionStart = selection_start - (new_value.length - value.length);
+        const new_start = selection_start - length_difference;
+        const new_end = selection_end - length_difference;
+
+        if (new_end > -1 && new_start > -1) {
+            element.setSelectionRange(new_start, new_end);
+        }
     }
 
     function on_input(event: Event): void {

--- a/src/lib/actions/mask_input.ts
+++ b/src/lib/actions/mask_input.ts
@@ -1,0 +1,129 @@
+import type {IAction, IActionHandle} from "./actions";
+
+/**
+ * Represents the Svelte Action initializer signature for [[mask_input]]
+ */
+export type IMaskInputAction = IAction<
+    HTMLInputElement | HTMLTextAreaElement,
+    IMaskInputOptions,
+    IMaskInputHandle
+>;
+
+/**
+ * Represents the Svelte Action handle returned by [[mask_input]]
+ */
+export type IMaskInputHandle = Required<IActionHandle<IMaskInputOptions>>;
+
+/**
+ * Represents the typing for the [[IMaskInputOptions.on_mask_input]] callback
+ */
+export type IMaskInputCallback = (event: IMaskInputEvent) => void;
+
+/**
+ * Represents the typing used for the event passed to [[IMaskInputCallback]]
+ */
+export type IMaskInputEvent = CustomEvent<{value: string}>;
+
+/**
+ * Represents the options passable to the [[mask_input]] Svelte Action
+ */
+export interface IMaskInputOptions {
+    /**
+     *
+     */
+    enabled?: boolean;
+
+    /**
+     *
+     */
+    pattern?: string | RegExp;
+
+    /**
+     *
+     */
+    on_mask_input?: IMaskInputCallback;
+}
+
+/**
+ *
+ * @returns
+ */
+function compile_pattern(pattern?: string | RegExp): RegExp | null {
+    // NOTE: `<input pattern={string}>` uses the `u` flag to properly
+    // handle Unicode, so we should match the behavior here. Ditto
+    // w/ implicit line start and end anchoring
+    if (typeof pattern === "string") return new RegExp(`^${pattern}$`, "u");
+    return pattern ?? null;
+}
+
+/**
+ *
+ *
+ * @param element
+ * @param options
+ * @returns
+ */
+export const mask_input: IMaskInputAction = (element, options) => {
+    let {enabled, pattern, on_mask_input} = options;
+
+    let expression = compile_pattern(pattern);
+    let value = element.value;
+
+    function mask_value(new_value: string): void {
+        const selection_end = element.selectionEnd ?? 0;
+        const selection_start = element.selectionStart ?? 0;
+
+        element.value = value;
+
+        element.selectionEnd = selection_end - (new_value.length - value.length);
+        element.selectionStart = selection_start - (new_value.length - value.length);
+    }
+
+    function on_input(event: Event): void {
+        const new_value = element.value;
+
+        if (on_mask_input) {
+            const detail: IMaskInputEvent["detail"] = {value: new_value};
+            const custom_event: IMaskInputEvent = new CustomEvent("maskinput", {
+                cancelable: true,
+                detail,
+            });
+
+            on_mask_input(custom_event);
+
+            if (custom_event.cancelBubble) custom_event.stopPropagation();
+            if (custom_event.defaultPrevented) mask_value(new_value);
+        }
+
+        if (expression && new_value && !expression.test(new_value)) {
+            mask_value(new_value);
+        }
+
+        value = element.value;
+    }
+
+    function detach_events() {
+        element.removeEventListener("input", on_input);
+    }
+
+    function attach_events() {
+        element.addEventListener("input", on_input);
+    }
+
+    if (enabled) attach_events();
+
+    return {
+        destroy() {
+            if (enabled) detach_events();
+        },
+
+        update(options: IMaskInputOptions) {
+            ({enabled, pattern, on_mask_input} = options);
+
+            expression = compile_pattern(pattern);
+
+            if (enabled) attach_events();
+            else detach_events();
+        },
+    };
+};

--- a/src/lib/components/interactables/numberinput/NumberInput.stories.svelte
+++ b/src/lib/components/interactables/numberinput/NumberInput.stories.svelte
@@ -1,0 +1,94 @@
+<script>
+    import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
+
+    import Stack from "../../layouts/stack/Stack.svelte";
+
+    import NumberInput from "./NumberInput.svelte";
+
+    const PALETTES = [
+        ["neutral", true],
+        ["accent", false],
+        ["auto", false],
+        ["inverse", false],
+        ["dark", false],
+        ["light", false],
+        ["alert", false],
+        ["affirmative", false],
+        ["negative", false],
+    ];
+
+    const SIZES = [
+        ["default", true],
+        ["tiny", false],
+        ["small", false],
+        ["medium", false],
+        ["large", false],
+        ["huge", false],
+    ];
+</script>
+
+<Meta title="Interactables/NumberInput" />
+
+<Template>
+    <slot />
+</Template>
+
+<Story name="Preview">
+    <NumberInput value={42} />
+</Story>
+
+<Story name="Palette">
+    <Stack orientation="horizontal" spacing="medium" variation="wrap">
+        {#each PALETTES as [palette, is_default]}
+            <NumberInput
+                placeholder={`${palette.toUpperCase()}${
+                    is_default ? " / DEFAULT" : ""
+                } NumberInput`}
+                characters="20"
+                {palette}
+            />
+        {/each}
+    </Stack>
+</Story>
+
+<Story name="Block">
+    <Stack orientation="horizontal" spacing="medium" variation="wrap">
+        {#each PALETTES as [palette, is_default]}
+            <NumberInput
+                variation="block"
+                placeholder={`${palette.toUpperCase()}${
+                    is_default ? " / DEFAULT" : ""
+                } NumberInput`}
+                characters="20"
+                {palette}
+            />
+        {/each}
+    </Stack>
+</Story>
+
+<Story name="Flush">
+    <Stack orientation="horizontal" spacing="medium" variation="wrap">
+        {#each PALETTES as [palette, is_default]}
+            <NumberInput
+                variation="flush"
+                placeholder={`${palette.toUpperCase()}${
+                    is_default ? " / DEFAULT" : ""
+                } NumberInput`}
+                characters="20"
+                {palette}
+            />
+        {/each}
+    </Stack>
+</Story>
+
+<Story name="Size">
+    <Stack orientation="horizontal" alignment_y="top" spacing="medium" variation="wrap">
+        {#each SIZES as [size, is_default]}
+            <NumberInput
+                placeholder={`${size.toUpperCase()}${is_default ? " / DEFAULT" : ""} NumberInput`}
+                characters="20"
+                {size}
+            />
+        {/each}
+    </Stack>
+</Story>

--- a/src/lib/components/interactables/numberinput/NumberInput.svelte
+++ b/src/lib/components/interactables/numberinput/NumberInput.svelte
@@ -1,0 +1,126 @@
+<script context="module" lang="ts">
+    const EXPRESSION_NUMBER = "-?\\d+\\.?\\d*";
+</script>
+
+<script lang="ts">
+    import type {IGlobalProperties} from "../../../types/global";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
+    import type {PROPERTY_PALETTE} from "../../../types/palettes";
+    import type {PROPERTY_SIZING} from "../../../types/sizings";
+    import type {IMarginProperties} from "../../../types/spacings";
+    import type {PROPERTY_TEXT_ALIGNMENT} from "../../../types/typography";
+    import type {PROPERTY_VARIATION_INPUT} from "../../../types/variations";
+
+    import {mask_input} from "../../../actions/mask_input";
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
+    import {
+        map_attributes,
+        map_data_attributes,
+        map_global_attributes,
+    } from "../../../util/attributes";
+
+    import {CONTEXT_FORM_ID, CONTEXT_FORM_NAME} from "../form/FormGroup.svelte";
+
+    type $$Events = {
+        change: InputEvent;
+
+        input: InputEvent;
+    } & IHTML5Events;
+
+    type $$Props = {
+        actions?: IForwardedActions;
+        element?: HTMLInputElement;
+
+        disabled?: boolean;
+        required?: boolean;
+        readonly?: boolean;
+
+        placeholder?: string;
+        value?: number;
+
+        characters?: number;
+
+        align?: PROPERTY_TEXT_ALIGNMENT;
+        palette?: PROPERTY_PALETTE;
+        size?: PROPERTY_SIZING;
+        variation?: PROPERTY_VARIATION_INPUT;
+    } & IHTML5Properties &
+        IGlobalProperties &
+        IMarginProperties;
+
+    export let actions: $$Props["actions"] = undefined;
+    export let element: $$Props["element"] = undefined;
+
+    export let id: $$Props["id"] = "";
+    export let name: $$Props["name"] = "";
+
+    export let disabled: $$Props["disabled"] = undefined;
+    export let required: $$Props["required"] = undefined;
+    export let readonly: $$Props["readonly"] = undefined;
+
+    export let placeholder: $$Props["placeholder"] = "";
+    export let value: $$Props["value"] = undefined;
+
+    export let characters: $$Props["characters"] = undefined;
+
+    export let align: $$Props["align"] = undefined;
+    export let palette: $$Props["palette"] = undefined;
+    export let size: $$Props["size"] = undefined;
+    export let variation: $$Props["variation"] = undefined;
+
+    let _value: string | undefined = value?.toString();
+
+    const _form_id = CONTEXT_FORM_ID.get();
+    const _form_name = CONTEXT_FORM_NAME.get();
+
+    function on_input(event: Event): void {
+        if (!element) return;
+
+        const new_value = element.value;
+        value = new_value ? parseFloat(new_value) : undefined;
+    }
+
+    $: _id = _form_id ? $_form_id : id;
+    $: _name = _form_name ? $_form_name : name;
+    $: _value = value?.toString();
+</script>
+
+<input
+    bind:this={element}
+    {...map_global_attributes($$props)}
+    type="text"
+    {...map_data_attributes({align, palette, size, variation})}
+    {...map_attributes({
+        disabled,
+        id: _id,
+        name: _name,
+        pattern: EXPRESSION_NUMBER,
+        placeholder,
+        readonly,
+        required,
+        size: characters,
+        value,
+    })}
+    use:mask_input={{enabled: true, pattern: EXPRESSION_NUMBER}}
+    on:input={on_input}
+    bind:value={_value}
+    use:forward_actions={{actions}}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+    on:change
+    on:input
+/>

--- a/src/lib/components/interactables/numberinput/index.ts
+++ b/src/lib/components/interactables/numberinput/index.ts
@@ -1,0 +1,1 @@
+export {default as NumberInput} from "./NumberInput.svelte";

--- a/src/lib/components/interactables/textinput/TextInput.stories.svelte
+++ b/src/lib/components/interactables/textinput/TextInput.stories.svelte
@@ -48,7 +48,6 @@
     function on_mask(event) {
         for (const character of event.detail.value) {
             if (!CHARACTERS_HEXADECIMAL.has(character.toLowerCase())) {
-                console.log("TextInput::on_mask", event);
                 event.preventDefault();
                 return;
             }

--- a/src/lib/components/interactables/textinput/TextInput.stories.svelte
+++ b/src/lib/components/interactables/textinput/TextInput.stories.svelte
@@ -5,6 +5,25 @@
 
     import TextInput from "./TextInput.svelte";
 
+    const CHARACTERS_HEXADECIMAL = new Set([
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+    ]);
+
     const PALETTES = [
         ["neutral", true],
         ["accent", false],
@@ -25,6 +44,16 @@
         ["large", false],
         ["huge", false],
     ];
+
+    function on_mask(event) {
+        for (const character of event.detail.value) {
+            if (!CHARACTERS_HEXADECIMAL.has(character.toLowerCase())) {
+                console.log("TextInput::on_mask", event);
+                event.preventDefault();
+                return;
+            }
+        }
+    }
 </script>
 
 <Meta title="Interactables/TextInput" />
@@ -35,6 +64,14 @@
 
 <Story name="Default">
     <TextInput value="This is a TextInput" />
+</Story>
+
+<Story name="Mask - Pattern">
+    <TextInput pattern="[0-9a-fA-F]+" mask />
+</Story>
+
+<Story name="Mask - Event">
+    <TextInput mask on:mask={on_mask} />
 </Story>
 
 <Story name="Palette">

--- a/src/lib/components/interactables/textinput/TextInput.svelte
+++ b/src/lib/components/interactables/textinput/TextInput.svelte
@@ -45,7 +45,7 @@
         element?: HTMLInputElement | HTMLTextAreaElement;
 
         is?: "input" | "textarea";
-        type?: "email" | "number" | "password" | "text" | "search" | "url";
+        type?: "email" | "password" | "text" | "search" | "url";
 
         disabled?: boolean;
         required?: boolean;
@@ -167,47 +167,6 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         type="email"
-        {...map_data_attributes({align, palette, size, transform, variation})}
-        {...map_attributes({
-            disabled,
-            id: _id,
-            maxlength: max_length,
-            minlength: min_length,
-            name: _name,
-            pattern: _pattern,
-            placeholder,
-            readonly,
-            required,
-            size: characters,
-            value,
-        })}
-        use:mask_input={{enabled: mask, on_mask, pattern}}
-        bind:value
-        use:forward_actions={{actions}}
-        on:click
-        on:contextmenu
-        on:dblclick
-        on:focusin
-        on:focusout
-        on:keydown
-        on:keyup
-        on:pointercancel
-        on:pointerdown
-        on:pointerenter
-        on:pointerleave
-        on:pointermove
-        on:pointerout
-        on:pointerup
-        on:blur
-        on:change
-        on:focus
-        on:input
-    />
-{:else if type === "number"}
-    <input
-        bind:this={element}
-        {...map_global_attributes($$props)}
-        type="number"
         {...map_data_attributes({align, palette, size, transform, variation})}
         {...map_attributes({
             disabled,

--- a/src/lib/components/interactables/textinput/TextInput.svelte
+++ b/src/lib/components/interactables/textinput/TextInput.svelte
@@ -8,6 +8,8 @@
     import type {PROPERTY_TEXT_ALIGNMENT, PROPERTY_TEXT_TRANSFORM} from "../../../types/typography";
     import type {PROPERTY_VARIATION_INPUT} from "../../../types/variations";
 
+    import type {IMaskInputEvent} from "../../../actions/mask_input";
+    import {mask_input} from "../../../actions/mask_input";
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
@@ -16,6 +18,7 @@
         map_data_attributes,
         map_global_attributes,
     } from "../../../util/attributes";
+    import {create_event_forwarder} from "../../../util/svelte";
 
     import {CONTEXT_FORM_ID, CONTEXT_FORM_NAME} from "../form/FormGroup.svelte";
 
@@ -24,12 +27,17 @@
          * @deprecated Use `on:focusout` instead.
          */
         blur: FocusEvent;
+
         change: InputEvent;
+
         /**
          * @deprecated Use `on:focusin` instead.
          */
         focus: FocusEvent;
+
         input: InputEvent;
+
+        mask: IMaskInputEvent;
     } & IHTML5Events;
 
     type $$Props = {
@@ -37,7 +45,7 @@
         element?: HTMLInputElement | HTMLTextAreaElement;
 
         is?: "input" | "textarea";
-        type?: "email" | "password" | "text" | "search" | "url";
+        type?: "email" | "number" | "password" | "text" | "search" | "url";
 
         disabled?: boolean;
         required?: boolean;
@@ -46,6 +54,7 @@
         placeholder?: string;
         value?: string;
 
+        mask?: boolean;
         max_length?: number | undefined;
         min_length?: number | undefined;
         pattern?: RegExp | string;
@@ -65,6 +74,8 @@
         IGlobalProperties &
         IMarginProperties;
 
+    const forward = create_event_forwarder();
+
     export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
@@ -81,6 +92,7 @@
     export let placeholder: $$Props["placeholder"] = "";
     export let value: $$Props["value"] = "";
 
+    export let mask: $$Props["mask"] = undefined;
     export let max_length: $$Props["max_length"] = undefined;
     export let min_length: $$Props["min_length"] = undefined;
     export let pattern: $$Props["pattern"] = "";
@@ -99,6 +111,10 @@
 
     const _form_id = CONTEXT_FORM_ID.get();
     const _form_name = CONTEXT_FORM_NAME.get();
+
+    function on_mask(event: IMaskInputEvent): void {
+        forward("mask", event);
+    }
 
     $: _id = _form_id ? $_form_id : id;
     $: _name = _form_name ? $_form_name : name;
@@ -124,6 +140,7 @@
             rows: lines,
             spellcheck: spell_check === undefined ? undefined : spell_check.toString(),
         })}
+        use:mask_input={{enabled: mask, on_mask, pattern}}
         bind:value
         use:forward_actions={{actions}}
         on:click
@@ -164,6 +181,48 @@
             size: characters,
             value,
         })}
+        use:mask_input={{enabled: mask, on_mask, pattern}}
+        bind:value
+        use:forward_actions={{actions}}
+        on:click
+        on:contextmenu
+        on:dblclick
+        on:focusin
+        on:focusout
+        on:keydown
+        on:keyup
+        on:pointercancel
+        on:pointerdown
+        on:pointerenter
+        on:pointerleave
+        on:pointermove
+        on:pointerout
+        on:pointerup
+        on:blur
+        on:change
+        on:focus
+        on:input
+    />
+{:else if type === "number"}
+    <input
+        bind:this={element}
+        {...map_global_attributes($$props)}
+        type="number"
+        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_attributes({
+            disabled,
+            id: _id,
+            maxlength: max_length,
+            minlength: min_length,
+            name: _name,
+            pattern: _pattern,
+            placeholder,
+            readonly,
+            required,
+            size: characters,
+            value,
+        })}
+        use:mask_input={{enabled: mask, on_mask, pattern}}
         bind:value
         use:forward_actions={{actions}}
         on:click
@@ -204,6 +263,7 @@
             size: characters,
             value,
         })}
+        use:mask_input={{enabled: mask, on_mask, pattern}}
         bind:value
         use:forward_actions={{actions}}
         on:click
@@ -244,6 +304,7 @@
             size: characters,
             value,
         })}
+        use:mask_input={{enabled: mask, on_mask, pattern}}
         bind:value
         use:forward_actions={{actions}}
         on:click
@@ -284,6 +345,7 @@
             size: characters,
             value,
         })}
+        use:mask_input={{enabled: mask, on_mask, pattern}}
         bind:value
         use:forward_actions={{actions}}
         on:click
@@ -324,6 +386,7 @@
             size: characters,
             value,
         })}
+        use:mask_input={{enabled: mask, on_mask, pattern}}
         bind:value
         use:forward_actions={{actions}}
         on:click

--- a/src/lib/components/interactables/textinput/textinput.css
+++ b/src/lib/components/interactables/textinput/textinput.css
@@ -1,4 +1,5 @@
 [type="email"],
+[type="number"],
 [type="password"],
 [type="text"],
 [type="search"],

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -49,6 +49,7 @@ export * from "./components/interactables/filedropinput";
 import * as Form from "./components/interactables/form";
 export {Form};
 export * from "./components/interactables/hiddeninput";
+export * from "./components/interactables/numberinput";
 export * from "./components/interactables/radio";
 export * from "./components/interactables/switch";
 export * from "./components/interactables/textinput";

--- a/src/lib/util/svelte.ts
+++ b/src/lib/util/svelte.ts
@@ -1,0 +1,20 @@
+import {get_current_component} from "svelte/internal";
+
+export function create_event_forwarder<EventMap extends {} = any>(): <
+    EventKey extends Extract<keyof EventMap, string>
+>(
+    type: EventKey,
+    event: Event
+) => void {
+    // SOURCE: https://github.com/sveltejs/svelte/blob/7521bd55b5e0f5f8203745f6a6d9a16fe775f596/src/runtime/internal/lifecycle.ts#L30-L47
+    const component = get_current_component();
+
+    return (type, event) => {
+        const callbacks: Function[] | undefined = component.$$.callbacks[type];
+        if (callbacks) {
+            callbacks.slice().forEach((fn) => {
+                fn.call(component, event);
+            });
+        }
+    };
+}


### PR DESCRIPTION
# CHANGELOG

-   Added the following Components / Component Features

    -   Interactables

        -   `NumberInput` — Subset of `TextInput` that only accepts numbers into its text field.

            -   `<NumberInput value={number}>` — Accepts / Returns `number` types instead of strings.

        -   `TextInput`

            -   `<TextInput mask={boolean}>` — When enabled, user input into the text field will drop alterations that are invalid.

                -   `<TextInput on:mask={(event: CustomEvent<{value: string}>) => void}>` — Fires whenever `<TextInput mask={boolean}>` is `true`. Whenever `event.preventDefault` is called, the new `value` alteration will be dropped.
                -   `<TextInput pattern={string | RegExp}>` — Is used whenever `<TextInput mask={boolean}>` is `true`, this property is used to mask user input. Dropping any new values that don't match the expression.