### PR TITLE
[0.5.1] Add `MediaQueryRender` Utility Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Added the following Components / Component Features
+
+    -   Utilities
+
+        -   `MediaQueryRender` — Renders inner content to DOM, only when the specified [Media Query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media) is active.
+
+            -   `<MediaQueryRender fallthrough={boolean}>` — When `true`, always renders content in SSR environments, e.g. SvelteKit
+            -   `<MediaQueryRender queries={string | string[]}>` — Sets the Media Query / Queries to validate against.
+            -   `<MediaQueryRender behavior="and/or">` — When you have use Media Queries, you can set `MediaQueryRender` to only render if both are `true`, or at least one is `true`.
+
 ## 0.5.0 - 2022/01/02
 
 -   Migrated the following Components: `Aside`, `Omni`.

--- a/src/lib/components/utilities/mediaqueryrender/MediaQueryRender.stories.svelte
+++ b/src/lib/components/utilities/mediaqueryrender/MediaQueryRender.stories.svelte
@@ -1,0 +1,57 @@
+<script>
+    import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
+
+    import Stack from "../../layouts/stack/Stack.svelte";
+    import Box from "../../surfaces/box/Box.svelte";
+    import Text from "../../typography/text/Text.svelte";
+
+    import MediaQueryRender from "./MediaQueryRender.svelte";
+</script>
+
+<Meta title="Utilities/MediaQueryRender" />
+
+<Template>
+    <slot />
+</Template>
+
+<Story name="Preview">
+    <Stack spacing="medium">
+        <MediaQueryRender queries="(min-width: 1280px) and (min-height: 720px)">
+            <Box palette="affirmative" padding="small">
+                This is only rendered when the Viewport is at least sHD resolution
+            </Box>
+        </MediaQueryRender>
+
+        <MediaQueryRender
+            queries={["(min-width: 1280px) and (min-height: 720px)", "(aspect-ratio: 16/9)"]}
+        >
+            <Box palette="affirmative" padding="small">
+                This is only rendered when the Viewport is at least sHD resolution <Text
+                    is="strong"
+                >
+                    OR
+                </Text> is 16:9.
+            </Box>
+        </MediaQueryRender>
+
+        <MediaQueryRender queries={["(orientation: portrait)", "(pointer: coarse)"]} behavior="and">
+            <Box palette="affirmative" padding="small">
+                This is only rendered when the Viewport is in a portrait orientation <Text
+                    is="strong"
+                >
+                    AND
+                </Text> the main interaction device is touch.
+            </Box>
+        </MediaQueryRender>
+
+        <MediaQueryRender queries={["(orientation: landscape)", "(pointer: fine)"]} behavior="and">
+            <Box palette="affirmative" padding="small">
+                This is only rendered when the Viewport is in a landscape orientation <Text
+                    is="strong"
+                >
+                    AND
+                </Text> the main interaction device is mouse / stylus.
+            </Box>
+        </MediaQueryRender>
+    </Stack>
+</Story>

--- a/src/lib/components/utilities/mediaqueryrender/MediaQueryRender.svelte
+++ b/src/lib/components/utilities/mediaqueryrender/MediaQueryRender.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+    import type {IMediaQueryStore} from "../../../stores/mediaquery";
+    import {MEDIA_QUERIES_BEHAVIORS, mediaquery, mediaqueries} from "../../../stores/mediaquery";
+
+    import {IS_SERVER} from "../../../util/environment";
+
+    type $$Props = {
+        fallthrough?: boolean;
+
+        behavior?: keyof typeof MEDIA_QUERIES_BEHAVIORS;
+        queries?: string | string[];
+    };
+
+    type $$Slots = {
+        default: {};
+    };
+
+    export let fallthrough: $$Props["fallthrough"] = undefined;
+
+    export let behavior: $$Props["behavior"] = MEDIA_QUERIES_BEHAVIORS.or;
+    export let queries: $$Props["queries"] = undefined;
+
+    let _query_store: IMediaQueryStore | null = null;
+    $: {
+        if (queries) {
+            if (queries instanceof Array) _query_store = mediaqueries(queries, {behavior});
+            else _query_store = mediaquery(queries);
+        } else _query_store = null;
+    }
+</script>
+
+{#if (_query_store && $_query_store) || (IS_SERVER && fallthrough)}
+    <slot />
+{/if}

--- a/src/lib/components/utilities/mediaqueryrender/index.ts
+++ b/src/lib/components/utilities/mediaqueryrender/index.ts
@@ -1,0 +1,1 @@
+export {default as MediaQueryRender} from "./MediaQueryRender.svelte";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -100,6 +100,7 @@ export * from "./components/typography/text";
 
 export * from "./components/utilities/browserrender";
 export * from "./components/utilities/intersectionrender";
+export * from "./components/utilities/mediaqueryrender";
 export * from "./components/utilities/portal";
 export * from "./components/utilities/serverrender";
 export * from "./components/utilities/transition";


### PR DESCRIPTION
# CHANGELOG

-   Added the following Components / Component Features

    -   Utilities

        -   `MediaQueryRender` — Renders inner content to DOM, only when the specified [Media Query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media) is active.

            -   `<MediaQueryRender fallthrough={boolean}>` — When `true`, always renders content in SSR environments, e.g. SvelteKit
            -   `<MediaQueryRender queries={string | string[]}>` — Sets the Media Query / Queries to validate against.
            -   `<MediaQueryRender behavior="and/or">` — When you have use Media Queries, you can set `MediaQueryRender` to only render if both are `true`, or at least one is `true`.
