### PR TITLE
[0.5.2] Fix `<Accordion/Tab.Container logic_state>` Two-Way Binding + Add Default Icons to `<Accordion.Label>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Fixed the following Components / Component Features
+
+    -   Disclosure
+
+        -   `Accordion` / `Tab`
+
+            -   `<*.Container bind:logic_state>` — Fixed two-way binding not working post-mount.
+
+        -   `Accordion`
+
+            -   `<svelte:fragment slot="close/open">` — Updated to default to `<span>&blacktriangledown;/&blacktriangleright;</span>` respectively.
+
 ## 0.5.1 - 2022/01/05
 
 -   Added the following Components / Component Features

--- a/src/lib/components/disclosure/accordion/Accordion.stories.svelte
+++ b/src/lib/components/disclosure/accordion/Accordion.stories.svelte
@@ -1,6 +1,7 @@
 <script>
     import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
 
+    import Button from "../../interactables/button/Button.svelte";
     import Box from "../../surfaces/box/Box.svelte";
     import Code from "../../typography/code/Code.svelte";
     import Heading from "../../typography/heading/Heading.svelte";
@@ -22,6 +23,12 @@
         ["affirmative", false],
         ["negative", false],
     ];
+
+    let logic_state = "accordion-logic-state-1";
+
+    function on_state_click(id, event) {
+        logic_state = id;
+    }
 </script>
 
 <Meta title="Disclosure/Accordion" />
@@ -33,15 +40,125 @@
 <Story name="Default">
     <Accordion.Container logic_name="accordion-default">
         <Accordion.Group logic_id="accordion-default-1">
+            <Accordion.Label palette="accent">Section One</Accordion.Label>
+
+            <Accordion.Section>
+                <Heading>Item One Content</Heading>
+
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Accordion.Section>
+        </Accordion.Group>
+
+        <Accordion.Group logic_id="accordion-default-2">
+            <Accordion.Label palette="accent">Section Two</Accordion.Label>
+
+            <Accordion.Section>
+                <Heading>Item Two Content</Heading>
+
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Accordion.Section>
+        </Accordion.Group>
+
+        <Accordion.Group logic_id="accordion-default-3">
+            <Accordion.Label palette="accent">Section Three</Accordion.Label>
+
+            <Accordion.Section>
+                <Heading>Item Three Content</Heading>
+
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Accordion.Section>
+        </Accordion.Group>
+    </Accordion.Container>
+</Story>
+
+<Story name="Logic State">
+    <Button on:click={on_state_click.bind(null, "accordion-logic-state-1")}>
+        Select Section One
+    </Button>
+
+    <Button on:click={on_state_click.bind(null, "accordion-logic-state-2")}>
+        Select Section Two
+    </Button>
+
+    <Button on:click={on_state_click.bind(null, "accordion-logic-state-3")}>
+        Select Section Three
+    </Button>
+
+    <Accordion.Container logic_name="accordion-logic-state" bind:logic_state>
+        <Accordion.Group logic_id="accordion-logic-state-1">
+            <Accordion.Label palette="accent">Section One</Accordion.Label>
+
+            <Accordion.Section>
+                <Heading>Item One Content</Heading>
+
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Accordion.Section>
+        </Accordion.Group>
+
+        <Accordion.Group logic_id="accordion-logic-state-2">
+            <Accordion.Label palette="accent">Section Two</Accordion.Label>
+
+            <Accordion.Section>
+                <Heading>Item Two Content</Heading>
+
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Accordion.Section>
+        </Accordion.Group>
+
+        <Accordion.Group logic_id="accordion-logic-state-3">
+            <Accordion.Label palette="accent">Section Three</Accordion.Label>
+
+            <Accordion.Section>
+                <Heading>Item Three Content</Heading>
+
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Accordion.Section>
+        </Accordion.Group>
+    </Accordion.Container>
+</Story>
+
+<Story name="Slot">
+    <Accordion.Container logic_name="accordion-slot">
+        <Accordion.Group logic_id="accordion-slot-1">
             <Accordion.Label palette="accent">
                 Section One
 
                 <svelte:fragment slot="close">
-                    <Text is="span">&blacktriangledown;</Text>
+                    <Text is="span">-</Text>
                 </svelte:fragment>
 
                 <svelte:fragment slot="open">
-                    <Text is="span">&blacktriangleright;</Text>
+                    <Text is="span">+</Text>
                 </svelte:fragment>
             </Accordion.Label>
 
@@ -57,16 +174,16 @@
             </Accordion.Section>
         </Accordion.Group>
 
-        <Accordion.Group logic_id="accordion-default-2">
+        <Accordion.Group logic_id="accordion-slot-2">
             <Accordion.Label palette="accent">
                 Section Two
 
                 <svelte:fragment slot="close">
-                    <Text is="span">&blacktriangledown;</Text>
+                    <Text is="span">-</Text>
                 </svelte:fragment>
 
                 <svelte:fragment slot="open">
-                    <Text is="span">&blacktriangleright;</Text>
+                    <Text is="span">+</Text>
                 </svelte:fragment>
             </Accordion.Label>
 
@@ -82,16 +199,16 @@
             </Accordion.Section>
         </Accordion.Group>
 
-        <Accordion.Group logic_id="accordion-default-3">
+        <Accordion.Group logic_id="accordion-slot-3">
             <Accordion.Label palette="accent">
                 Section Three
 
                 <svelte:fragment slot="close">
-                    <Text is="span">&blacktriangledown;</Text>
+                    <Text is="span">-</Text>
                 </svelte:fragment>
 
                 <svelte:fragment slot="open">
-                    <Text is="span">&blacktriangleright;</Text>
+                    <Text is="span">+</Text>
                 </svelte:fragment>
             </Accordion.Label>
 
@@ -119,14 +236,6 @@
             <Accordion.Group logic_id="accordion-lazy-{index + 1}">
                 <Accordion.Label>
                     Section {name}
-
-                    <svelte:fragment slot="close">
-                        <Text is="span">&blacktriangledown;</Text>
-                    </svelte:fragment>
-
-                    <svelte:fragment slot="open">
-                        <Text is="span">&blacktriangleright;</Text>
-                    </svelte:fragment>
                 </Accordion.Label>
 
                 <Accordion.Section loading="lazy">
@@ -150,14 +259,6 @@
             <Accordion.Group logic_id="accordion-inclusive-{index + 1}">
                 <Accordion.Label>
                     Section {name}
-
-                    <svelte:fragment slot="close">
-                        <Text is="span">&blacktriangledown;</Text>
-                    </svelte:fragment>
-
-                    <svelte:fragment slot="open">
-                        <Text is="span">&blacktriangleright;</Text>
-                    </svelte:fragment>
                 </Accordion.Label>
 
                 <Accordion.Section>
@@ -181,14 +282,6 @@
             <Accordion.Group logic_id="accordion-palette-{index + 1}">
                 <Accordion.Label {palette}>
                     Section {`${palette.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
-
-                    <svelte:fragment slot="close">
-                        <Text is="span">&blacktriangledown;</Text>
-                    </svelte:fragment>
-
-                    <svelte:fragment slot="open">
-                        <Text is="span">&blacktriangleright;</Text>
-                    </svelte:fragment>
                 </Accordion.Label>
 
                 <Accordion.Section>
@@ -212,14 +305,6 @@
             <Accordion.Group logic_id="accordion-transition-exclusive-{index + 1}">
                 <Accordion.Label>
                     Section {name}
-
-                    <svelte:fragment slot="close">
-                        <Text is="span">&blacktriangledown;</Text>
-                    </svelte:fragment>
-
-                    <svelte:fragment slot="open">
-                        <Text is="span">&blacktriangleright;</Text>
-                    </svelte:fragment>
                 </Accordion.Label>
 
                 <Accordion.Section>
@@ -246,14 +331,6 @@
             <Accordion.Group logic_id="accordion-transition-inclusive-{index + 1}">
                 <Accordion.Label>
                     Section {name}
-
-                    <svelte:fragment slot="close">
-                        <Text is="span">&blacktriangledown;</Text>
-                    </svelte:fragment>
-
-                    <svelte:fragment slot="open">
-                        <Text is="span">&blacktriangleright;</Text>
-                    </svelte:fragment>
                 </Accordion.Label>
 
                 <Accordion.Section>

--- a/src/lib/components/disclosure/accordion/AccordionContainer.svelte
+++ b/src/lib/components/disclosure/accordion/AccordionContainer.svelte
@@ -64,7 +64,7 @@
     on:pointerout
     on:pointerup
 >
-    <AccordionGroup {behavior} {logic_name} {logic_state} on:change>
+    <AccordionGroup {behavior} {logic_name} bind:logic_state on:change>
         <slot />
     </AccordionGroup>
 </div>

--- a/src/lib/components/disclosure/accordion/AccordionGroup.svelte
+++ b/src/lib/components/disclosure/accordion/AccordionGroup.svelte
@@ -20,7 +20,7 @@
 </script>
 
 <script lang="ts">
-    import {afterUpdate, createEventDispatcher} from "svelte";
+    import {createEventDispatcher} from "svelte";
 
     type $$Events = {
         change: CustomEvent<void>;
@@ -52,10 +52,18 @@
 
     const _accordion_behavior = CONTEXT_ACCORDION_BEHAVIOR.create(behavior);
 
-    if (_accordion_state) {
-        afterUpdate(() => {
-            if (_accordion_state) $_accordion_state = logic_state ?? "";
-        });
+    function on_state_property_update(state: string | string[]): void {
+        if (_accordion_state && state !== $_accordion_state) {
+            $_accordion_state = state;
+            dispatch("change");
+        }
+    }
+
+    function on_state_store_update(state: string | string[]): void {
+        if (state !== logic_state) {
+            logic_state = state;
+            dispatch("change");
+        }
     }
 
     $: if (_accordion_id) $_accordion_id = logic_id ?? "";
@@ -63,11 +71,8 @@
 
     $: if (_accordion_behavior) $_accordion_behavior = behavior as PROPERTY_BEHAVIOR_TOGGLE;
 
-    $: if (_accordion_state && logic_state !== $_accordion_state) {
-        logic_state = $_accordion_state;
-
-        dispatch("change");
-    }
+    $: if (logic_state !== undefined) on_state_property_update(logic_state);
+    $: if (_accordion_state) on_state_store_update($_accordion_state);
 </script>
 
 <slot />

--- a/src/lib/components/disclosure/accordion/AccordionLabel.svelte
+++ b/src/lib/components/disclosure/accordion/AccordionLabel.svelte
@@ -142,6 +142,11 @@
 >
     <slot />
 
-    <slot name="open" />
-    <slot name="close" />
+    <slot name="open">
+        <span>&blacktriangleright;</span>
+    </slot>
+
+    <slot name="close">
+        <span>&blacktriangledown;</span>
+    </slot>
 </label>

--- a/src/lib/components/disclosure/tab/Tab.stories.svelte
+++ b/src/lib/components/disclosure/tab/Tab.stories.svelte
@@ -1,6 +1,7 @@
 <script>
     import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
 
+    import Button from "../../interactables/button/Button.svelte";
     import * as Grid from "../../layouts/grid";
     import Box from "../../surfaces/box/Box.svelte";
     import Code from "../../typography/code/Code.svelte";
@@ -39,6 +40,12 @@
     ];
 
     const TABS = ["One", "Two", "Three"];
+
+    let logic_state = "tab-logic-state-1";
+
+    function on_state_click(id, event) {
+        logic_state = id;
+    }
 </script>
 
 <Meta title="Disclosure/Tab" />
@@ -78,6 +85,56 @@
         </Tab.Group>
 
         <Tab.Group logic_id="tab-default-3">
+            <Tab.Label palette="accent">Tab Three <span>ICON</span></Tab.Label>
+            <Tab.Section>
+                <Heading>Tab Three Content</Heading>
+
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Tab.Section>
+        </Tab.Group>
+    </Tab.Container>
+</Story>
+
+<Story name="Logic State">
+    <Button on:click={on_state_click.bind(null, "tab-logic-state-1")}>Select Tab One</Button>
+    <Button on:click={on_state_click.bind(null, "tab-logic-state-2")}>Select Tab Two</Button>
+    <Button on:click={on_state_click.bind(null, "tab-logic-state-3")}>Select Tab Three</Button>
+
+    <Tab.Container logic_name="tab-logic-state" alignment_x="stretch" bind:logic_state>
+        <Tab.Group logic_id="tab-logic-state-1">
+            <Tab.Label palette="accent">Tab One <span>ICON</span></Tab.Label>
+            <Tab.Section>
+                <Heading>Tab One Content</Heading>
+
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Tab.Section>
+        </Tab.Group>
+
+        <Tab.Group logic_id="tab-logic-state-2">
+            <Tab.Label palette="accent">Tab Two <span>ICON</span></Tab.Label>
+            <Tab.Section>
+                <Heading>Tab Two Content</Heading>
+
+                <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et consectetur
+                    orci. Curabitur a egestas turpis, vitae convallis sapien. Sed pellentesque
+                    rutrum tellus, in iaculis dolor tincidunt non. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus.
+                </Text>
+            </Tab.Section>
+        </Tab.Group>
+
+        <Tab.Group logic_id="tab-logic-state-3">
             <Tab.Label palette="accent">Tab Three <span>ICON</span></Tab.Label>
             <Tab.Section>
                 <Heading>Tab Three Content</Heading>

--- a/src/lib/components/disclosure/tab/TabContainer.svelte
+++ b/src/lib/components/disclosure/tab/TabContainer.svelte
@@ -69,7 +69,7 @@
     on:pointerout
     on:pointerup
 >
-    <TabGroup {logic_name} {logic_state} on:change>
+    <TabGroup {logic_name} bind:logic_state on:change>
         <slot />
     </TabGroup>
 </div>

--- a/src/lib/components/disclosure/tab/TabGroup.svelte
+++ b/src/lib/components/disclosure/tab/TabGroup.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <script lang="ts">
-    import {afterUpdate, createEventDispatcher} from "svelte";
+    import {createEventDispatcher} from "svelte";
 
     type $$Events = {
         change: CustomEvent<void>;
@@ -35,20 +35,25 @@
     const _tab_name = CONTEXT_TAB_NAME.create(logic_name);
     const _tab_state = CONTEXT_TAB_STATE.create(logic_state);
 
-    if (_tab_state) {
-        afterUpdate(() => {
-            $_tab_state = logic_state ?? "";
-        });
+    function on_state_property_update(state: string): void {
+        if (_tab_state && state !== $_tab_state) {
+            $_tab_state = state;
+            dispatch("change");
+        }
     }
 
-    $: if (_tab_id) $_tab_id = logic_id ?? "";
-    $: if (_tab_name) $_tab_name = logic_name ?? "";
-
-    $: if (_tab_state && logic_state !== $_tab_state) {
-        logic_state = $_tab_state;
-
-        dispatch("change");
+    function on_state_store_update(state: string): void {
+        if (state !== logic_state) {
+            logic_state = state;
+            dispatch("change");
+        }
     }
+
+    $: if (_tab_id) $_tab_id = logic_id as string;
+    $: if (_tab_name) $_tab_name = logic_name as string;
+
+    $: if (logic_state !== undefined) on_state_property_update(logic_state);
+    $: if (_tab_state) on_state_store_update($_tab_state);
 </script>
 
 <slot />


### PR DESCRIPTION
# CHANGELOG

-   Fixed the following Components / Component Features

    -   Disclosure

        -   `Accordion` / `Tab`

            -   `<*.Container bind:logic_state>` — Fixed two-way binding not working post-mount.

        -   `Accordion`

            -   `<svelte:fragment slot="close/open">` — Updated to default to `<span>&blacktriangledown;/&blacktriangleright;</span>` respectively.