### PR TITLE
[0.5.3] Add `DataTable` Widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,72 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Added the following Actions / Action Features
+
+    -   `action_activate(element: HTMLElement, options: {on_bind: IKeybindCallback}): IKeybindHandle` — Used for activating the current context, e.g. a focused label.
+
+        -   `Enter`, ` ` _(space)_
+
+    -   `action_exit(element: HTMLElement, options: {on_bind: IKeybindCallback}): IKeybindHandle` — Used for exiting the current context, e.g. a prompt.
+
+        -   `Esc`
+
+    -   `action_submit(element: HTMLElement, options: {on_bind: IKeybindCallback}): IKeybindHandle` — Used for submitting the current context, e.g. a focused input.
+
+        -   `Enter`
+
+    -   `navigate_down(element: HTMLElement, options: {on_bind: IKeybindCallback}): IKeybindHandle` — Used for navigating to the next item down.
+
+        -   `ArrowDown`
+        -   Repeatable, `250ms` throttle
+
+    -   `navigate_left(element: HTMLElement, options: {on_bind: IKeybindCallback}): IKeybindHandle` — Used for navigating to the next item left.
+
+        -   `ArrowLeft`
+        -   Repeatable, `250ms` throttle
+
+    -   `navigate_right(element: HTMLElement, options: {on_bind: IKeybindCallback}): IKeybindHandle` — Used for navigating to the next item right.
+
+        -   `ArrowRight`
+        -   Repeatable, `250ms` throttle
+
+    -   `navigate_up(element: HTMLElement, options: {on_bind: IKeybindCallback}): IKeybindHandle` — Used for navigating to the next item up.
+
+        -   `ArrowUp`
+        -   Repeatable, `250ms` throttle
+
+-   Added the following Components / Component Features
+
+    -   Widgets
+
+        -   `DataTable` — Automatically handles rendering tabular data of rows and columns into HTML.
+
+            -   `<DataTable columns={{key: keyof T, text: string}[]}>` — Configures metadata on how `DataTable` should renders the tabular data.
+            -   `<DataTable rows={T[]}>` — Sets the tabular data that `DataTable` is to render.
+
+            -   `<DataTable page={number | string}>` — Sets the current page of the pagination.
+            -   `<DataTable paginate={boolean}>` — Enables `DataTable` to split the tabular data into paged views.
+            -   `<DataTable paging={number | string}>` — Sets how many rows should appear per page.
+
+            -   `<DataTable sorting={keyof T}>` — Sets which row member that `DataTable` is currently sorting by.
+
+                -   `<DataTable columns={{sorting: boolean}[]}>` — Enables sorting for the particular column.
+                -   `<DataTable columns={{sorting_algorithm: (a: T[keyof T], b: T[keyof T]) => number}[]}>` — Optional custom sorter. By default, all row members are lowercased and alphabetized.
+
+            -   `<DataTable sorting_mode="ascending/decending">` — Sets which direction `DataTable` is sorting the row member by.
+
+            -   `<DataTable searching={string}>` — Sets the current search query that `DataTable` is using to filter the tabular data.
+            -   `<DataTable searching_algorithm={(row: T) => boolean}>` — Optional custom searching filter. By default, all row members are lowercased and fuzzy searched.
+
+            -   `<DataTable palette="accent/dark/light/alert/affirmative/negative">` — Alters the rendered color palette.
+            -   `<DataTable sizing="tiny/small/medium/large/huge">` — Alters the sizing of the Widget and children Components.
+            -   `<DataTable variation={"borders" | "stripes" | ["borders", "stripes"]}>` — Alters the appearance of the Component.
+
+            -   `<svelte:fragment let:key={keyof T} let:row={T}>` — Customizes how each column in a row is rendered in a table cell.
+            -   `<svelte:fragment slot="next/previous">` — Customizes the next / previous paging button content.
+            -   `<svelte:fragment slot="unsorted/ascending/decending">` — Customizes the not-sorted, ascending sort, decending sort button content.
+
 ## 0.5.2 - 2022/01/05
 
 -   Fixed the following Components / Component Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
                 -   `<DataTable columns={{sorting: boolean}[]}>` — Enables sorting for the particular column.
                 -   `<DataTable columns={{sorting_algorithm: (a: T[keyof T], b: T[keyof T]) => number}[]}>` — Optional custom sorter. By default, all row members are lowercased and alphabetized.
 
-            -   `<DataTable sorting_mode="ascending/decending">` — Sets which direction `DataTable` is sorting the row member by.
+            -   `<DataTable sorting_mode="ascending/descending">` — Sets which direction `DataTable` is sorting the row member by.
 
             -   `<DataTable searching={string}>` — Sets the current search query that `DataTable` is using to filter the tabular data.
             -   `<DataTable searching_algorithm={(row: T) => boolean}>` — Optional custom searching filter. By default, all row members are lowercased and fuzzy searched.
@@ -65,7 +65,7 @@
 
             -   `<svelte:fragment let:key={keyof T} let:row={T}>` — Customizes how each column in a row is rendered in a table cell.
             -   `<svelte:fragment slot="next/previous">` — Customizes the next / previous paging button content.
-            -   `<svelte:fragment slot="unsorted/ascending/decending">` — Customizes the not-sorted, ascending sort, decending sort button content.
+            -   `<svelte:fragment slot="unsorted/ascending/descending">` — Customizes the not-sorted, ascending sort, descending sort button content.
 
 ## 0.5.2 - 2022/01/05
 

--- a/src/lib/components/interactables/numberinput/NumberInput.svelte
+++ b/src/lib/components/interactables/numberinput/NumberInput.svelte
@@ -6,6 +6,7 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
+    import type {ISizeProperties} from "../../../types/sizes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
     import type {PROPERTY_TEXT_ALIGNMENT} from "../../../types/typography";
@@ -40,7 +41,7 @@
         placeholder?: string;
         value?: number;
 
