### PR TITLE
[0.5.0] Remove Deprecated Features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,20 @@
 
         -   `Badge` / `Dot`
 
-            -   `<Badge/Dot position>` — Removed previously deprecated feature in favor of `Position` Component.
+            -   **(BREAKING)** `<Badge/Dot position>` — Removed previously deprecated feature in favor of `Position` Component.
 
     -   Interactables
 
         -   `Check` / `Radio` / `Switch` / `TextInput`
 
-            -   `<Check/Radio/Switch/TextInput on:blur on:focus>` — Removed previously deprecated feature in favor of `<* on:focusin on:focusout>` events.
+            -   **(BREAKING)** `<Check/Radio/Switch/TextInput on:blur on:focus>` — Removed previously deprecated feature in favor of `<* on:focusin on:focusout>` events.
 
     -   Layouts
 
         -   `Spacer`
 
-            -   `<Spacer orientation>` — Removed previously deprecated feature in favor of `<Spacer spacing_x spacing_y>` properties.
-            -   `<Spacer variation>` — Removed previously deprecated feature in favor of `<Spacer is="div/span">` property.
+            -   **(BREAKING)** `<Spacer orientation>` — Removed previously deprecated feature in favor of `<Spacer spacing_x spacing_y>` properties.
+            -   **(BREAKING)** `<Spacer variation>` — Removed previously deprecated feature in favor of `<Spacer is="div/span">` property.
 
 ## v0.4.13 - 2021/12/13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Removed Components / Component Features
+
+    -   Display / Feedback
+
+        -   `Badge` / `Dot`
+
+            -   `<Badge/Dot position>` — Removed previously deprecated feature in favor of `Position` Component.
+
+    -   Interactables
+
+        -   `Check` / `Radio` / `Switch` / `TextInput`
+
+            -   `<Check/Radio/Switch/TextInput on:blur on:focus>` — Removed previously deprecated feature in favor of `<* on:focusin on:focusout>` events.
+
+    -   Layouts
+
+        -   `Spacer`
+
+            -   `<Spacer orientation>` — Removed previously deprecated feature in favor of `<Spacer spacing_x spacing_y>` properties.
+            -   `<Spacer variation>` — Removed previously deprecated feature in favor of `<Spacer is="div/span">` property.
+
 ## v0.4.13 - 2021/12/13
 
 -   Updated button-like `<label>`-based Components to emulate button-like behavior, e.g. Enter key activates element.

--- a/src/framework/index.css
+++ b/src/framework/index.css
@@ -120,7 +120,6 @@
 @import url("./orientations.css");
 @import url("./palettes.css");
 @import url("./placements.css");
-@import url("./positions.css");
 @import url("./resizable.css");
 @import url("./shape.css");
 @import url("./sizes.css");

--- a/src/framework/positions.css
+++ b/src/framework/positions.css
@@ -1,7 +1,0 @@
-[data-position="floated"] {
-    @apply absolute right-0 top-0 transform translate-x-1/2 -translate-y-1/2;
-}
-
-[data-position="raised"] {
-    @apply transform -translate-y-1/2;
-}

--- a/src/lib/components/display/badge/Badge.svelte
+++ b/src/lib/components/display/badge/Badge.svelte
@@ -18,8 +18,6 @@
         element?: HTMLSpanElement;
 
         palette?: PROPERTY_PALETTE;
-        /** @deprecated Use `Position` Component instead. */
-        position?: PROPERTY_POSITION;
         shape?: PROPERTY_SHAPE;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -36,8 +34,6 @@
     export {_class as class};
 
     export let palette: $$Props["palette"] = undefined;
-    /** @deprecated Use `Position` Component instead. */
-    export let position: $$Props["position"] = undefined;
     export let shape: $$Props["shape"] = undefined;
 </script>
 
@@ -45,7 +41,7 @@
     bind:this={element}
     {...map_global_attributes($$props)}
     class="badge {_class}"
-    {...map_data_attributes({palette, position, shape})}
+    {...map_data_attributes({palette, shape})}
     use:forward_actions={{actions}}
     on:click
     on:contextmenu

--- a/src/lib/components/display/badge/badge.css
+++ b/src/lib/components/display/badge/badge.css
@@ -30,8 +30,4 @@
 
     transition: background-color var(--animation-visual-duration) var(--animation-visual-function),
         color var(--animation-visual-duration) var(--animation-visual-function);
-
-    &[data-position] {
-        @apply pointer-events-none rounded-4xl select-none;
-    }
 }

--- a/src/lib/components/feedback/dot/Dot.svelte
+++ b/src/lib/components/feedback/dot/Dot.svelte
@@ -19,8 +19,6 @@
 
         animation?: PROPERTY_ANIMATION_FEEDBACK;
         palette?: PROPERTY_PALETTE;
