### PR TITLE
[0.5.7] Add Final `v0.6.0` Deprecation Notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 -   Deprecated the following Components / Component Features
 
+    -   Display
+
+        -   `Table`
+
+            -   `<Table.Column colspan>` / `<Table.Heading colspan>` — Being consolidated into `span_x` property, e.g. `span_x="3"`.
+
+                -   **NOTE**: `<Table.Column span_x>` / `<Table.Heading span_x>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+            -   `<Table.Column rowspan>` / `<Table.Heading rowspan>` — Being consolidated into `span_y` property, e.g. `span_y="3"`.
+
+                -   **NOTE**: `<Table.Column span_y>` / `<Table.Heading span_y>` was made available as an alias in this release, to help with progressively migrating codebases.
+
     -   Feedback
 
         -   `Dot`
@@ -24,7 +36,7 @@
 
             -   **(BREAKING)** `<Button href for value>` — Will require explicit `is` property being set to switch between HTML tags.
 
-            -   **NOTE**: `<Button is="a/label/input">` was made available as an optional property in this release, to help with progressively migrating codebases.
+                -   **NOTE**: `<Button is="a/label/input">` was made available as an optional property in this release, to help with progressively migrating codebases.
 
         -   `NumberInput`
 
@@ -36,19 +48,19 @@
 
             -   **(BREAKING)** `<TextInput characters>` — Being consolidated into `span_x` property, e.g. `span_x="3"`.
 
-                -   **NOTE**: `<NumberInput span_x>` was made available as an alias in this release, to help with progressively migrating codebases.
+                -   **NOTE**: `<TextInput span_x>` was made available as an alias in this release, to help with progressively migrating codebases.
 
             -   **(BREAKING)** `<TextInput lines>` — Being consolidated into `span_y` property, e.g. `span_y="3"`.
 
-                -   **NOTE**: `<NumberInput span_y>` was made available as an alias in this release, to help with progressively migrating codebases.
+                -   **NOTE**: `<TextInput span_y>` was made available as an alias in this release, to help with progressively migrating codebases.
 
             -   **(BREAKING)** `<TextInput max_length>` — Being consolidated into `max_length` property, e.g. `max="8"`.
 
-                -   **NOTE**: `<NumberInput max>` was made available as an alias in this release, to help with progressively migrating codebases.
+                -   **NOTE**: `<TextInput max>` was made available as an alias in this release, to help with progressively migrating codebases.
 
             -   **(BREAKING)** `<TextInput min_length>` — Being consolidated into `min_length` property, e.g. `min="2"`.
 
-                -   **NOTE**: `<NumberInput min>` was made available as an alias in this release, to help with progressively migrating codebases.
+                -   **NOTE**: `<TextInput min>` was made available as an alias in this release, to help with progressively migrating codebases.
 
     -   Typography
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   Deprecated the following Components / Component Features
+
+    -   Feedback
+
+        -   `Dot`
+
+            -   **(BREAKING)** `<Dot animation>` — Being replaced with generalized `<Animation>` Component.
+
+        -   `Spinner`
+
+            -   **(BREAKING)** `<Spinner>` — Being replaced by `<Progress shape="circle" value={undefined}>` indeterminate animation.
+
+        -   `Wave`
+
+            -   **(BREAKING)** `<Wave>` — Being replaced by expanded `<Ellipsis>` functionality, e.g. `<Ellipsis animation="bounce" iterations="5">`.
+
+    -   Interactables
+
+        -   `Button`
+
+            -   **(BREAKING)** `<Button href for value>` — Will require explicit `is` property being set to switch between HTML tags.
+
+            -   **NOTE**: `<Button is="a/label/input">` was made available as an optional property in this release, to help with progressively migrating codebases.
+
+        -   `NumberInput`
+
+            -   **(BREAKING)** `<NumberInput characters>` — Being consolidated into `span_x` property, e.g. `span_x="3"`.
+
+                -   **NOTE**: `<NumberInput span_x>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+        -   `TextInput`
+
+            -   **(BREAKING)** `<TextInput characters>` — Being consolidated into `span_x` property, e.g. `span_x="3"`.
+
+                -   **NOTE**: `<NumberInput span_x>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+            -   **(BREAKING)** `<TextInput lines>` — Being consolidated into `span_y` property, e.g. `span_y="3"`.
+
+                -   **NOTE**: `<NumberInput span_y>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+            -   **(BREAKING)** `<TextInput max_length>` — Being consolidated into `max_length` property, e.g. `max="8"`.
+
+                -   **NOTE**: `<NumberInput max>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+            -   **(BREAKING)** `<TextInput min_length>` — Being consolidated into `min_length` property, e.g. `min="2"`.
+
+                -   **NOTE**: `<NumberInput min>` was made available as an alias in this release, to help with progressively migrating codebases.
+
+    -   Typography
+
+        -   `Text`
+
+            -   **(BREAKING)** `<Text is="kbd">` — Will be elevated to a standalone `<Kbd>` Component.
+
+    -   Widgets
+
+        -   `DayPicker` / `DayStepper` / `MonthPicker` / `MonthStepper` / `YearPicker` / `YearStepper`
+
+            -   **(BREAKING)** `<* calendar>` — Being removed due to not accepting non ISO 8601 calendar datestamps in the future and to better align with Browsers.
+
+        -   `TimePicker`
+
+            -   **(BREAKING)** `<TimePicker highlight>` — Will be updated to accept string arrays (_`string[]`_) instead of singular strings (_`string`_).
+
 ## v0.5.6 - 2022/02/01
 
 -   Fixed the following Stores / Store Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,11 +54,11 @@
 
                 -   **NOTE**: `<TextInput span_y>` was made available as an alias in this release, to help with progressively migrating codebases.
 
-            -   **(BREAKING)** `<TextInput max_length>` — Being consolidated into `max_length` property, e.g. `max="8"`.
+            -   **(BREAKING)** `<TextInput max_length>` — Being consolidated into `max` property, e.g. `max="8"`.
 
                 -   **NOTE**: `<TextInput max>` was made available as an alias in this release, to help with progressively migrating codebases.
 
-            -   **(BREAKING)** `<TextInput min_length>` — Being consolidated into `min_length` property, e.g. `min="2"`.
+            -   **(BREAKING)** `<TextInput min_length>` — Being consolidated into `min` property, e.g. `min="2"`.
 
                 -   **NOTE**: `<TextInput min>` was made available as an alias in this release, to help with progressively migrating codebases.
 

--- a/src/lib/components/display/table/TableColumn.svelte
+++ b/src/lib/components/display/table/TableColumn.svelte
@@ -15,8 +15,16 @@
         actions?: IForwardedActions;
         element?: HTMLTableCellElement;
 
+        /**
+         * @deprecated Use `<Table.Column span_x="...">` instead.
+         */
         colspan?: number | string;
+        span_x?: number | string;
+        /**
+         * @deprecated Use `<Table.Column span_y="...">` instead.
+         */
         rowspan?: number | string;
+        span_y?: number | string;
     } & IHTML5Properties &
         IGlobalProperties &
         IMarginProperties &
@@ -30,14 +38,22 @@
     export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
+    /**
+     * @deprecated Use `<Table.Column span_x="...">` instead.
+     */
     export let colspan: $$Props["colspan"] = undefined;
+    export let span_x: $$Props["span_x"] = undefined;
+    /**
+     * @deprecated Use `<Table.Column span_y="...">` instead.
+     */
     export let rowspan: $$Props["rowspan"] = undefined;
+    export let span_y: $$Props["span_y"] = undefined;
 </script>
 
 <td
     bind:this={element}
     {...map_global_attributes($$props)}
-    {...map_attributes({colspan, rowspan})}
+    {...map_attributes({colspan: colspan ?? span_x, rowspan: rowspan ?? span_y})}
     use:forward_actions={{actions}}
     on:click
     on:contextmenu

--- a/src/lib/components/display/table/TableHeading.svelte
+++ b/src/lib/components/display/table/TableHeading.svelte
@@ -15,8 +15,16 @@
         actions?: IForwardedActions;
         element?: HTMLTableCellElement;
 
+        /**
+         * @deprecated Use `<Table.Heading span_x="...">` instead.
+         */
         colspan?: number | string;
+        span_x?: number | string;
+        /**
+         * @deprecated Use `<Table.Heading span_y="...">` instead.
+         */
         rowspan?: number | string;
+        span_y?: number | string;
     } & IHTML5Properties &
         IGlobalProperties &
         IMarginProperties &
@@ -30,14 +38,22 @@
     export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
+    /**
+     * @deprecated Use `<Table.Heading span_x="...">` instead.
+     */
     export let colspan: $$Props["colspan"] = undefined;
+    export let span_x: $$Props["span_x"] = undefined;
+    /**
+     * @deprecated Use `<Table.Heading span_y="...">` instead.
+     */
     export let rowspan: $$Props["rowspan"] = undefined;
+    export let span_y: $$Props["span_y"] = undefined;
 </script>
 
 <th
     bind:this={element}
     {...map_global_attributes($$props)}
-    {...map_attributes({colspan, rowspan})}
+    {...map_attributes({colspan: colspan ?? span_x, rowspan: rowspan ?? span_y})}
     use:forward_actions={{actions}}
     on:click
     on:contextmenu

--- a/src/lib/components/feedback/dot/Dot.svelte
+++ b/src/lib/components/feedback/dot/Dot.svelte
@@ -17,6 +17,9 @@
         actions?: IForwardedActions;
         element?: HTMLSpanElement;
 
+        /**
+         * @deprecated Being removed in `v0.6.0` for a generalized `<Animation>` Component.
+         */
         animation?: PROPERTY_ANIMATION_FEEDBACK;
         palette?: PROPERTY_PALETTE;
     } & IHTML5Properties &
@@ -29,6 +32,9 @@
     let _class: $$Props["class"] = "";
     export {_class as class};
 
+    /**
+     * @deprecated Being removed in `v0.6.0` for a generalized `<Animation>` Component.
+     */
     export let animation: $$Props["animation"] = undefined;
     export let palette: $$Props["palette"] = undefined;
 </script>

--- a/src/lib/components/feedback/spinner/index.ts
+++ b/src/lib/components/feedback/spinner/index.ts
@@ -1,1 +1,6 @@
-export {default as Spinner} from "./Spinner.svelte";
+import _Spinner from "./Spinner.svelte";
+
+/**
+ * @deprecated Being removed in `v0.6.0` in favor of updated look and feel of indeterminate `<Progress shape="circle" value={undefined}>` animation look and feel.
+ */
+export const Spinner = _Spinner;

--- a/src/lib/components/feedback/wave/index.ts
+++ b/src/lib/components/feedback/wave/index.ts
@@ -1,1 +1,6 @@
-export {default as Wave} from "./Wave.svelte";
+import _Wave from "./Wave.svelte";
+
+/**
+ * @deprecated Being removed in `v0.6.0` in favor of expanded `<Ellipsis>` functionality, e.g. `<Ellipsis animation="bounce" iterations="5">`
+ */
+export const Wave = _Wave;

--- a/src/lib/components/interactables/button/Button.svelte
+++ b/src/lib/components/interactables/button/Button.svelte
@@ -24,17 +24,28 @@
         actions?: IForwardedActions;
         element?: HTMLAnchorElement | HTMLButtonElement | HTMLInputElement | HTMLLabelElement;
 
+        is?: "a" | "button" | "label" | "input";
+
         active?: boolean;
         disabled?: boolean;
 
         type?: "reset" | "submit";
+        /**
+         * @deprecated Being updated in `v0.6.0` to require explicit `<Button is="input">`.
+         */
         value?: string;
 
         download?: string;
+        /**
+         * @deprecated Being updated in `v0.6.0` to require explicit `<Button is="a">`.
+         */
         href?: string;
         rel?: string;
         target?: string;
 
+        /**
+         * @deprecated Being updated in `v0.6.0` to require explicit `<Button is="label">`.
+         */
         for?: string;
 
         palette?: PROPERTY_PALETTE;
@@ -56,6 +67,8 @@
     export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
+    export let is: $$Props["is"] = undefined;
+
     let _class: $$Props["class"] = "";
     export let tabindex: $$Props["tabindex"] = 0;
     export {_class as class};
@@ -64,13 +77,22 @@
     export let disabled: $$Props["disabled"] = undefined;
 
     export let type: $$Props["type"] = undefined;
+    /**
+     * @deprecated Being updated in `v0.6.0` to require explicit `<Button is="input">`.
+     */
     export let value: $$Props["value"] = "";
 
     export let download: $$Props["download"] = undefined;
+    /**
+     * @deprecated Being updated in `v0.6.0` to require explicit `<Button is="href">`.
+     */
     export let href: $$Props["href"] = undefined;
     export let rel: $$Props["rel"] = undefined;
     export let target: $$Props["target"] = undefined;
 
+    /**
+     * @deprecated Being updated in `v0.6.0` to require explicit `<Button is="label">`.
+     */
     let _for: $$Props["for"] = undefined;
     export {_for as for};
 
@@ -87,7 +109,7 @@
     $: _tabindex = tabindex as number | undefined;
 </script>
 
-{#if href}
+{#if href || is === "a"}
     <a
         bind:this={element}
         {...map_global_attributes($$props)}
@@ -117,7 +139,7 @@
     >
         <slot />
     </a>
-{:else if _for}
+{:else if _for || is === "label"}
     <label
         bind:this={element}
         {...map_global_attributes($$props)}
@@ -146,7 +168,7 @@
     >
         <slot />
     </label>
-{:else if value}
+{:else if value || is === "input"}
     {#if type === "reset"}
         <input
             bind:this={element}

--- a/src/lib/components/interactables/numberinput/NumberInput.svelte
+++ b/src/lib/components/interactables/numberinput/NumberInput.svelte
@@ -42,7 +42,7 @@
         value?: number;
 
         /**
-         * @deprecated Use `<Text span_x="...">` instead.
+         * @deprecated Use `<NumberInput span_x="...">` instead.
          */
         characters?: number | string;
         span_x?: number | string;
@@ -78,7 +78,7 @@
     export let value: $$Props["value"] = undefined;
 
     /**
-     * @deprecated Use `<Text span_x="...">` instead.
+     * @deprecated Use `<NumberInput span_x="...">` instead.
      */
     export let characters: $$Props["characters"] = undefined;
     export let span_x: $$Props["span_x"] = undefined;

--- a/src/lib/components/interactables/numberinput/NumberInput.svelte
+++ b/src/lib/components/interactables/numberinput/NumberInput.svelte
@@ -41,7 +41,11 @@
         placeholder?: string;
         value?: number;
 
+        /**
+         * @deprecated Use `<Text span_x="...">` instead.
+         */
         characters?: number | string;
+        span_x?: number | string;
 
         /**
          * @deprecated Use `<NumberInput alignment_x="...">` instead.
@@ -73,7 +77,11 @@
     export let placeholder: $$Props["placeholder"] = "";
     export let value: $$Props["value"] = undefined;
 
+    /**
+     * @deprecated Use `<Text span_x="...">` instead.
+     */
     export let characters: $$Props["characters"] = undefined;
+    export let span_x: $$Props["span_x"] = undefined;
 
     /**
      * @deprecated Use `<NumberInput alignment_x="...">` instead.
@@ -123,7 +131,7 @@
         placeholder,
         readonly,
         required,
-        size: characters,
+        size: characters ?? span_x,
         value,
     })}
     use:mask_input={{enabled: true, pattern: EXPRESSION_NUMBER}}

--- a/src/lib/components/interactables/textinput/TextInput.svelte
+++ b/src/lib/components/interactables/textinput/TextInput.svelte
@@ -46,12 +46,28 @@
         value?: string;
 
         mask?: boolean;
+        max?: number | undefined;
+        /**
+         * @deprecated Use `<Text max="...">` instead.
+         */
         max_length?: number | undefined;
+        min?: number | undefined;
+        /**
+         * @deprecated Use `<Text min="...">` instead.
+         */
         min_length?: number | undefined;
         pattern?: RegExp | string;
 
+        /**
+         * @deprecated Use `<Text span_x="...">` instead.
+         */
         characters?: number | string;
+        span_x?: number | string;
+        /**
+         * @deprecated Use `<Text span_x="...">` instead.
+         */
         lines?: number | string;
+        span_y?: number | string;
 
         resizable?: PROPERTY_RESIZEABLE;
         spell_check?: boolean;
@@ -93,12 +109,29 @@
     export let value: $$Props["value"] = "";
 
     export let mask: $$Props["mask"] = undefined;
+    export let max: $$Props["max"] = undefined;
+    /**
+     * @deprecated Use `<Text max="...">` instead.
+     */
     export let max_length: $$Props["max_length"] = undefined;
+    export let min: $$Props["min"] = undefined;
+    /**
+     * @deprecated Use `<Text min="...">` instead.
+     */
     export let min_length: $$Props["min_length"] = undefined;
     export let pattern: $$Props["pattern"] = "";
 
+    /**
+     * @deprecated Use `<Text span_x="...">` instead.
+     */
     export let characters: $$Props["characters"] = undefined;
+    export let span_x: $$Props["span_x"] = undefined;
+
+    /**
+     * @deprecated Use `<Text span_y="...">` instead.
+     */
     export let lines: $$Props["lines"] = undefined;
+    export let span_y: $$Props["span_y"] = undefined;
 
     export let resizable: $$Props["resizable"] = undefined;
     export let spell_check: $$Props["spell_check"] = undefined;
@@ -143,16 +176,16 @@
             variation,
         })}
         {...map_attributes({
-            cols: characters,
+            cols: characters ?? span_x,
             disabled,
             id: _id,
-            maxlength: max_length,
-            minlength: min_length,
+            maxlength: max_length ?? max,
+            minlength: min_length ?? min,
             name: _name,
             placeholder,
             readonly,
             required,
-            rows: lines,
+            rows: lines ?? span_y,
             spellcheck: spell_check === undefined ? undefined : spell_check.toString(),
         })}
         use:mask_input={{enabled: mask, on_mask, pattern}}
@@ -190,14 +223,14 @@
         {...map_attributes({
             disabled,
             id: _id,
-            maxlength: max_length,
-            minlength: min_length,
+            maxlength: max_length ?? max,
+            minlength: min_length ?? min,
             name: _name,
             pattern: _pattern,
             placeholder,
             readonly,
             required,
-            size: characters,
+            size: characters ?? span_x,
             value,
         })}
         use:mask_input={{enabled: mask, on_mask, pattern}}
@@ -235,14 +268,14 @@
         {...map_attributes({
             disabled,
             id: _id,
-            maxlength: max_length,
-            minlength: min_length,
+            maxlength: max_length ?? max,
+            minlength: min_length ?? min,
             name: _name,
             pattern: _pattern,
             placeholder,
             readonly,
             required,
-            size: characters,
+            size: characters ?? span_x,
             value,
         })}
         use:mask_input={{enabled: mask, on_mask, pattern}}
@@ -280,14 +313,14 @@
         {...map_attributes({
             disabled,
             id: _id,
-            maxlength: max_length,
-            minlength: min_length,
+            maxlength: max_length ?? max,
+            minlength: min_length ?? min,
             name: _name,
             pattern: _pattern,
             placeholder,
             readonly,
             required,
-            size: characters,
+            size: characters ?? span_x,
             value,
         })}
         use:mask_input={{enabled: mask, on_mask, pattern}}
@@ -325,14 +358,14 @@
         {...map_attributes({
             disabled,
             id: _id,
-            maxlength: max_length,
-            minlength: min_length,
+            maxlength: max_length ?? max,
+            minlength: min_length ?? min,
             name: _name,
             pattern: _pattern,
             placeholder,
             readonly,
             required,
-            size: characters,
+            size: characters ?? span_x,
             value,
         })}
         use:mask_input={{enabled: mask, on_mask, pattern}}
@@ -370,14 +403,14 @@
         {...map_attributes({
             disabled,
             id: _id,
-            maxlength: max_length,
-            minlength: min_length,
+            maxlength: max_length ?? max,
+            minlength: min_length ?? min,
             name: _name,
             pattern: _pattern,
             placeholder,
             readonly,
             required,
-            size: characters,
+            size: characters ?? span_x,
             value,
         })}
         use:mask_input={{enabled: mask, on_mask, pattern}}

--- a/src/lib/components/interactables/textinput/TextInput.svelte
+++ b/src/lib/components/interactables/textinput/TextInput.svelte
@@ -48,12 +48,12 @@
         mask?: boolean;
         max?: number | undefined;
         /**
-         * @deprecated Use `<Text max="...">` instead.
+         * @deprecated Use `<TextInput max="...">` instead.
          */
         max_length?: number | undefined;
         min?: number | undefined;
         /**
-         * @deprecated Use `<Text min="...">` instead.
+         * @deprecated Use `<TextInput min="...">` instead.
          */
         min_length?: number | undefined;
         pattern?: RegExp | string;

--- a/src/lib/components/interactables/textinput/TextInput.svelte
+++ b/src/lib/components/interactables/textinput/TextInput.svelte
@@ -59,12 +59,12 @@
         pattern?: RegExp | string;
 
         /**
-         * @deprecated Use `<Text span_x="...">` instead.
+         * @deprecated Use `<TextInput span_x="...">` instead.
          */
         characters?: number | string;
         span_x?: number | string;
         /**
-         * @deprecated Use `<Text span_x="...">` instead.
+         * @deprecated Use `<TextInput span_y="...">` instead.
          */
         lines?: number | string;
         span_y?: number | string;
@@ -111,24 +111,24 @@
     export let mask: $$Props["mask"] = undefined;
     export let max: $$Props["max"] = undefined;
     /**
-     * @deprecated Use `<Text max="...">` instead.
+     * @deprecated Use `<TextInput max="...">` instead.
      */
     export let max_length: $$Props["max_length"] = undefined;
     export let min: $$Props["min"] = undefined;
     /**
-     * @deprecated Use `<Text min="...">` instead.
+     * @deprecated Use `<TextInput min="...">` instead.
      */
     export let min_length: $$Props["min_length"] = undefined;
     export let pattern: $$Props["pattern"] = "";
 
     /**
-     * @deprecated Use `<Text span_x="...">` instead.
+     * @deprecated Use `<TextInput span_x="...">` instead.
      */
     export let characters: $$Props["characters"] = undefined;
     export let span_x: $$Props["span_x"] = undefined;
 
     /**
-     * @deprecated Use `<Text span_y="...">` instead.
+     * @deprecated Use `<TextInput span_y="...">` instead.
      */
     export let lines: $$Props["lines"] = undefined;
     export let span_y: $$Props["span_y"] = undefined;

--- a/src/lib/components/typography/text/Text.svelte
+++ b/src/lib/components/typography/text/Text.svelte
@@ -22,6 +22,9 @@
         actions?: IForwardedActions;
         element?: HTMLElement | HTMLParagraphElement | HTMLPreElement | HTMLSpanElement;
 
+        /**
+         * @deprecated `<Text is="kbd">` is being elevated to a standalone `<Kbd>` Component in `v0.6.0`.
+         */
         is?:
             | "abbr"
             | "b"
@@ -72,6 +75,9 @@
     let _class: $$Props["class"] = "";
     export {_class as class};
 
+    /**
+     * @deprecated `<Text is="kbd">` is being elevated to a standalone `<Kbd>` Component in `v0.6.0`.
+     */
     export let is: $$Props["is"] = "p";
 
     /**

--- a/src/lib/components/widgets/daypicker/DayPicker.svelte
+++ b/src/lib/components/widgets/daypicker/DayPicker.svelte
@@ -36,6 +36,9 @@
         once?: boolean;
         readonly?: boolean;
 
+        /**
+         * @deprecated Being removed in `v0.6.0` due to cross-calendar manipulation being removed.
+         */
         calendar?: string;
         locale?: string;
 
@@ -67,6 +70,9 @@
     export let once: $$Props["once"] = undefined;
     export let readonly: $$Props["readonly"] = undefined;
 
+    /**
+     * @deprecated Being removed in `v0.6.0` due to cross-calendar manipulation being removed.
+     */
     export let calendar: $$Props["calendar"] = undefined;
     export let locale: $$Props["locale"] = undefined;
 

--- a/src/lib/components/widgets/daystepper/DayStepper.svelte
+++ b/src/lib/components/widgets/daystepper/DayStepper.svelte
@@ -30,6 +30,9 @@
         disabled?: boolean;
         readonly?: boolean;
 
+        /**
+         * @deprecated Being removed in `v0.6.0` due to cross-calendar manipulation being removed.
+         */
         calendar?: string;
         locale?: string;
 
@@ -65,6 +68,9 @@
     export let disabled: $$Props["disabled"] = undefined;
     export let readonly: $$Props["readonly"] = undefined;
 
+    /**
+     * @deprecated Being removed in `v0.6.0` due to cross-calendar manipulation being removed.
+     */
     export let calendar: $$Props["calendar"] = undefined;
     export let locale: $$Props["locale"] = undefined;
 

--- a/src/lib/components/widgets/monthpicker/MonthPicker.svelte
+++ b/src/lib/components/widgets/monthpicker/MonthPicker.svelte
@@ -35,6 +35,9 @@
         once?: boolean;
         readonly?: boolean;
 
+        /**
+         * @deprecated Being removed in `v0.6.0` due to cross-calendar manipulation being removed.
+         */
         calendar?: string;
         locale?: string;
 
@@ -65,6 +68,9 @@
     export let once: $$Props["once"] = undefined;
     export let readonly: $$Props["readonly"] = undefined;
 
+    /**
+     * @deprecated Being removed in `v0.6.0` due to cross-calendar manipulation being removed.
+     */
     export let calendar: $$Props["calendar"] = undefined;
     export let locale: $$Props["locale"] = undefined;
 

--- a/src/lib/components/widgets/monthstepper/MonthStepper.svelte
+++ b/src/lib/components/widgets/monthstepper/MonthStepper.svelte
@@ -30,6 +30,9 @@
         disabled?: boolean;
         readonly?: boolean;
 
+        /**
+         * @deprecated Being removed in `v0.6.0` due to cross-calendar manipulation being removed.
+         */
         calendar?: string;
         locale?: string;
 
@@ -63,6 +66,9 @@
     export let disabled: $$Props["disabled"] = undefined;
     export let readonly: $$Props["readonly"] = undefined;
 
+    /**
+     * @deprecated Being removed in `v0.6.0` due to cross-calendar manipulation being removed.
+     */
     export let calendar: $$Props["calendar"] = undefined;
     export let locale: $$Props["locale"] = undefined;
 

--- a/src/lib/components/widgets/timepicker/TimePicker.svelte
+++ b/src/lib/components/widgets/timepicker/TimePicker.svelte
@@ -44,6 +44,9 @@
         max?: string;
         min?: string;
 
+        /**
+         * @deprecated Being updated in `v0.6.0` to accept `string[]` instead of `string`.
+         */
         highlight?: string;
         value?: string;
 
@@ -79,6 +82,9 @@
     export let max: $$Props["max"] = undefined;
     export let min: $$Props["min"] = undefined;
 
+    /**
+     * @deprecated Being updated in `v0.6.0` to accept `string[]` instead of `string`.
+     */
     export let highlight: $$Props["highlight"] = undefined;
     export let value: $$Props["value"] = undefined;
 

--- a/src/lib/components/widgets/yearpicker/YearPicker.svelte
+++ b/src/lib/components/widgets/yearpicker/YearPicker.svelte
@@ -34,6 +34,9 @@
         once?: boolean;
         readonly?: boolean;
 
+        /**
+         * @deprecated Being removed in `v0.6.0` due to cross-calendar manipulation being removed.
+         */
         calendar?: string;
         locale?: string;
 
@@ -64,6 +67,9 @@
     export let once: $$Props["once"] = undefined;
     export let readonly: $$Props["readonly"] = undefined;
 
+    /**
+     * @deprecated Being removed in `v0.6.0` due to cross-calendar manipulation being removed.
+     */
     export let calendar: $$Props["calendar"] = undefined;
     export let locale: $$Props["locale"] = undefined;
 

--- a/src/lib/components/widgets/yearstepper/YearStepper.svelte
+++ b/src/lib/components/widgets/yearstepper/YearStepper.svelte
@@ -30,6 +30,9 @@
         disabled?: boolean;
         readonly?: boolean;
 
+        /**
+         * @deprecated Being removed in `v0.6.0` due to cross-calendar manipulation being removed.
+         */
         calendar?: string;
         locale?: string;
 
@@ -63,6 +66,9 @@
     export let disabled: $$Props["disabled"] = undefined;
     export let readonly: $$Props["readonly"] = undefined;
 
+    /**
+     * @deprecated Being removed in `v0.6.0` due to cross-calendar manipulation being removed.
+     */
     export let calendar: $$Props["calendar"] = undefined;
     export let locale: $$Props["locale"] = undefined;
 


### PR DESCRIPTION
# CHANGELOG

-   Deprecated the following Components / Component Features

    -   Display

        -   `Table`

            -   `<Table.Column colspan>` / `<Table.Heading colspan>` — Being consolidated into `span_x` property, e.g. `span_x="3"`.

                -   **NOTE**: `<Table.Column span_x>` / `<Table.Heading span_x>` was made available as an alias in this release, to help with progressively migrating codebases.

            -   `<Table.Column rowspan>` / `<Table.Heading rowspan>` — Being consolidated into `span_y` property, e.g. `span_y="3"`.

                -   **NOTE**: `<Table.Column span_y>` / `<Table.Heading span_y>` was made available as an alias in this release, to help with progressively migrating codebases.

    -   Feedback

        -   `Dot`

            -   **(BREAKING)** `<Dot animation>` — Being replaced with generalized `<Animation>` Component.

        -   `Spinner`

            -   **(BREAKING)** `<Spinner>` — Being replaced by `<Progress shape="circle" value={undefined}>` indeterminate animation.

        -   `Wave`

            -   **(BREAKING)** `<Wave>` — Being replaced by expanded `<Ellipsis>` functionality, e.g. `<Ellipsis animation="bounce" iterations="5">`.

    -   Interactables

        -   `Button`

            -   **(BREAKING)** `<Button href for value>` — Will require explicit `is` property being set to switch between HTML tags.

                -   **NOTE**: `<Button is="a/label/input">` was made available as an optional property in this release, to help with progressively migrating codebases.

        -   `NumberInput`

            -   **(BREAKING)** `<NumberInput characters>` — Being consolidated into `span_x` property, e.g. `span_x="3"`.

                -   **NOTE**: `<NumberInput span_x>` was made available as an alias in this release, to help with progressively migrating codebases.

        -   `TextInput`

            -   **(BREAKING)** `<TextInput characters>` — Being consolidated into `span_x` property, e.g. `span_x="3"`.

                -   **NOTE**: `<TextInput span_x>` was made available as an alias in this release, to help with progressively migrating codebases.

            -   **(BREAKING)** `<TextInput lines>` — Being consolidated into `span_y` property, e.g. `span_y="3"`.

                -   **NOTE**: `<TextInput span_y>` was made available as an alias in this release, to help with progressively migrating codebases.

            -   **(BREAKING)** `<TextInput max_length>` — Being consolidated into `max` property, e.g. `max="8"`.

                -   **NOTE**: `<TextInput max>` was made available as an alias in this release, to help with progressively migrating codebases.

            -   **(BREAKING)** `<TextInput min_length>` — Being consolidated into `min` property, e.g. `min="2"`.

                -   **NOTE**: `<TextInput min>` was made available as an alias in this release, to help with progressively migrating codebases.

    -   Typography

        -   `Text`

            -   **(BREAKING)** `<Text is="kbd">` — Will be elevated to a standalone `<Kbd>` Component.

    -   Widgets

        -   `DayPicker` / `DayStepper` / `MonthPicker` / `MonthStepper` / `YearPicker` / `YearStepper`

            -   **(BREAKING)** `<* calendar>` — Being removed due to not accepting non ISO 8601 calendar datestamps in the future and to better align with Browsers.

        -   `TimePicker`

            -   **(BREAKING)** `<TimePicker highlight>` — Will be updated to accept string arrays (_`string[]`_) instead of singular strings (_`string`_).