-        characters?: number;
+        characters?: number | string;
 
         align?: PROPERTY_TEXT_ALIGNMENT;
         palette?: PROPERTY_PALETTE;
@@ -48,7 +49,8 @@
         variation?: PROPERTY_VARIATION_INPUT;
     } & IHTML5Properties &
         IGlobalProperties &
-        IMarginProperties;
+        IMarginProperties &
+        ISizeProperties;
 
     export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;

--- a/src/lib/components/interactables/textinput/TextInput.svelte
+++ b/src/lib/components/interactables/textinput/TextInput.svelte
@@ -50,9 +50,9 @@
         min_length?: number | undefined;
         pattern?: RegExp | string;
 
-        characters?: number;
+        characters?: number | string;
+        lines?: number | string;
 
-        lines?: number;
         resizable?: PROPERTY_RESIZEABLE;
         spell_check?: boolean;
 
@@ -90,8 +90,8 @@
     export let pattern: $$Props["pattern"] = "";
 
     export let characters: $$Props["characters"] = undefined;
-
     export let lines: $$Props["lines"] = undefined;
+
     export let resizable: $$Props["resizable"] = undefined;
     export let spell_check: $$Props["spell_check"] = undefined;
 

--- a/src/lib/components/widgets/datatable/DataTable.stories.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.stories.svelte
@@ -8,16 +8,16 @@
     import DataTable from "./DataTable.svelte";
 
     const COLUMNS_SW = [
-        {text: "First Name", key: "first_name", sorting_enabled: true},
-        {text: "Last Name", key: "last_name", sorting_enabled: true},
-        {text: "Occupation", key: "occupation", sorting_enabled: true},
-        {text: "Species", key: "species", sorting_enabled: true},
+        {text: "First Name", key: "first_name", sorting: true},
+        {text: "Last Name", key: "last_name", sorting: true},
+        {text: "Occupation", key: "occupation", sorting: true},
+        {text: "Species", key: "species", sorting: true},
     ];
 
     const COLUMNS_VIEWPORT = [
-        {text: "Viewport", key: "viewport", sorting_enabled: true},
-        {text: "Minimum", key: "minimum", sorting_enabled: true},
-        {text: "Maximum", key: "maximum", sorting_enabled: true},
+        {text: "Viewport", key: "viewport", sorting: true},
+        {text: "Minimum", key: "minimum", sorting: true},
+        {text: "Maximum", key: "maximum", sorting: true},
     ];
 
     const ROWS_SW = [
@@ -35,7 +35,7 @@
         {first_name: "Tila", last_name: "Mong", occupation: "Baron Do Sage", species: "Kel Dor"},
     ];
 
