### PR TITLE
[0.5.4] Fix `sveltekit:*` Attribute Typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Updated the following Components / Component Features
+
+    -   `*`
+
+        -   `<* sveltekit:noscroll={boolean} sveltekit:prefetch={boolean}>` — Added missing typings.
+
 ## 0.5.3 - 2022/01/08
 
 -   Added the following Actions / Action Features

--- a/src/lib/components/disclosure/tab/TabAnchor.svelte
+++ b/src/lib/components/disclosure/tab/TabAnchor.svelte
@@ -3,6 +3,7 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
+    import type {ISvelteKitAnchorProperties} from "../../../types/sveltekit";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
@@ -30,7 +31,8 @@
 
         palette?: PROPERTY_PALETTE;
     } & IHTML5Properties &
-        IGlobalProperties;
+        IGlobalProperties &
+        ISvelteKitAnchorProperties;
 
     type $$Slots = {
         default: {};

--- a/src/lib/components/interactables/button/Button.svelte
+++ b/src/lib/components/interactables/button/Button.svelte
@@ -4,6 +4,7 @@
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {PROPERTY_SIZING} from "../../../types/sizings";
     import type {IMarginProperties} from "../../../types/spacings";
+    import type {ISvelteKitAnchorProperties} from "../../../types/sveltekit";
     import type {PROPERTY_VARIATION_BUTTON} from "../../../types/variations";
 
     import {behavior_button} from "../../../actions/behavior_button";
@@ -41,7 +42,8 @@
         variation?: PROPERTY_VARIATION_BUTTON;
     } & IHTML5Properties &
         IGlobalProperties &
-        IMarginProperties;
+        IMarginProperties &
+        ISvelteKitAnchorProperties;
 
     type $$Slots = {
         default: {};

--- a/src/lib/components/navigation/anchor/Anchor.svelte
+++ b/src/lib/components/navigation/anchor/Anchor.svelte
@@ -8,6 +8,7 @@
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
     import type {IMarginProperties} from "../../../types/spacings";
+    import type {ISvelteKitAnchorProperties} from "../../../types/sveltekit";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
@@ -36,7 +37,8 @@
         palette?: PROPERTY_PALETTE;
     } & IHTML5Properties &
         IGlobalProperties &
-        IMarginProperties;
+        IMarginProperties &
+        ISvelteKitAnchorProperties;
 
     type $$Slots = {
         default: {};

--- a/src/lib/components/navigation/breadcrumb/BreadcrumbAnchor.svelte
+++ b/src/lib/components/navigation/breadcrumb/BreadcrumbAnchor.svelte
@@ -2,6 +2,7 @@
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {IGlobalProperties} from "../../../types/global";
     import type {IMarginProperties} from "../../../types/spacings";
+    import type {ISvelteKitAnchorProperties} from "../../../types/sveltekit";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
@@ -24,7 +25,8 @@
         target?: string;
     } & IHTML5Properties &
         IGlobalProperties &
-        IMarginProperties;
+        IMarginProperties &
+        ISvelteKitAnchorProperties;
 
     type $$Slots = {
         default: {};

--- a/src/lib/components/navigation/menu/MenuAnchor.svelte
+++ b/src/lib/components/navigation/menu/MenuAnchor.svelte
@@ -2,6 +2,7 @@
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
     import type {PROPERTY_PALETTE} from "../../../types/palettes";
+    import type {ISvelteKitAnchorProperties} from "../../../types/sveltekit";
 
     import {
         map_aria_attributes,
@@ -30,7 +31,8 @@
 
         palette?: PROPERTY_PALETTE;
     } & IHTML5Properties &
-        IGlobalProperties;
+        IGlobalProperties &
+        ISvelteKitAnchorProperties;
 
     type $$Slots = {
         default: {};

--- a/src/lib/types/sveltekit.ts
+++ b/src/lib/types/sveltekit.ts
@@ -1,0 +1,4 @@
+export interface ISvelteKitAnchorProperties {
+    "sveltekit:prefetch"?: boolean;
+    "sveltekit:noscroll"?: boolean;
+}


### PR DESCRIPTION
# CHANGELOG

-   Updated the following Components / Component Features

    -   `*`

        -   `<* sveltekit:noscroll={boolean} sveltekit:prefetch={boolean}>` — Added missing typings.