### PR TITLE
[0.5.4] Add `0.6.0` Aliases + Deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,14 @@
 
                 -   **NOTE**: `<Text alignment_x>` was made available as an alias in this release, to help with progressively migrating codebases.
 
+-   Deprecated the following Stores / Store Features
+
+    -   `htmlpalette`
+
+        -   **(BREAKING)** Being renamed to `htmlmode` due to theme mode attribute being changed `<html data-palette="dark/light">` -> `<html data-mode="dark/light">`.
+
+            -   **NOTE**: `htmlmode` was made available as an alias in this release, to help with progressively migrating codebases.
+
 ## 0.5.3 - 2022/01/08
 
 -   Added the following Actions / Action Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,126 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Deprecated the following Components / Component Features
+
+    -   Embedded
+
+        -   `Figure`
+
+            -   **(BREAKING)** `<Figure variation="icon">` — Being replaced with global `icon-` prefixed `size` property values, e.g. `size="icon-small"`.
+
+    -   Feedback
+
+        -   `Progress`
+
+            -   **(BREAKING)** `<Progress size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.
+
+                -   **NOTE**: `<Progress sizing>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+        -   `Spinner`
+
+            -   **(BREAKING)** `<Spinner size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.
+
+                -   **NOTE**: `<Spinner sizing>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+    -   Interactables
+
+        -   `Button`
+
+            -   **(BREAKING)** `<Button size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.
+
+                -   **NOTE**: `<Button sizing>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+        -   `Check`
+
+            -   **(BREAKING)** `<Check size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.
+
+                -   **NOTE**: `<Check sizing>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+        -   `NumberInput`
+
+            -   **(BREAKING)** `<NumberInput align>` — Being consolidated into `alignment_x` property, e.g. `alignment_x="justify"`.
+
+                -   **NOTE**: `<NumberInput alignment_x>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+            -   **(BREAKING)** `<NumberInput size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.
+
+                -   **NOTE**: `<NumberInput sizing>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+        -   `Radio`
+
+            -   **(BREAKING)** `<Radio size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.
+
+                -   **NOTE**: `<Radio sizing>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+        -   `Switch`
+
+            -   **(BREAKING)** `<Switch size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.
+
+                -   **NOTE**: `<Switch sizing>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+        -   `TextInput`
+
+            -   **(BREAKING)** `<TextInput align>` — Being consolidated into `alignment_x` property, e.g. `alignment_x="justify"`.
+
+                -   **NOTE**: `<TextInput alignment_x>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+            -   **(BREAKING)** `<TextInput size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.
+
+                -   **NOTE**: `<TextInput sizing>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+    -   Layouts
+
+        -   `Container`
+
+            -   **(BREAKING)** `<Container viewport>` — Being replaced with global `viewport-` prefixed `max_width` property values, e.g. `max_width="viewport-mobile"`.
+
+        -   `Mosaic`
+
+            -   **(BREAKING)** `<Mosaic>` — Being converted into a multi-part Component, `<Mosaic.Container>`.
+
+        -   `Stack`
+
+            -   **(BREAKING)** `<Stack>` — Being converted into a multi-part Component, `<Stack.Container>`.
+
+    -   Navigation
+
+        -   `Menu`
+
+            -   **(BREAKING)** `<Menu.Divider>` / `<Menu.Heading>` `slot="sub-menu"` — DOM tree structure for `Menu` will be restructured, removing the need for the slot.
+            -   **(BREAKING)** `<Menu.SubMenu>` — Being renamed to Framework-consistent `<Menu.Section>`.
+
+                -   **NOTE**: `<Menu.Section>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+    -   Overlays
+
+        -   `Overlay`
+
+            -   **(BREAKING)** `<Overlay.Button size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.
+
+                -   **NOTE**: `<Overlay.Button sizing>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+        -   `Popover`
+
+            -   **(BREAKING)** `<Popover.Button size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.
+
+                -   **NOTE**: `<Popover.Button sizing>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+    -   Typography
+
+        -   `Heading`
+
+            -   **(BREAKING)** `<Heading align>` — Being consolidated into `alignment_x` property, e.g. `alignment_x="justify"`.
+
+                -   **NOTE**: `<Heading alignment_x>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+        -   `Text`
+
+            -   **(BREAKING)** `<Text align>` — Being consolidated into `alignment_x` property, e.g. `alignment_x="justify"`.
+
+                -   **NOTE**: `<Text alignment_x>` was made available as an alias in this release, to help with progressively migrating codebases.
+
 ## 0.5.3 - 2022/01/08
 
 -   Added the following Actions / Action Features