-    const ROWS_VIEWPORT = [
+    let ROWS_VIEWPORT = [
         {
             viewport: "mobile",
             minimum: "0px",
@@ -81,6 +81,13 @@
         ["large", false],
         ["huge", false],
     ];
+
+    function on_viewport_input(row, event) {
+        const index = ROWS_VIEWPORT.findIndex((_row) => row === _row);
+
+        ROWS_VIEWPORT = [...ROWS_VIEWPORT];
+        ROWS_VIEWPORT[index] = {...row, viewport: event.target.value};
+    }
 </script>
 
 <Meta title="Widgets/DataTable" />
@@ -97,7 +104,12 @@
     <DataTable columns={COLUMNS_VIEWPORT} rows={ROWS_VIEWPORT}>
         <svelte:fragment let:key let:row>
             {#if key === "viewport"}
-                <TextInput value={row["viewport"]} variation="flush" width="100" />
+                <TextInput
+                    value={row["viewport"]}
+                    variation="flush"
+                    width="100"
+                    on:input={on_viewport_input.bind(null, row)}
+                />
             {:else}
                 {row[key]}
             {/if}

--- a/src/lib/components/widgets/datatable/DataTable.stories.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.stories.svelte
@@ -15,7 +15,7 @@
     ];
 
     let ROWS = [
-        {first_name: "Ashoka", last_name: "Tano", occupation: "Unknown", species: "Togruta"},
+        {first_name: "Ahsoka", last_name: "Tano", occupation: "Unknown", species: "Togruta"},
         {first_name: "Cad", last_name: "Bane", occupation: "Bounty Hunter", species: "Duros"},
         {first_name: "Cobb", last_name: "Vanth", occupation: "Marshal", species: "Human"},
         {first_name: "Din", last_name: "Djarin", occupation: "Bounty Hunter", species: "Human"},

--- a/src/lib/components/widgets/datatable/DataTable.stories.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.stories.svelte
@@ -8,16 +8,16 @@
     import DataTable from "./DataTable.svelte";
 
     const COLUMNS_SW = [
-        {text: "First Name", key: "first_name"},
-        {text: "Last Name", key: "last_name"},
-        {text: "Occupation", key: "occupation"},
-        {text: "Species", key: "species"},
+        {text: "First Name", key: "first_name", sorting_enabled: true},
+        {text: "Last Name", key: "last_name", sorting_enabled: true},
+        {text: "Occupation", key: "occupation", sorting_enabled: true},
+        {text: "Species", key: "species", sorting_enabled: true},
     ];
 
     const COLUMNS_VIEWPORT = [
-        {text: "Viewport", key: "viewport"},
-        {text: "Minimum", key: "minimum"},
-        {text: "Maximum", key: "maximum"},
+        {text: "Viewport", key: "viewport", sorting_enabled: true},
+        {text: "Minimum", key: "minimum", sorting_enabled: true},
+        {text: "Maximum", key: "maximum", sorting_enabled: true},
     ];
 
     const ROWS_SW = [
@@ -25,8 +25,8 @@
         {first_name: "Cad", last_name: "Bane", occupation: "Bounty Hunter", species: "Duros"},
         {first_name: "Cobb", last_name: "Vanth", occupation: "Marshal", species: "Human"},
         {first_name: "Din", last_name: "Djarin", occupation: "Bounty Hunter", species: "Human"},
-        {first_name: "Gilad", last_name: "Pellaeon", occupation: "Grand Admiral", species: "Human"},
         {first_name: "Fennec", last_name: "Shand", occupation: "Assassin", species: "Human"},
+        {first_name: "Gilad", last_name: "Pellaeon", occupation: "Grand Admiral", species: "Human"},
         {first_name: "Jagged", last_name: "Fel", occupation: "Emperor", species: "Human"},
         {first_name: "Max", last_name: "Rebo", occupation: "Musician", species: "Ortolan"},
         {first_name: "Mok", last_name: "Shaiz", occupation: "Mayor", species: "Ithorian"},

--- a/src/lib/components/widgets/datatable/DataTable.stories.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.stories.svelte
@@ -50,11 +50,11 @@
         ["huge", false],
     ];
 
-    function on_viewport_input(row, event) {
+    function on_first_name_input(row, event) {
         const index = ROWS.findIndex((_row) => row === _row);
 
         ROWS = [...ROWS];
-        ROWS[index] = {...row, viewport: event.target.value};
+        ROWS[index] = {...row, first_name: event.target.value};
     }
 </script>
 
@@ -71,12 +71,12 @@
 <Story name="Slot">
     <DataTable columns={COLUMNS} rows={ROWS}>
         <svelte:fragment let:key let:row>
-            {#if key === "viewport"}
+            {#if key === "first_name"}
                 <TextInput
-                    value={row["viewport"]}
+                    value={row["first_name"]}
                     variation="flush"
                     width="100"
-                    on:input={on_viewport_input.bind(null, row)}
+                    on:input={on_first_name_input.bind(null, row)}
                 />
             {:else}
                 {row[key]}

--- a/src/lib/components/widgets/datatable/DataTable.stories.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.stories.svelte
@@ -1,0 +1,157 @@
+<script>
+    import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
+
+    import TextInput from "../../interactables/textinput/TextInput.svelte";
+    import Stack from "../../layouts/stack/Stack.svelte";
+    import Text from "../../typography/text/Text.svelte";
+
+    import DataTable from "./DataTable.svelte";
+
+    const COLUMNS_SW = [
+        {text: "First Name", key: "first_name"},
+        {text: "Last Name", key: "last_name"},
+        {text: "Occupation", key: "occupation"},
+        {text: "Species", key: "species"},
+    ];
+
+    const COLUMNS_VIEWPORT = [
+        {text: "Viewport", key: "viewport"},
+        {text: "Minimum", key: "minimum"},
+        {text: "Maximum", key: "maximum"},
+    ];
+
+    const ROWS_SW = [
+        {first_name: "Ashoka", last_name: "Tano", occupation: "Unknown", species: "Togruta"},
+        {first_name: "Cad", last_name: "Bane", occupation: "Bounty Hunter", species: "Duros"},
+        {first_name: "Cobb", last_name: "Vanth", occupation: "Marshal", species: "Human"},
+        {first_name: "Din", last_name: "Djarin", occupation: "Bounty Hunter", species: "Human"},
+        {first_name: "Gilad", last_name: "Pellaeon", occupation: "Grand Admiral", species: "Human"},
+        {first_name: "Fennec", last_name: "Shand", occupation: "Assassin", species: "Human"},
+        {first_name: "Jagged", last_name: "Fel", occupation: "Emperor", species: "Human"},
+        {first_name: "Max", last_name: "Rebo", occupation: "Musician", species: "Ortolan"},
+        {first_name: "Mok", last_name: "Shaiz", occupation: "Mayor", species: "Ithorian"},
+        {first_name: "Natasi", last_name: "Daala", occupation: "Chief of State", species: "Human"},
+        {first_name: "Quinlan", last_name: "Vos", occupation: "Jedi Master", species: "Kiffar"},
+        {first_name: "Tila", last_name: "Mong", occupation: "Baron Do Sage", species: "Kel Dor"},
+    ];
+
+    const ROWS_VIEWPORT = [
+        {
+            viewport: "mobile",
+            minimum: "0px",
+            maximum: "640px",
+        },
+
+        {
+            viewport: "tablet",
+            minimum: "641px",
+            maximum: "768px",
+        },
+
+        {
+            viewport: "desktop",
+            minimum: "769px",
+            maximum: "1024px",
+        },
+
+        {
+            viewport: "widescreen",
+            minimum: "1025px",
+            maximum: "∞",
+        },
+    ];
+
+    const PALETTES = [
+        ["neutral", true],
+        ["accent", false],
+        ["auto", false],
+        ["inverse", false],
+        ["dark", false],
+        ["light", false],
+        ["alert", false],
+        ["affirmative", false],
+        ["negative", false],
+    ];
+
+    const SIZINGS = [
+        ["default", true],
+        ["tiny", false],
+        ["small", false],
+        ["medium", false],
+        ["large", false],
+        ["huge", false],
+    ];
+</script>
+
+<Meta title="Widgets/DataTable" />
+
+<Template>
+    <slot />
+</Template>
+
+<Story name="Preview">
+    <DataTable columns={COLUMNS_SW} rows={ROWS_SW} palette="accent" paginate />
+</Story>
+
+<Story name="Slot">
+    <DataTable columns={COLUMNS_VIEWPORT} rows={ROWS_VIEWPORT}>
+        <svelte:fragment let:key let:row>
+            {#if key === "viewport"}
+                <TextInput value={row["viewport"]} variation="flush" width="100" />
+            {:else}
+                {row[key]}
+            {/if}
+        </svelte:fragment>
+    </DataTable>
+</Story>
+
+<Story name="Paging">
+    <DataTable columns={COLUMNS_SW} rows={ROWS_SW} paging={7} palette="accent" paginate />
+</Story>
+
+<Story name="Variation">
+    <Text is="strong">DEFAULT</Text>
+    <DataTable columns={COLUMNS_VIEWPORT} rows={ROWS_VIEWPORT} />
+
+    <Text is="strong">BORDERS</Text>
+    <DataTable columns={COLUMNS_VIEWPORT} rows={ROWS_VIEWPORT} variation="borders" />
+
+    <Text is="strong">STRIPES</Text>
+    <DataTable columns={COLUMNS_VIEWPORT} rows={ROWS_VIEWPORT} variation="stripes" />
+
+    <Text is="strong">BORDERS+STRIPES</Text>
+    <DataTable columns={COLUMNS_VIEWPORT} rows={ROWS_VIEWPORT} variation={["borders", "stripes"]} />
+</Story>
+
+<Story name="Palette">
+    <Stack spacing="medium">
+        {#each PALETTES as [palette, is_default] (palette)}
+            <div>
+                <Text is="strong">
+                    {`${palette.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                </Text>
+
+                <DataTable
+                    columns={COLUMNS_SW}
+                    rows={ROWS_SW}
+                    palette={is_default ? undefined : palette}
+                    paginate
+                />
+            </div>
+        {/each}
+    </Stack>
+</Story>
+
+<Story name="Sizing">
+    <Stack spacing="medium">
+        {#each SIZINGS as [sizing, is_default] (sizing)}
+            <div>
+                <Text is="strong">
+                    {`${sizing.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                </Text>
+
+                <DataTable columns={COLUMNS_SW} rows={ROWS_SW} palette="accent" {sizing} paginate />
+            </div>
+        {/each}
+    </Stack>
+</Story>

--- a/src/lib/components/widgets/datatable/DataTable.stories.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.stories.svelte
@@ -7,20 +7,14 @@
 
     import DataTable from "./DataTable.svelte";
 
-    const COLUMNS_SW = [
+    const COLUMNS = [
         {text: "First Name", key: "first_name", sorting: true},
         {text: "Last Name", key: "last_name", sorting: true},
         {text: "Occupation", key: "occupation", sorting: true},
         {text: "Species", key: "species", sorting: true},
     ];
 
-    const COLUMNS_VIEWPORT = [
-        {text: "Viewport", key: "viewport", sorting: true},
-        {text: "Minimum", key: "minimum", sorting: true},
-        {text: "Maximum", key: "maximum", sorting: true},
-    ];
-
-    const ROWS_SW = [
+    let ROWS = [
         {first_name: "Ashoka", last_name: "Tano", occupation: "Unknown", species: "Togruta"},
         {first_name: "Cad", last_name: "Bane", occupation: "Bounty Hunter", species: "Duros"},
         {first_name: "Cobb", last_name: "Vanth", occupation: "Marshal", species: "Human"},
@@ -33,32 +27,6 @@
         {first_name: "Natasi", last_name: "Daala", occupation: "Chief of State", species: "Human"},
         {first_name: "Quinlan", last_name: "Vos", occupation: "Jedi Master", species: "Kiffar"},
         {first_name: "Tila", last_name: "Mong", occupation: "Baron Do Sage", species: "Kel Dor"},
-    ];
-
-    let ROWS_VIEWPORT = [
-        {
-            viewport: "mobile",
-            minimum: "0px",
-            maximum: "640px",
-        },
-
-        {
-            viewport: "tablet",
-            minimum: "641px",
-            maximum: "768px",
-        },
-
-        {
-            viewport: "desktop",
-            minimum: "769px",
-            maximum: "1024px",
-        },
-
-        {
-            viewport: "widescreen",
-            minimum: "1025px",
-            maximum: "∞",
-        },
     ];
 
     const PALETTES = [
@@ -83,10 +51,10 @@
     ];
 
     function on_viewport_input(row, event) {
-        const index = ROWS_VIEWPORT.findIndex((_row) => row === _row);
+        const index = ROWS.findIndex((_row) => row === _row);
 
-        ROWS_VIEWPORT = [...ROWS_VIEWPORT];
-        ROWS_VIEWPORT[index] = {...row, viewport: event.target.value};
+        ROWS = [...ROWS];
+        ROWS[index] = {...row, viewport: event.target.value};
     }
 </script>
 
@@ -97,11 +65,11 @@
 </Template>
 
 <Story name="Preview">
-    <DataTable columns={COLUMNS_SW} rows={ROWS_SW} palette="accent" paginate />
+    <DataTable columns={COLUMNS} rows={ROWS} palette="accent" paginate />
 </Story>
 
 <Story name="Slot">
-    <DataTable columns={COLUMNS_VIEWPORT} rows={ROWS_VIEWPORT}>
+    <DataTable columns={COLUMNS} rows={ROWS}>
         <svelte:fragment let:key let:row>
             {#if key === "viewport"}
                 <TextInput
@@ -118,21 +86,21 @@
 </Story>
 
 <Story name="Paging">
-    <DataTable columns={COLUMNS_SW} rows={ROWS_SW} paging={7} palette="accent" paginate />
+    <DataTable columns={COLUMNS} rows={ROWS} paging={7} palette="accent" paginate />
 </Story>
 
 <Story name="Variation">
     <Text is="strong">DEFAULT</Text>
-    <DataTable columns={COLUMNS_VIEWPORT} rows={ROWS_VIEWPORT} />
+    <DataTable columns={COLUMNS} rows={ROWS} />
 
     <Text is="strong">BORDERS</Text>
-    <DataTable columns={COLUMNS_VIEWPORT} rows={ROWS_VIEWPORT} variation="borders" />
+    <DataTable columns={COLUMNS} rows={ROWS} variation="borders" />
 
     <Text is="strong">STRIPES</Text>
-    <DataTable columns={COLUMNS_VIEWPORT} rows={ROWS_VIEWPORT} variation="stripes" />
+    <DataTable columns={COLUMNS} rows={ROWS} variation="stripes" />
 
     <Text is="strong">BORDERS+STRIPES</Text>
-    <DataTable columns={COLUMNS_VIEWPORT} rows={ROWS_VIEWPORT} variation={["borders", "stripes"]} />
+    <DataTable columns={COLUMNS} rows={ROWS} variation={["borders", "stripes"]} />
 </Story>
 
 <Story name="Palette">
@@ -144,8 +112,8 @@
                 </Text>
 
                 <DataTable
-                    columns={COLUMNS_SW}
-                    rows={ROWS_SW}
+                    columns={COLUMNS}
+                    rows={ROWS}
                     palette={is_default ? undefined : palette}
                     paginate
                 />
@@ -162,7 +130,7 @@
                     {`${sizing.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
                 </Text>
 
-                <DataTable columns={COLUMNS_SW} rows={ROWS_SW} palette="accent" {sizing} paginate />
+                <DataTable columns={COLUMNS} rows={ROWS} palette="accent" {sizing} paginate />
             </div>
         {/each}
     </Stack>

--- a/src/lib/components/widgets/datatable/DataTable.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+    import type {IGlobalProperties} from "../../../types/global";
+    import type {IHTML5Properties} from "../../../types/html5";
+    import type {PROPERTY_PALETTE} from "../../../types/palettes";
+    import type {ISizeProperties} from "../../../types/sizes";
+    import type {PROPERTY_SIZING} from "../../../types/sizings";
+    import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
+    import type {PROPERTY_VARIATION_TABLE} from "../../../types/variations";
+
+    import type {IKeybindEvent} from "../../../actions/keybind";
+
+    import {IS_BROWSER} from "../../../util/environment";
+    import {debounce} from "../../../util/functional";
+    import {navigate_up, navigate_down} from "../../../util/keybind";
+    import {clamp} from "../../../util/number";
+
+    import * as Table from "../../display/table";
+    import Button from "../../interactables/button/Button.svelte";
+    import NumberInput from "../../interactables/numberinput/NumberInput.svelte";
+    import Stack from "../../layouts/stack/Stack.svelte";
+
+    type IDataTableRow = $$Generic<Record<string, any>>;
+
+    interface IDataTableColumn {
+        key: keyof IDataTableRow;
+
+        text: string;
+    }
+
+    type $$Props = {
+        element?: HTMLTableElement;
+
+        columns: IDataTableColumn[];
+        rows: IDataTableRow[];
+        page?: number | string;
+        paginate?: boolean;
+        paging?: number | string;
+
+        palette?: PROPERTY_PALETTE;
+        sizing?: PROPERTY_SIZING;
+        variation?: PROPERTY_VARIATION_TABLE;
+    } & IHTML5Properties &
+        IGlobalProperties &
+        IMarginProperties &
+        IPaddingProperties &
+        ISizeProperties;
+
+    type $$Slots = {
+        default: {key: keyof IDataTableRow; row: IDataTableRow};
+        next: {};
+        previous: {};
+    };
+
+    export let element: $$Props["element"] = undefined;
+
+    let _class = "";
+    export {_class as class};
+
+    export let columns: $$Props["columns"];
+    export let rows: $$Props["rows"];
+    export let page: $$Props["page"] = undefined;
+    export let paginate: $$Props["paginate"] = undefined;
+    export let paging: $$Props["paging"] = undefined;
+
+    export let palette: $$Props["palette"] = undefined;
+    export let sizing: $$Props["sizing"] = undefined;
+    export let variation: $$Props["variation"] = undefined;
+
+    function on_paging_focus_out(event: FocusEvent): void {
+        const target = event.target as HTMLInputElement | null;
+        if (!target) return;
+
+        const value = parseInt(target.value);
+        if (!isNaN(value)) return;
+
+        target.value = _page.toString();
+    }
+
+    function on_paging_input(event: InputEvent): void {
+        const target = event.target as HTMLInputElement | null;
+        if (!target) return;
+
+        const value = parseInt(target.value);
+        if (isNaN(value)) return;
+
+        page = clamp(value, 1, _pages);
+        target.value = page.toString();
+    }
+
+    function on_paging_step(step: number, event: IKeybindEvent | MouseEvent): void {
+        if (!(event instanceof MouseEvent) && !event.detail.active) return;
+
+        page = clamp(_page + step, 1, _pages);
+    }
+
+    $: _page = typeof page === "string" ? parseInt(page) : page ?? 1;
+    $: _paging = typeof paging === "string" ? parseInt(paging) : paging ?? 5;
+    $: _pages = Math.ceil(rows.length / _paging);
+
+    let _view: IDataTableRow[];
+    $: {
+        if (IS_BROWSER && paginate) {
+            const start_index = _paging * (_page - 1);
+            const end_index = start_index + _paging;
+
+            _view = rows.slice(start_index, end_index);
+        } else _view = [...rows];
+    }
+</script>
+
+<Table.Container {...$$props} bind:element class="data-table {_class}" {sizing} {variation}>
+    <Table.Header>
+        <Table.Row>
+            {#each columns as column (column.key)}
+                <Table.Heading>
+                    {column.text}
+                </Table.Heading>
+            {/each}
+        </Table.Row>
+    </Table.Header>
+
+    <Table.Section>
+        {#each _view as row}
+            <Table.Row>
+                {#each columns as column (column.key)}
+                    <Table.Column>
+                        <slot key={column.key} {row}>
+                            {row[column.key]}
+                        </slot>
+                    </Table.Column>
+                {/each}
+            </Table.Row>
+        {/each}
+    </Table.Section>
+
+    {#if IS_BROWSER && paginate}
+        <Table.Footer>
+            <Table.Row>
+                <Table.Column colspan={columns.length}>
+                    <Stack
+                        orientation="horizontal"
+                        alignment_x="right"
+                        alignment_y="center"
+                        spacing="small"
+                    >
+                        <NumberInput
+                            characters="1"
+                            value={_page}
+                            align="right"
+                            {palette}
+                            size={sizing}
+                            actions={[
+                                [navigate_up, {on_bind: on_paging_step.bind(null, 1)}],
+                                [navigate_down, {on_bind: on_paging_step.bind(null, -1)}],
+                            ]}
+                            on:focusout={on_paging_focus_out}
+                            on:input={debounce(on_paging_input, 250)}
+                        />
+
+                        <span>/</span>
+                        <span>{_pages}</span>
+
+                        <Button
+                            disabled={_page === 1}
+                            variation={["subtle", "clear"]}
+                            size={sizing}
+                            {palette}
+                            on:click={on_paging_step.bind(null, -1)}
+                        >
+                            <slot name="previous">&lt;</slot>
+                        </Button>
+
+                        <Button
+                            disabled={_page === _pages}
+                            variation={["subtle", "clear"]}
+                            size={sizing}
+                            {palette}
+                            on:click={on_paging_step.bind(null, 1)}
+                        >
+                            <slot name="next">&gt;</slot>
+                        </Button>
+                    </Stack>
+                </Table.Column>
+            </Table.Row>
+        </Table.Footer>
+    {/if}
+</Table.Container>

--- a/src/lib/components/widgets/datatable/DataTable.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.svelte
@@ -28,12 +28,12 @@
     interface IDataTableColumn {
         key: IDataTableKey;
 
+        sorting: boolean;
+
         sorting_algorithm?: (
             a: IDataTableRow[IDataTableKey],
             b: IDataTableRow[IDataTableKey]
         ) => number;
-
-        sorting_enabled?: boolean;
 
         text: string;
     }
@@ -49,7 +49,7 @@
         paging?: number | string;
 
         sorting?: IDataTableKey;
-        sort_by?: PROPERTY_SORT_BY;
+        sorting_mode?: PROPERTY_SORT_BY;
 
         palette?: PROPERTY_PALETTE;
         sizing?: PROPERTY_SIZING;
@@ -79,7 +79,7 @@
     export let paging: $$Props["paging"] = undefined;
 
     export let sorting: $$Props["sorting"] = undefined;
-    export let sort_by: $$Props["sort_by"] = undefined;
+    export let sorting_mode: $$Props["sorting_mode"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
     export let sizing: $$Props["sizing"] = undefined;
@@ -127,13 +127,13 @@
     function on_sorting_click(key: IDataTableKey, event: MouseEvent): void {
         if (sorting !== key) {
             sorting = key;
-            sort_by = TOKENS_SORT_BY.ascending;
+            sorting_mode = TOKENS_SORT_BY.ascending;
 
             return;
         }
 
-        sort_by =
-            sort_by === TOKENS_SORT_BY.ascending
+        sorting_mode =
+            sorting_mode === TOKENS_SORT_BY.ascending
                 ? TOKENS_SORT_BY.decending
                 : TOKENS_SORT_BY.ascending;
     }
@@ -148,7 +148,7 @@
 
         if (sorting) {
             const column = columns.find((_column) => _column.key === sorting);
-            if (column?.sorting_enabled) {
+            if (column?.sorting) {
                 _view = _view.sort((a, b) => {
                     // HACK: TypeScript or Svelte just isn't smart enough to infer `sorting` is
                     // a string in this nested enclosure
@@ -160,7 +160,7 @@
                         ? column.sorting_algorithm(a_value, b_value)
                         : default_sort(a_value, b_value);
 
-                    return sort_by === TOKENS_SORT_BY.ascending ? delta : delta * -1;
+                    return sorting_mode === TOKENS_SORT_BY.ascending ? delta : delta * -1;
                 });
             }
         }
@@ -181,7 +181,7 @@
                 <Table.Heading>
                     {column.text}
 
-                    {#if column.sorting_enabled}
+                    {#if column.sorting}
                         <Button
                             disabled={!IS_BROWSER}
                             variation={["subtle", "clear"]}
@@ -190,7 +190,7 @@
                             on:click={on_sorting_click.bind(null, column.key)}
                         >
                             {#if sorting === column.key}
-                                {#if sort_by === TOKENS_SORT_BY.ascending}
+                                {#if sorting_mode === TOKENS_SORT_BY.ascending}
                                     <slot name="ascending">&uuarr;</slot>
                                 {:else}
                                     <slot name="decending">&ddarr;</slot>

--- a/src/lib/components/widgets/datatable/DataTable.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.svelte
@@ -66,7 +66,9 @@
 
     type $$Slots = {
         default: {key: IDataTableKey; row: IDataTableRow};
+
         next: {};
+
         previous: {};
     };
 
@@ -255,7 +257,7 @@
         {/each}
     </Table.Section>
 
-    {#if IS_BROWSER && paginate}
+    {#if IS_BROWSER}
         <Table.Footer>
             <Table.Row>
                 <Table.Column>
@@ -270,49 +272,51 @@
                 </Table.Column>
 
                 <Table.Column colspan={columns.length}>
-                    <Stack
-                        orientation="horizontal"
-                        alignment_x="right"
-                        alignment_y="center"
-                        spacing="small"
-                    >
-                        <NumberInput
-                            characters="1"
-                            value={_page}
-                            align="right"
-                            {palette}
-                            size={sizing}
-                            actions={[
-                                [navigate_up, {on_bind: on_paging_step.bind(null, 1)}],
-                                [navigate_down, {on_bind: on_paging_step.bind(null, -1)}],
-                            ]}
-                            on:focusout={on_paging_focus_out}
-                            on:input={debounce(on_paging_input, 250)}
-                        />
-
-                        <span>/</span>
-                        <span>{_pages}</span>
-
-                        <Button
-                            disabled={_page === 1}
-                            variation={["subtle", "clear"]}
-                            size={sizing}
-                            {palette}
-                            on:click={on_paging_step.bind(null, -1)}
+                    {#if paginate}
+                        <Stack
+                            orientation="horizontal"
+                            alignment_x="right"
+                            alignment_y="center"
+                            spacing="small"
                         >
-                            <slot name="previous">&lt;</slot>
-                        </Button>
+                            <NumberInput
+                                characters="1"
+                                value={_page}
+                                align="right"
+                                {palette}
+                                size={sizing}
+                                actions={[
+                                    [navigate_up, {on_bind: on_paging_step.bind(null, 1)}],
+                                    [navigate_down, {on_bind: on_paging_step.bind(null, -1)}],
+                                ]}
+                                on:focusout={on_paging_focus_out}
+                                on:input={debounce(on_paging_input, 250)}
+                            />
 
-                        <Button
-                            disabled={_page === _pages}
-                            variation={["subtle", "clear"]}
-                            size={sizing}
-                            {palette}
-                            on:click={on_paging_step.bind(null, 1)}
-                        >
-                            <slot name="next">&gt;</slot>
-                        </Button>
-                    </Stack>
+                            <span>/</span>
+                            <span>{_pages}</span>
+
+                            <Button
+                                disabled={_page === 1}
+                                variation={["subtle", "clear"]}
+                                size={sizing}
+                                {palette}
+                                on:click={on_paging_step.bind(null, -1)}
+                            >
+                                <slot name="previous">&lt;</slot>
+                            </Button>
+
+                            <Button
+                                disabled={_page === _pages}
+                                variation={["subtle", "clear"]}
+                                size={sizing}
+                                {palette}
+                                on:click={on_paging_step.bind(null, 1)}
+                            >
+                                <slot name="next">&gt;</slot>
+                            </Button>
+                        </Stack>
+                    {/if}
                 </Table.Column>
             </Table.Row>
         </Table.Footer>

--- a/src/lib/components/widgets/datatable/DataTable.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.svelte
@@ -271,6 +271,7 @@
                         <TextInput
                             characters="10"
                             size={sizing}
+                            value={searching}
                             {palette}
                             on:input={debounce(on_searching_input, 250)}
                         />

--- a/src/lib/components/widgets/datatable/DataTable.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.svelte
@@ -69,7 +69,7 @@
 
         ascending: {};
 
-        decending: {};
+        descending: {};
 
         next: {};
 
@@ -170,7 +170,7 @@
 
         sorting_mode =
             sorting_mode === TOKENS_SORTING_MODE.ascending
-                ? TOKENS_SORTING_MODE.decending
+                ? TOKENS_SORTING_MODE.descending
                 : TOKENS_SORTING_MODE.ascending;
     }
 
@@ -241,7 +241,7 @@
                                 {#if sorting_mode === TOKENS_SORTING_MODE.ascending}
                                     <slot name="ascending">&uuarr;</slot>
                                 {:else}
-                                    <slot name="decending">&ddarr;</slot>
+                                    <slot name="descending">&ddarr;</slot>
                                 {/if}
                             {:else}
                                 <slot name="unsorted">&udarr;</slot>

--- a/src/lib/components/widgets/datatable/DataTable.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.svelte
@@ -101,10 +101,14 @@
     export let variation: $$Props["variation"] = undefined;
 
     function default_search(row: IDataTableRow): boolean {
+        // HACK: TypeScript can't obviously know this is only called whenever
+        // the `searching` property DOES have a string
+        const _searching = (searching as string).toLowerCase();
+
         for (const key in row) {
             const value = row[key].toLowerCase();
 
-            if (value.includes(searching)) return true;
+            if (value.includes(_searching)) return true;
         }
 
         return false;

--- a/src/lib/components/widgets/datatable/DataTable.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.svelte
@@ -67,9 +67,15 @@
     type $$Slots = {
         default: {key: IDataTableKey; row: IDataTableRow};
 
+        ascending: {};
+
+        decending: {};
+
         next: {};
 
         previous: {};
+
+        unsorted: {};
     };
 
     export let element: $$Props["element"] = undefined;

--- a/src/lib/components/widgets/datatable/index.ts
+++ b/src/lib/components/widgets/datatable/index.ts
@@ -1,0 +1,1 @@
+export {default as DataTable} from "./DataTable.svelte";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -138,3 +138,4 @@ export * from "./stores/scrolllock";
 export * from "./stores/viewport";
 
 export * from "./util/environment";
+export * from "./util/keybind";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -14,6 +14,7 @@ export * from "./types/resizable";
 export * from "./types/shapes";
 export * from "./types/sizes";
 export * from "./types/sizings";
+export * from "./types/sorting";
 export * from "./types/spacings";
 export * from "./types/typography";
 export * from "./types/variations";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -106,6 +106,7 @@ export * from "./components/utilities/serverrender";
 export * from "./components/utilities/transition";
 export * from "./components/utilities/viewportrender";
 
+export * from "./components/widgets/datatable";
 export * from "./components/widgets/daypicker";
 export * from "./components/widgets/daystepper";
 export * from "./components/widgets/monthpicker";

--- a/src/lib/types/sorting.ts
+++ b/src/lib/types/sorting.ts
@@ -6,7 +6,7 @@ import type {LiteralEnum} from "./util";
 export enum TOKENS_SORTING_MODE {
     ascending = "ascending",
 
-    decending = "decending",
+    descending = "descending",
 }
 
 export type PROPERTY_SORTING_MODE = LiteralEnum<TOKENS_SORTING_MODE>;

--- a/src/lib/types/sorting.ts
+++ b/src/lib/types/sorting.ts
@@ -3,10 +3,10 @@ import type {LiteralEnum} from "./util";
 /**
  * Represents the sorting modes that can be applied to Framework Components
  */
-export enum TOKENS_SORT_BY {
+export enum TOKENS_SORTING_MODE {
     ascending = "ascending",
 
     decending = "decending",
 }
 
-export type PROPERTY_SORT_BY = LiteralEnum<TOKENS_SORT_BY>;
+export type PROPERTY_SORTING_MODE = LiteralEnum<TOKENS_SORTING_MODE>;

--- a/src/lib/types/sorting.ts
+++ b/src/lib/types/sorting.ts
@@ -1,0 +1,12 @@
+import type {LiteralEnum} from "./util";
+
+/**
+ * Represents the sorting modes that can be applied to Framework Components
+ */
+export enum TOKENS_SORT_BY {
+    ascending = "ascending",
+
+    decending = "decending",
+}
+
+export type PROPERTY_SORT_BY = LiteralEnum<TOKENS_SORT_BY>;

--- a/src/lib/util/keybind.ts
+++ b/src/lib/util/keybind.ts
@@ -49,3 +49,61 @@ export const action_activate = make_shortcut_factory({
 export const action_exit = make_shortcut_factory({
     binds: ["escape"],
 });
+
+/**
+ * Represents a keybind used for submitting the currently focused element
+ * @param element
+ * @param options
+ * @returns
+ */
+export const action_submit = make_shortcut_factory({
+    binds: ["enter"],
+});
+
+/**
+ * Represents a keybind used for navigating to the next available navigation option downwards
+ * @param element
+ * @param options
+ * @returns
+ */
+export const navigate_down = make_shortcut_factory({
+    binds: ["arrowdown"],
+    repeat: true,
+    repeat_throttle: 250,
+});
+
+/**
+ * Represents a keybind used for navigating to the next available navigation option leftwards
+ * @param element
+ * @param options
+ * @returns
+ */
+export const navigate_left = make_shortcut_factory({
+    binds: ["arrowleft"],
+    repeat: true,
+    repeat_throttle: 250,
+});
+
+/**
+ * Represents a keybind used for navigating to the next available navigation option rightwards
+ * @param element
+ * @param options
+ * @returns
+ */
+export const navigate_right = make_shortcut_factory({
+    binds: ["arrowright"],
+    repeat: true,
+    repeat_throttle: 250,
+});
+
+/**
+ * Represents a keybind used for navigating to the next available navigation option upwards
+ * @param element
+ * @param options
+ * @returns
+ */
+export const navigate_up = make_shortcut_factory({
+    binds: ["arrowup"],
+    repeat: true,
+    repeat_throttle: 250,
+});


### PR DESCRIPTION
# CHANGELOG

-   Added the following Actions / Action Features

    -   `action_activate(element: HTMLElement, options: {on_bind: IKeybindCallback}): IKeybindHandle` — Used for activating the current context, e.g. a focused label.

        -   `Enter`, ` ` _(space)_

    -   `action_exit(element: HTMLElement, options: {on_bind: IKeybindCallback}): IKeybindHandle` — Used for exiting the current context, e.g. a prompt.

        -   `Esc`

    -   `action_submit(element: HTMLElement, options: {on_bind: IKeybindCallback}): IKeybindHandle` — Used for submitting the current context, e.g. a focused input.

        -   `Enter`

    -   `navigate_down(element: HTMLElement, options: {on_bind: IKeybindCallback}): IKeybindHandle` — Used for navigating to the next item down.

        -   `ArrowDown`
        -   Repeatable, `250ms` throttle

    -   `navigate_left(element: HTMLElement, options: {on_bind: IKeybindCallback}): IKeybindHandle` — Used for navigating to the next item left.

        -   `ArrowLeft`
        -   Repeatable, `250ms` throttle

    -   `navigate_right(element: HTMLElement, options: {on_bind: IKeybindCallback}): IKeybindHandle` — Used for navigating to the next item right.

        -   `ArrowRight`
        -   Repeatable, `250ms` throttle

    -   `navigate_up(element: HTMLElement, options: {on_bind: IKeybindCallback}): IKeybindHandle` — Used for navigating to the next item up.

        -   `ArrowUp`
        -   Repeatable, `250ms` throttle

-   Added the following Components / Component Features

    -   Widgets

        -   `DataTable` — Automatically handles rendering tabular data of rows and columns into HTML.

            -   `<DataTable columns={{key: keyof T, text: string}[]}>` — Configures metadata on how `DataTable` should renders the tabular data.
            -   `<DataTable rows={T[]}>` — Sets the tabular data that `DataTable` is to render.

            -   `<DataTable page={number | string}>` — Sets the current page of the pagination.
            -   `<DataTable paginate={boolean}>` — Enables `DataTable` to split the tabular data into paged views.
            -   `<DataTable paging={number | string}>` — Sets how many rows should appear per page.

            -   `<DataTable sorting={keyof T}>` — Sets which row member that `DataTable` is currently sorting by.

                -   `<DataTable columns={{sorting: boolean}[]}>` — Enables sorting for the particular column.
                -   `<DataTable columns={{sorting_algorithm: (a: T[keyof T], b: T[keyof T]) => number}[]}>` — Optional custom sorter. By default, all row members are lowercased and alphabetized.

            -   `<DataTable sorting_mode="ascending/descending">` — Sets which direction `DataTable` is sorting the row member by.

            -   `<DataTable searching={string}>` — Sets the current search query that `DataTable` is using to filter the tabular data.
            -   `<DataTable searching_algorithm={(row: T) => boolean}>` — Optional custom searching filter. By default, all row members are lowercased and fuzzy searched.

            -   `<DataTable palette="accent/dark/light/alert/affirmative/negative">` — Alters the rendered color palette.
            -   `<DataTable sizing="tiny/small/medium/large/huge">` — Alters the sizing of the Widget and children Components.
            -   `<DataTable variation={"borders" | "stripes" | ["borders", "stripes"]}>` — Alters the appearance of the Component.

            -   `<svelte:fragment let:key={keyof T} let:row={T}>` — Customizes how each column in a row is rendered in a table cell.
            -   `<svelte:fragment slot="next/previous">` — Customizes the next / previous paging button content.
            -   `<svelte:fragment slot="unsorted/ascending/descending">` — Customizes the not-sorted, ascending sort, descending sort button content.