-        /** @deprecated Use `Position` Component instead. */
-        position?: PROPERTY_POSITION;
     } & IHTML5Properties &
         IGlobalProperties &
         IMarginProperties;
@@ -33,15 +31,13 @@
 
     export let animation: $$Props["animation"] = undefined;
     export let palette: $$Props["palette"] = undefined;
-    /** @deprecated Use `Position` Component instead. */
-    export let position: $$Props["position"] = undefined;
 </script>
 
 <span
     bind:this={element}
     {...map_global_attributes($$props)}
     class="dot {_class}"
-    {...map_data_attributes({animation, palette, position})}
+    {...map_data_attributes({animation, palette})}
     use:forward_actions={{actions}}
     on:click
     on:contextmenu

--- a/src/lib/components/interactables/check/Check.svelte
+++ b/src/lib/components/interactables/check/Check.svelte
@@ -24,15 +24,7 @@
     } from "../form/FormGroup.svelte";
 
     type $$Events = {
-        /**
-         * @deprecated Use `on:focusout` instead.
-         */
-        blur: FocusEvent;
         change: InputEvent;
-        /**
-         * @deprecated Use `on:focusin` instead.
-         */
-        focus: FocusEvent;
         input: InputEvent;
     } & IHTML5Events;
 
@@ -122,9 +114,7 @@
                 on:pointerout
                 on:pointerup
                 on:change={on_change}
-                on:blur
                 on:change
-                on:focus
                 on:input
             />
 
@@ -161,9 +151,7 @@
         on:pointerout
         on:pointerup
         on:change={on_change}
-        on:blur
         on:change
-        on:focus
         on:input
     />
 {/if}

--- a/src/lib/components/interactables/radio/Radio.svelte
+++ b/src/lib/components/interactables/radio/Radio.svelte
@@ -24,15 +24,7 @@
     } from "../form/FormGroup.svelte";
 
     type $$Events = {
-        /**
-         * @deprecated Use `on:focusout` instead.
-         */
-        blur: FocusEvent;
         change: InputEvent;
-        /**
-         * @deprecated Use `on:focusin` instead.
-         */
-        focus: FocusEvent;
         input: InputEvent;
     } & IHTML5Events;
 
@@ -122,9 +114,7 @@
                 on:pointerout
                 on:pointerup
                 on:change={on_change}
-                on:blur
                 on:change
-                on:focus
                 on:input
             />
 
@@ -161,9 +151,7 @@
         on:pointerout
         on:pointerup
         on:change={on_change}
-        on:blur
         on:change
-        on:focus
         on:input
     />
 {/if}

--- a/src/lib/components/interactables/switch/Switch.svelte
+++ b/src/lib/components/interactables/switch/Switch.svelte
@@ -23,15 +23,7 @@
     } from "../form/FormGroup.svelte";
 
     type $$Events = {
-        /**
-         * @deprecated Use `on:focusout` instead.
-         */
-        blur: FocusEvent;
         change: InputEvent;
-        /**
-         * @deprecated Use `on:focusin` instead.
-         */
-        focus: FocusEvent;
         input: InputEvent;
     } & IHTML5Events;
 
@@ -120,9 +112,7 @@
                 on:pointerout
                 on:pointerup
                 on:change={on_change}
-                on:blur
                 on:change
-                on:focus
                 on:input
             />
 
@@ -160,9 +150,7 @@
         on:pointerout
         on:pointerup
         on:change={on_change}
-        on:blur
         on:change
-        on:focus
         on:input
     />
 {/if}

--- a/src/lib/components/interactables/textinput/TextInput.svelte
+++ b/src/lib/components/interactables/textinput/TextInput.svelte
@@ -20,15 +20,7 @@
     import {CONTEXT_FORM_ID, CONTEXT_FORM_NAME} from "../form/FormGroup.svelte";
 
     type $$Events = {
-        /**
-         * @deprecated Use `on:focusout` instead.
-         */
-        blur: FocusEvent;
         change: InputEvent;
-        /**
-         * @deprecated Use `on:focusin` instead.
-         */
-        focus: FocusEvent;
         input: InputEvent;
     } & IHTML5Events;
 
@@ -140,9 +132,7 @@
         on:pointermove
         on:pointerout
         on:pointerup
-        on:blur
         on:change
-        on:focus
         on:input
     />
 {:else if type === "email"}
@@ -180,9 +170,7 @@
         on:pointermove
         on:pointerout
         on:pointerup
-        on:blur
         on:change
-        on:focus
         on:input
     />
 {:else if type === "password"}
@@ -220,9 +208,7 @@
         on:pointermove
         on:pointerout
         on:pointerup
-        on:blur
         on:change
-        on:focus
         on:input
     />
 {:else if type === "search"}