--- a/src/lib/components/embedded/figure/Figure.svelte
+++ b/src/lib/components/embedded/figure/Figure.svelte
@@ -21,6 +21,9 @@
         fit?: PROPERTY_FIT;
         shape?: PROPERTY_SHAPE;
         size?: PROPERTY_SIZING;
+        /**
+         * @deprecated Removed in `0.6.0` for `icon-` prefixed global sizes
+         */
         variation?: "icon";
     } & IHTML5Properties &
         IGlobalProperties &

--- a/src/lib/components/feedback/progress/Progress.svelte
+++ b/src/lib/components/feedback/progress/Progress.svelte
@@ -30,7 +30,11 @@
 
         palette?: PROPERTY_PALETTE;
         shape?: "circle";
+        /**
+         * @deprecated Use `<Progress sizing="...">` instead.
+         */
         size?: PROPERTY_SIZING;
+        sizing?: PROPERTY_SIZING;
     } & IHTML5Properties &
         IGlobalProperties &
         IMarginProperties;
@@ -44,7 +48,11 @@
 
     export let palette: $$Props["palette"] = undefined;
     export let shape: $$Props["shape"] = undefined;
+    /**
+     * @deprecated Use `<Progress sizing="...">` instead.
+     */
     export let size: $$Props["size"] = undefined;
+    export let sizing: $$Props["sizing"] = undefined;
 </script>
 
 <div
@@ -55,7 +63,7 @@
     })}
     role="progressbar"
     {...map_aria_attributes({valuemax: 1, valuemin: 0, valuenow: value})}
-    {...map_data_attributes({palette, size})}
+    {...map_data_attributes({palette, size: size ?? sizing})}
     use:forward_actions={{actions}}
     on:click
     on:contextmenu

--- a/src/lib/components/feedback/spinner/Spinner.svelte
+++ b/src/lib/components/feedback/spinner/Spinner.svelte
@@ -17,7 +17,11 @@
         element?: HTMLSpanElement;
 
         palette?: PROPERTY_PALETTE;
+        /**
+         * @deprecated Use `<Spinner sizing="...">` instead.
+         */
         size?: PROPERTY_SIZING;
+        sizing?: PROPERTY_SIZING;
     } & IHTML5Properties &
         IGlobalProperties &
         IMarginProperties;
@@ -29,14 +33,18 @@
     export {_class as class};
 
     export let palette: $$Props["palette"] = undefined;
+    /**
+     * @deprecated Use `<Spinner sizing="...">` instead.
+     */
     export let size: $$Props["size"] = undefined;
+    export let sizing: $$Props["sizing"] = undefined;
 </script>
 
 <span
     bind:this={element}
     {...map_global_attributes($$props)}
     class="spinner {_class}"
-    {...map_data_attributes({palette, size})}
+    {...map_data_attributes({palette, size: size ?? sizing})}
     use:forward_actions={{actions}}
     on:click
     on:contextmenu

--- a/src/lib/components/interactables/button/Button.svelte
+++ b/src/lib/components/interactables/button/Button.svelte
@@ -37,7 +37,11 @@
         for?: string;
 
         palette?: PROPERTY_PALETTE;
+        /**
+         * @deprecated Use `<Button sizing="...">` instead.
+         */
         size?: PROPERTY_SIZING;
+        sizing?: PROPERTY_SIZING;
         variation?: PROPERTY_VARIATION_BUTTON;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -69,7 +73,11 @@
     export {_for as for};
 
     export let palette: $$Props["palette"] = undefined;
+    /**
+     * @deprecated Use `<Button sizing="...">` instead.
+     */
     export let size: $$Props["size"] = undefined;
+    export let sizing: $$Props["sizing"] = undefined;
     export let variation: $$Props["variation"] = undefined;
 
     // HACK: Svelte has `tabindex` typed as `number | undefined` unless
@@ -83,7 +91,7 @@
         {...map_global_attributes($$props)}
         role="button"
         class="button {_class}"
-        {...map_data_attributes({palette, size, variation})}
+        {...map_data_attributes({palette, size: size ?? sizing, variation})}
         {...map_aria_attributes({active, disabled})}
         {download}
         {href}
@@ -115,7 +123,7 @@
         class="button {_class}"
         for={_for}
         tabindex={_tabindex}
-        {...map_data_attributes({palette, size, variation})}
+        {...map_data_attributes({palette, size: size ?? sizing, variation})}
         {...map_aria_attributes({disabled, pressed: active})}
         use:behavior_button={{enabled: true}}
         use:forward_actions={{actions}}
@@ -142,7 +150,7 @@
             bind:this={element}
             {...map_global_attributes($$props)}
             type="reset"
-            {...map_data_attributes({palette, size, variation})}
+            {...map_data_attributes({palette, size: size ?? sizing, variation})}
             {...map_aria_attributes({pressed: active})}
             {...map_attributes({disabled, value})}
             use:forward_actions={{actions}}
@@ -166,7 +174,7 @@
             bind:this={element}
             {...map_global_attributes($$props)}
             type="submit"
-            {...map_data_attributes({palette, size, variation})}
+            {...map_data_attributes({palette, size: size ?? sizing, variation})}
             {...map_aria_attributes({pressed: active})}
             {...map_attributes({disabled, value})}
             use:forward_actions={{actions}}
@@ -190,7 +198,7 @@
             bind:this={element}
             {...map_global_attributes($$props)}
             type="button"
-            {...map_data_attributes({palette, size, variation})}
+            {...map_data_attributes({palette, size: size ?? sizing, variation})}
             {...map_aria_attributes({pressed: active})}
             {...map_attributes({disabled, value})}
             use:forward_actions={{actions}}
@@ -214,7 +222,7 @@
     <button
         bind:this={element}
         {...map_global_attributes($$props)}
-        {...map_data_attributes({palette, size, variation})}
+        {...map_data_attributes({palette, size: size ?? sizing, variation})}
         {...map_aria_attributes({pressed: active})}
         {...map_attributes({disabled})}
         use:forward_actions={{actions}}

--- a/src/lib/components/interactables/check/Check.svelte
+++ b/src/lib/components/interactables/check/Check.svelte
@@ -38,7 +38,11 @@
         value?: string;
 
         palette?: PROPERTY_PALETTE;
+        /**
+         * @deprecated Use `<Check sizing="...">` instead.
+         */
         size?: PROPERTY_SIZING;
+        sizing?: PROPERTY_SIZING;
         variation?: PROPERTY_VARIATION_TOGGLE;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -60,7 +64,11 @@
     export let value: $$Props["value"] = "";
 
     export let palette: $$Props["palette"] = undefined;
+    /**
+     * @deprecated Use `<Check sizing="...">` instead.
+     */
     export let size: $$Props["size"] = undefined;
+    export let sizing: $$Props["sizing"] = undefined;
     export let variation: $$Props["variation"] = undefined;
 
     const _form_id = CONTEXT_FORM_ID.get();
@@ -89,7 +97,7 @@
                 bind:this={element}
                 {...map_global_attributes($$props)}
                 type="checkbox"