@@ -260,9 +246,7 @@
         on:pointermove
         on:pointerout
         on:pointerup
-        on:blur
         on:change
-        on:focus
         on:input
     />
 {:else if type === "url"}
@@ -300,9 +284,7 @@
         on:pointermove
         on:pointerout
         on:pointerup
-        on:blur
         on:change
-        on:focus
         on:input
     />
 {:else}
@@ -340,9 +322,7 @@
         on:pointermove
         on:pointerout
         on:pointerup
-        on:blur
         on:change
-        on:focus
         on:input
     />
 {/if}

--- a/src/lib/components/layouts/spacer/Spacer.stories.svelte
+++ b/src/lib/components/layouts/spacer/Spacer.stories.svelte
@@ -49,7 +49,7 @@
 
             <Box palette="inverse" margin_top="small" padding="small">
                 LEFT
-                <Spacer variation="inline" spacing_x="huge" />
+                <Spacer is="span" spacing_x="huge" />
                 RIGHT
             </Box>
         </div>

--- a/src/lib/components/layouts/spacer/Spacer.svelte
+++ b/src/lib/components/layouts/spacer/Spacer.svelte
@@ -17,15 +17,6 @@
 
         is?: "div" | "span";
 
-        /**
-         * @deprecated Use `<Spacer spacing_x="...">` / `<Spacer spacing_y="...">` instead.
-         */
-        orientation?: PROPERTY_ORIENTATION_BREAKPOINT;
-        /**
-         * @deprecated Use `<Spacer is="span">` instead.
-         */
-        variation?: "inline";
-
         spacing?: PROPERTY_SPACING_BREAKPOINT;
         spacing_x?: PROPERTY_SPACING_BREAKPOINT;
         spacing_y?: PROPERTY_SPACING_BREAKPOINT;
@@ -44,21 +35,12 @@
     let _class: $$Props["class"] = "";
     export {_class as class};
 
-    /**
-     * @deprecated Use `<Spacer spacing_x="...">` / `<Spacer spacing_y="...">` instead.
-     */
-    export let orientation: $$Props["orientation"] = undefined;
-    /**
-     * @deprecated Use `<Spacer is="span">` instead.
-     */
-    export let variation: $$Props["variation"] = undefined;
-
     export let spacing: $$Props["spacing"] = undefined;
     export let spacing_x: $$Props["spacing_x"] = undefined;
     export let spacing_y: $$Props["spacing_y"] = undefined;
 </script>
 
-{#if is === "span" || variation === "inline"}
+{#if is === "span"}
     <span
         bind:this={element}
         {...map_global_attributes($$props)}

--- a/src/lib/components/widgets/daystepper/DayStepper.svelte
+++ b/src/lib/components/widgets/daystepper/DayStepper.svelte
@@ -106,7 +106,7 @@
             })}
         </WidgetHeader>
 
-        <Spacer variation="inline" />
+        <Spacer is="span" />
 
         <WidgetButton
             disabled={disabled || !is_day_in_range(_day, undefined, min)}

--- a/src/lib/components/widgets/monthstepper/MonthStepper.svelte
+++ b/src/lib/components/widgets/monthstepper/MonthStepper.svelte
@@ -109,7 +109,7 @@
             })}
         </WidgetHeader>
 
-        <Spacer variation="inline" />
+        <Spacer is="span" />
 
         <WidgetButton
             disabled={disabled || !is_month_in_range(_month, undefined, min)}

--- a/src/lib/components/widgets/yearstepper/YearStepper.svelte
+++ b/src/lib/components/widgets/yearstepper/YearStepper.svelte
@@ -98,7 +98,7 @@
             {_year.toLocaleString(locale ?? DEFAULT_LOCALE, {year: year ?? "numeric"})}
         </WidgetHeader>
 
-        <Spacer variation="inline" />
+        <Spacer is="span" />
 
         <WidgetButton
             disabled={disabled || !is_year_in_range(_year, undefined, min)}


### PR DESCRIPTION
# CHANGELOG

-   Removed Components / Component Features

    -   Display / Feedback

        -   `Badge` / `Dot`

            -   **(BREAKING)** `<Badge/Dot position>` — Removed previously deprecated feature in favor of `Position` Component.

    -   Interactables

        -   `Check` / `Radio` / `Switch` / `TextInput`

            -   **(BREAKING)** `<Check/Radio/Switch/TextInput on:blur on:focus>` — Removed previously deprecated feature in favor of `<* on:focusin on:focusout>` events.

    -   Layouts

        -   `Spacer`

            -   **(BREAKING)** `<Spacer orientation>` — Removed previously deprecated feature in favor of `<Spacer spacing_x spacing_y>` properties.
            -   **(BREAKING)** `<Spacer variation>` — Removed previously deprecated feature in favor of `<Spacer is="div/span">` property.