-                {...map_data_attributes({palette, size, variation})}
+                {...map_data_attributes({palette, size: size ?? sizing, variation})}
                 {...map_aria_attributes({pressed: active})}
                 {...map_attributes({
                     disabled,
@@ -126,7 +134,7 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         type="checkbox"
-        {...map_data_attributes({palette, size, variation})}
+        {...map_data_attributes({palette, size: size ?? sizing, variation})}
         {...map_aria_attributes({pressed: active})}
         {...map_attributes({
             disabled,

--- a/src/lib/components/interactables/numberinput/NumberInput.svelte
+++ b/src/lib/components/interactables/numberinput/NumberInput.svelte
@@ -43,9 +43,17 @@
 
         characters?: number | string;
 
+        /**
+         * @deprecated Use `<NumberInput alignment_x="...">` instead.
+         */
         align?: PROPERTY_TEXT_ALIGNMENT;
+        alignment_x?: PROPERTY_TEXT_ALIGNMENT;
         palette?: PROPERTY_PALETTE;
+        /**
+         * @deprecated Use `<NumberInput sizing="...">` instead.
+         */
         size?: PROPERTY_SIZING;
+        sizing?: PROPERTY_SIZING;
         variation?: PROPERTY_VARIATION_INPUT;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -67,9 +75,17 @@
 
     export let characters: $$Props["characters"] = undefined;
 
+    /**
+     * @deprecated Use `<NumberInput alignment_x="...">` instead.
+     */
     export let align: $$Props["align"] = undefined;
+    export let alignment_x: $$Props["alignment_x"] = undefined;
     export let palette: $$Props["palette"] = undefined;
+    /**
+     * @deprecated Use `<NumberInput sizing="...">` instead.
+     */
     export let size: $$Props["size"] = undefined;
+    export let sizing: $$Props["sizing"] = undefined;
     export let variation: $$Props["variation"] = undefined;
 
     let _value: string | undefined = value?.toString();
@@ -93,7 +109,12 @@
     bind:this={element}
     {...map_global_attributes($$props)}
     type="text"
-    {...map_data_attributes({align, palette, size, variation})}
+    {...map_data_attributes({
+        align: align ?? alignment_x,
+        palette,
+        size: size ?? sizing,
+        variation,
+    })}
     {...map_attributes({
         disabled,
         id: _id,

--- a/src/lib/components/interactables/radio/Radio.svelte
+++ b/src/lib/components/interactables/radio/Radio.svelte
@@ -38,7 +38,11 @@
         value?: string;
 
         palette?: PROPERTY_PALETTE;
+        /**
+         * @deprecated Use `<Radio sizing="...">` instead.
+         */
         size?: PROPERTY_SIZING;
+        sizing?: PROPERTY_SIZING;
         variation?: PROPERTY_VARIATION_TOGGLE;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -60,7 +64,11 @@
     export let value: $$Props["value"] = "";
 
     export let palette: $$Props["palette"] = undefined;
+    /**
+     * @deprecated Use `<Radio sizing="...">` instead.
+     */
     export let size: $$Props["size"] = undefined;
+    export let sizing: $$Props["sizing"] = undefined;
     export let variation: $$Props["variation"] = undefined;
 
     const _form_id = CONTEXT_FORM_ID.get();
@@ -89,7 +97,7 @@
                 bind:this={element}
                 {...map_global_attributes($$props)}
                 type="radio"
-                {...map_data_attributes({palette, size, variation})}
+                {...map_data_attributes({palette, size: size ?? sizing, variation})}
                 {...map_aria_attributes({pressed: active})}
                 {...map_attributes({
                     disabled,
@@ -126,7 +134,7 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         type="radio"
-        {...map_data_attributes({palette, size, variation})}
+        {...map_data_attributes({palette, size: size ?? sizing, variation})}
         {...map_aria_attributes({pressed: active})}
         {...map_attributes({
             disabled,

--- a/src/lib/components/interactables/switch/Switch.svelte
+++ b/src/lib/components/interactables/switch/Switch.svelte
@@ -36,8 +36,12 @@
         state?: boolean;
         value?: string;
 
-        palette?: PROPERTY_PALETTE;
+        palette?: PROPERTY_PALETTE
+        /**
+         * @deprecated Use `<Switch sizing="...">` instead.
+         */;
         size?: PROPERTY_SIZING;
+        sizing?: PROPERTY_SIZING;
     } & IHTML5Properties &
         IGlobalProperties &
         IMarginProperties;
@@ -58,7 +62,11 @@
     export let value: $$Props["value"] = "";
 
     export let palette: $$Props["palette"] = undefined;
+    /**
+     * @deprecated Use `<Switch sizing="...">` instead.
+     */
     export let size: $$Props["size"] = undefined;
+    export let sizing: $$Props["sizing"] = undefined;
 
     const _form_id = CONTEXT_FORM_ID.get();
     const _form_name = CONTEXT_FORM_NAME.get();
@@ -87,7 +95,7 @@
                 {...map_global_attributes($$props)}
                 type="checkbox"
                 role="switch"
-                {...map_data_attributes({palette, size})}
+                {...map_data_attributes({palette, size: size ?? sizing})}
                 {...map_aria_attributes({pressed: active})}
                 {...map_attributes({
                     disabled,
@@ -125,7 +133,7 @@
         {...map_global_attributes($$props)}
         type="checkbox"
         role="switch"
-        {...map_data_attributes({palette, size})}
+        {...map_data_attributes({palette, size: size ?? sizing})}
         {...map_aria_attributes({pressed: active})}
         {...map_attributes({
             disabled,

--- a/src/lib/components/interactables/textinput/TextInput.svelte
+++ b/src/lib/components/interactables/textinput/TextInput.svelte
@@ -56,9 +56,17 @@
         resizable?: PROPERTY_RESIZEABLE;
         spell_check?: boolean;
 
+        /**
+         * @deprecated Use `<TextInput alignment_x="...">` instead.
+         */
         align?: PROPERTY_TEXT_ALIGNMENT;
+        alignment_x?: PROPERTY_TEXT_ALIGNMENT;
         palette?: PROPERTY_PALETTE;
+        /**
+         * @deprecated Use `<TextInput sizing="...">` instead.
+         */
         size?: PROPERTY_SIZING;
+        sizing?: PROPERTY_SIZING;
         transform?: PROPERTY_TEXT_TRANSFORM;
         variation?: PROPERTY_VARIATION_INPUT;
     } & IHTML5Properties &
@@ -95,9 +103,17 @@
     export let resizable: $$Props["resizable"] = undefined;
     export let spell_check: $$Props["spell_check"] = undefined;
 
+    /**
+     * @deprecated Use `<TextInput alignment_x="...">` instead.
+     */
     export let align: $$Props["align"] = undefined;
+    export let alignment_x: $$Props["alignment_x"] = undefined;
     export let palette: $$Props["palette"] = undefined;
+    /**
+     * @deprecated Use `<TextInput sizing="...">` instead.
+     */
     export let size: $$Props["size"] = undefined;
+    export let sizing: $$Props["sizing"] = undefined;
     export let transform: $$Props["transform"] = undefined;
     export let variation: $$Props["variation"] = undefined;
 
@@ -118,7 +134,14 @@
     <textarea
         bind:this={element}
         {...map_global_attributes($$props)}
-        {...map_data_attributes({align, palette, resizable, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            resizable,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         {...map_attributes({
             cols: characters,
             disabled,
@@ -157,7 +180,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         type="email"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         {...map_attributes({
             disabled,
             id: _id,
@@ -196,7 +225,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         type="password"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         {...map_attributes({
             disabled,
             id: _id,
@@ -235,7 +270,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         type="search"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         {...map_attributes({
             disabled,
             id: _id,
@@ -274,7 +315,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         type="url"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         {...map_attributes({
             disabled,
             id: _id,
@@ -313,7 +360,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         type="text"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         {...map_attributes({
             disabled,
             id: _id,

--- a/src/lib/components/layouts/container/Container.svelte
+++ b/src/lib/components/layouts/container/Container.svelte
@@ -18,6 +18,9 @@
 
         is?: "div" | "main";
 
+        /**
+         * @deprecated Removed in `0.6.0` in favor of `viewport-` prefixed `width` / `max_width` globals
+         */
         viewport?: PROPERTY_VIEWPORT_BREAKPOINT;
     } & IHTML5Properties &
         IGlobalProperties &

--- a/src/lib/components/layouts/mosaic/index.ts
+++ b/src/lib/components/layouts/mosaic/index.ts
@@ -1,1 +1,6 @@
-export {default as Mosaic} from "./Mosaic.svelte";
+import _Mosaic from "./Mosaic.svelte";
+
+/**
+ * @deprecated Updated into a multi-part `<Mosaic.Container>` Component in `0.6.0`.
+ */
+export const Mosaic = _Mosaic;

--- a/src/lib/components/layouts/stack/index.ts
+++ b/src/lib/components/layouts/stack/index.ts
@@ -1,1 +1,6 @@
-export {default as Stack} from "./Stack.svelte";
+import _Stack from "./Stack.svelte";
+
+/**
+ * @deprecated Updated into a multi-part `<Stack.Container>` Component in `0.6.0`.
+ */
+export const Stack = _Stack;

--- a/src/lib/components/navigation/menu/MenuDivider.svelte
+++ b/src/lib/components/navigation/menu/MenuDivider.svelte
@@ -18,6 +18,9 @@
     type $$Slots = {
         default: {};
 
+        /**
+         * @deprecated `Menu` DOM structure is being updated in `0.6.0`, removing need for `sub-menu` slot.
+         */
         "sub-menu": {};
     };
 

--- a/src/lib/components/navigation/menu/MenuHeading.svelte
+++ b/src/lib/components/navigation/menu/MenuHeading.svelte
@@ -18,6 +18,9 @@
     type $$Slots = {
         default: {};
 
+        /**
+         * @deprecated `Menu` DOM structure is being updated in `0.6.0`, removing need for `sub-menu` slot.
+         */
         "sub-menu": {};
     };
 

--- a/src/lib/components/navigation/menu/index.ts
+++ b/src/lib/components/navigation/menu/index.ts
@@ -6,4 +6,12 @@ export {default as Divider} from "./MenuDivider.svelte";
 export {default as Heading} from "./MenuHeading.svelte";
 export {default as Item} from "./MenuItem.svelte";
 export {default as Label} from "./MenuLabel.svelte";
-export {default as SubMenu} from "./MenuSubMenu.svelte";
+
+import _SubMenu from "./MenuSubMenu.svelte";
+
+/**
+ * @deprecated Use `<Menu.Section>` instead.
+ */
+export const SubMenu = _SubMenu;
+
+export const Section = _SubMenu;

--- a/src/lib/components/overlays/overlay/OverlayButton.svelte
+++ b/src/lib/components/overlays/overlay/OverlayButton.svelte
@@ -21,8 +21,12 @@
         active?: boolean;
         disabled?: boolean;
 
-        palette?: PROPERTY_PALETTE;
+        palette?: PROPERTY_PALETTE
+        /**
+         * @deprecated Use `<Overlay.Button sizing="...">` instead.
+         */;
         size?: PROPERTY_SIZING;
+        sizing?: PROPERTY_SIZING;
         variation?: PROPERTY_VARIATION_BUTTON;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -41,7 +45,11 @@
     export let disabled: $$Props["disabled"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
+    /**
+     * @deprecated Use `<Overlay.Button sizing="...">` instead.
+     */
     export let size: $$Props["size"] = undefined;
+    export let sizing: $$Props["sizing"] = undefined;
     export let variation: $$Props["variation"] = undefined;
 
     const _overlay_id = CONTEXT_OVERLAY_ID.get();
@@ -57,11 +65,11 @@
     {...$$props}
     bind:element
     for={$_overlay_id}
+    size={size ?? sizing}
     {actions}
     {active}
     {disabled}
     {palette}
-    {size}
     {variation}
     {tabindex}
     on:click

--- a/src/lib/components/overlays/popover/PopoverButton.svelte
+++ b/src/lib/components/overlays/popover/PopoverButton.svelte
@@ -22,7 +22,11 @@
         disabled?: boolean;
 
         palette?: PROPERTY_PALETTE;
+        /**
+         * @deprecated Use `<Popover.Button sizing="...">` instead.
+         */
         size?: PROPERTY_SIZING;
+        sizing?: PROPERTY_SIZING;
         variation?: PROPERTY_VARIATION_BUTTON;
     } & IHTML5Properties &
         IGlobalProperties &
@@ -41,7 +45,11 @@
     export let disabled: $$Props["disabled"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
+    /**
+     * @deprecated Use `<Popover.Button sizing="...">` instead.
+     */
     export let size: $$Props["size"] = undefined;
+    export let sizing: $$Props["sizing"] = undefined;
     export let variation: $$Props["variation"] = undefined;
 
     const _popover_id = CONTEXT_POPOVER_ID.get();
@@ -57,11 +65,11 @@
     {...$$props}
     bind:element
     for={$_popover_id}
+    size={size ?? sizing}
     {actions}
     {active}
     {disabled}
     {palette}
-    {size}
     {variation}
     {tabindex}
     on:click

--- a/src/lib/components/typography/heading/Heading.svelte
+++ b/src/lib/components/typography/heading/Heading.svelte
@@ -23,7 +23,11 @@
 
         is?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 
+        /**
+         * @deprecated Use `<Heading alignment_x="...">` instead.
+         */
         align?: PROPERTY_TEXT_ALIGNMENT;
+        alignment_x?: PROPERTY_TEXT_ALIGNMENT;
         transform?: PROPERTY_TEXT_TRANSFORM;
 
         palette?: PROPERTY_PALETTE;
@@ -46,7 +50,11 @@
 
     export let is: $$Props["is"] = "h1";
 
+    /**
+     * @deprecated Use `<Heading alignment_x="...">` instead.
+     */
     export let align: $$Props["align"] = undefined;
+    export let alignment_x: $$Props["alignment_x"] = undefined;
     export let transform: $$Props["transform"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
@@ -58,7 +66,7 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="heading {_class}"
-        {...map_data_attributes({align, palette, transform, variation})}
+        {...map_data_attributes({align: align ?? alignment_x, palette, transform, variation})}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -82,7 +90,7 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="heading {_class}"
-        {...map_data_attributes({align, palette, transform, variation})}
+        {...map_data_attributes({align: align ?? alignment_x, palette, transform, variation})}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -106,7 +114,7 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="heading {_class}"
-        {...map_data_attributes({align, palette, transform, variation})}
+        {...map_data_attributes({align: align ?? alignment_x, palette, transform, variation})}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -130,7 +138,7 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="heading {_class}"
-        {...map_data_attributes({align, palette, transform, variation})}
+        {...map_data_attributes({align: align ?? alignment_x, palette, transform, variation})}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -154,7 +162,7 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="heading {_class}"
-        {...map_data_attributes({align, palette, transform, variation})}
+        {...map_data_attributes({align: align ?? alignment_x, palette, transform, variation})}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -178,7 +186,7 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="heading {_class}"
-        {...map_data_attributes({align, palette, transform, variation})}
+        {...map_data_attributes({align: align ?? alignment_x, palette, transform, variation})}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu

--- a/src/lib/components/typography/text/Text.svelte
+++ b/src/lib/components/typography/text/Text.svelte
@@ -42,9 +42,17 @@
             | "sup"
             | "u";
 
+        /**
+         * @deprecated Use `<Text alignment_x="...">` instead.
+         */
         align?: PROPERTY_TEXT_ALIGNMENT;
+        alignment_x?: PROPERTY_TEXT_ALIGNMENT;
         transform?: PROPERTY_TEXT_TRANSFORM;
+        /**
+         * @deprecated Use `<Text sizing="...">` instead.
+         */
         size?: PROPERTY_SIZING;
+        sizing?: PROPERTY_SIZING;
 
         palette?: PROPERTY_PALETTE;
         variation?: PROPERTY_TEXT_VARIATION;
@@ -66,9 +74,17 @@
 
     export let is: $$Props["is"] = "p";
 
+    /**
+     * @deprecated Use `<Text alignment_x="...">` instead.
+     */
     export let align: $$Props["align"] = undefined;
+    export let alignment_x: $$Props["alignment_x"] = undefined;
     export let transform: $$Props["transform"] = undefined;
+    /**
+     * @deprecated Use `<Text sizing="...">` instead.
+     */
     export let size: $$Props["size"] = undefined;
+    export let sizing: $$Props["sizing"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
     export let variation: $$Props["variation"] = undefined;
@@ -79,7 +95,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -103,7 +125,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -127,7 +155,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -151,7 +185,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -175,7 +215,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -199,7 +245,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -223,7 +275,7 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, transform, variation})}
+        {...map_data_attributes({align: align ?? alignment_x, palette, transform, variation})}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -247,7 +299,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -272,7 +330,7 @@
         {...map_global_attributes($$props)}
         class="text {_class}"
         {...map_data_attributes({
-            align,
+            align: align ?? alignment_x,
             palette,
             transform,
             variation,
@@ -299,7 +357,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -323,7 +387,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -347,7 +417,7 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, transform, variation})}
+        {...map_data_attributes({align: align ?? alignment_x, palette, transform, variation})}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -371,7 +441,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -395,7 +471,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -419,7 +501,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -443,7 +531,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -467,7 +561,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu
@@ -491,7 +591,13 @@
         bind:this={element}
         {...map_global_attributes($$props)}
         class="text {_class}"
-        {...map_data_attributes({align, palette, size, transform, variation})}
+        {...map_data_attributes({
+            align: align ?? alignment_x,
+            palette,
+            size: size ?? sizing,
+            transform,
+            variation,
+        })}
         use:forward_actions={{actions}}
         on:click
         on:contextmenu

--- a/src/lib/stores/htmlpalette.ts
+++ b/src/lib/stores/htmlpalette.ts
@@ -7,6 +7,9 @@ import {IS_SERVER} from "../util/environment";
 
 export type IHTMLPaletteStore = Writable<string>;
 
+/**
+ * @deprecated Use `htmlmode` instead.
+ */
 export function htmlpalette(): IHTMLPaletteStore {
     if (IS_SERVER) return readable("") as IHTMLPaletteStore;
 
@@ -47,3 +50,5 @@ export function htmlpalette(): IHTMLPaletteStore {
         },
     };
 }
+
+export const htmlmode = htmlpalette;


### PR DESCRIPTION
# CHANGELOG

-   Deprecated the following Components / Component Features

    -   Embedded

        -   `Figure`

            -   **(BREAKING)** `<Figure variation="icon">` — Being replaced with global `icon-` prefixed `size` property values, e.g. `size="icon-small"`.

    -   Feedback

        -   `Progress`

            -   **(BREAKING)** `<Progress size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.

                -   **NOTE**: `<Progress sizing>` was made available as an alias in this release, to help with progressively migrating codebases.

        -   `Spinner`

            -   **(BREAKING)** `<Spinner size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.

                -   **NOTE**: `<Spinner sizing>` was made available as an alias in this release, to help with progressively migrating codebases.

    -   Interactables

        -   `Button`

            -   **(BREAKING)** `<Button size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.

                -   **NOTE**: `<Button sizing>` was made available as an alias in this release, to help with progressively migrating codebases.

        -   `Check`

            -   **(BREAKING)** `<Check size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.

                -   **NOTE**: `<Check sizing>` was made available as an alias in this release, to help with progressively migrating codebases.

        -   `NumberInput`

            -   **(BREAKING)** `<NumberInput align>` — Being consolidated into `alignment_x` property, e.g. `alignment_x="justify"`.

                -   **NOTE**: `<NumberInput alignment_x>` was made available as an alias in this release, to help with progressively migrating codebases.

            -   **(BREAKING)** `<NumberInput size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.

                -   **NOTE**: `<NumberInput sizing>` was made available as an alias in this release, to help with progressively migrating codebases.

        -   `Radio`

            -   **(BREAKING)** `<Radio size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.

                -   **NOTE**: `<Radio sizing>` was made available as an alias in this release, to help with progressively migrating codebases.

        -   `Switch`

            -   **(BREAKING)** `<Switch size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.

                -   **NOTE**: `<Switch sizing>` was made available as an alias in this release, to help with progressively migrating codebases.

        -   `TextInput`

            -   **(BREAKING)** `<TextInput align>` — Being consolidated into `alignment_x` property, e.g. `alignment_x="justify"`.

                -   **NOTE**: `<TextInput alignment_x>` was made available as an alias in this release, to help with progressively migrating codebases.

            -   **(BREAKING)** `<TextInput size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.

                -   **NOTE**: `<TextInput sizing>` was made available as an alias in this release, to help with progressively migrating codebases.

    -   Layouts

        -   `Container`

            -   **(BREAKING)** `<Container viewport>` — Being replaced with global `viewport-` prefixed `max_width` property values, e.g. `max_width="viewport-mobile"`.

        -   `Mosaic`

            -   **(BREAKING)** `<Mosaic>` — Being converted into a multi-part Component, `<Mosaic.Container>`.

        -   `Stack`

            -   **(BREAKING)** `<Stack>` — Being converted into a multi-part Component, `<Stack.Container>`.

    -   Navigation

        -   `Menu`

            -   **(BREAKING)** `<Menu.Divider>` / `<Menu.Heading>` `slot="sub-menu"` — DOM tree structure for `Menu` will be restructured, removing the need for the slot.
            -   **(BREAKING)** `<Menu.SubMenu>` — Being renamed to Framework-consistent `<Menu.Section>`.

                -   **NOTE**: `<Menu.Section>` was made available as an alias in this release, to help with progressively migrating codebases.

    -   Overlays

        -   `Overlay`

            -   **(BREAKING)** `<Overlay.Button size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.

                -   **NOTE**: `<Overlay.Button sizing>` was made available as an alias in this release, to help with progressively migrating codebases.

        -   `Popover`

            -   **(BREAKING)** `<Popover.Button size>` — Being consolidated into `sizing` property, e.g. `sizing="small"`.

                -   **NOTE**: `<Popover.Button sizing>` was made available as an alias in this release, to help with progressively migrating codebases.

    -   Typography

        -   `Heading`

            -   **(BREAKING)** `<Heading align>` — Being consolidated into `alignment_x` property, e.g. `alignment_x="justify"`.

                -   **NOTE**: `<Heading alignment_x>` was made available as an alias in this release, to help with progressively migrating codebases.

        -   `Text`

            -   **(BREAKING)** `<Text align>` — Being consolidated into `alignment_x` property, e.g. `alignment_x="justify"`.

                -   **NOTE**: `<Text alignment_x>` was made available as an alias in this release, to help with progressively migrating codebases.

-   Deprecated the following Stores / Store Features

    -   `htmlpalette`

        -   **(BREAKING)** Being renamed to `htmlmode` due to theme mode attribute being changed `<html data-palette="dark/light">` -> `<html data-mode="dark/light">`.

            -   **NOTE**: `htmlmode` was made available as an alias in this release, to help with progressively migrating codebases.