### PR TITLE
[0.5.7] Add Missing Final `v0.6.0` Deprecation Notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@
 
             -   **(BREAKING)** `<* calendar>` — Being removed due to not accepting non ISO 8601 calendar datestamps in the future and to better align with Browsers.
 
+        -   `DayStepper` / `MonthStepper` / `YearStepper`
+
+            -   **(BREAKING)** `<* step>` — Being consolidated into `steps` property, e.g. `steps="3"`.
+
+                -   **NOTE**: `<* steps>` was made available as an alias in this release, to help with progressively migrating codebases.
+
         -   `TimePicker`
 
             -   **(BREAKING)** `<TimePicker highlight>` — Will be updated to accept string arrays (_`string[]`_) instead of singular strings (_`string`_).

--- a/src/lib/components/widgets/daystepper/DayStepper.svelte
+++ b/src/lib/components/widgets/daystepper/DayStepper.svelte
@@ -42,7 +42,11 @@
 
         max?: string;
         min?: string;
+        /**
+         * @deprecated Use `<DayStepper steps="...">` instead.
+         */
         step?: number | string;
+        steps?: number | string;
 
         value?: string;
 
@@ -80,7 +84,11 @@
 
     export let max: $$Props["max"] = undefined;
     export let min: $$Props["min"] = undefined;
+    /**
+     * @deprecated Use `<DayStepper steps="...">` instead.
+     */
     export let step: $$Props["step"] = undefined;
+    export let steps: $$Props["steps"] = undefined;
 
     export let value: $$Props["value"] = undefined;
 
@@ -100,6 +108,11 @@
 
     $: _day = Temporal.PlainDate.from(value ?? _daystamp);
     $: _step = step ? (typeof step === "string" ? Math.abs(parseInt(step)) : Math.abs(step)) : 1;
+    $: _steps = steps
+        ? typeof steps === "string"
+            ? Math.abs(parseInt(steps))
+            : Math.abs(steps)
+        : undefined;
 </script>
 
 <WidgetContainer {...$$props} bind:element class="day-stepper {_class}">
@@ -117,7 +130,7 @@
         <WidgetButton
             disabled={disabled || !is_day_in_range(_day, undefined, min)}
             {palette}
-            on:click={on_day_select.bind(null, _step * -1)}
+            on:click={on_day_select.bind(null, (_steps ?? _step) * -1)}
         >
             <slot name="previous">&lt;</slot>
         </WidgetButton>
@@ -125,7 +138,7 @@
         <WidgetButton
             disabled={disabled || !is_day_in_range(_day, max)}
             {palette}
-            on:click={on_day_select.bind(null, _step)}
+            on:click={on_day_select.bind(null, _steps ?? _step)}
         >
             <slot name="next">&gt;</slot>
         </WidgetButton>

--- a/src/lib/components/widgets/monthstepper/MonthStepper.svelte
+++ b/src/lib/components/widgets/monthstepper/MonthStepper.svelte
@@ -41,7 +41,11 @@
 
         max?: string;
         min?: string;
+        /**
+         * @deprecated Use `<MonthStepper steps="...">` instead.
+         */
         step?: number | string;
+        steps?: number | string;
 
         value?: string;
         palette?: PROPERTY_PALETTE;
@@ -77,7 +81,11 @@
 
     export let max: $$Props["max"] = undefined;
     export let min: $$Props["min"] = undefined;
+    /**
+     * @deprecated Use `<MonthStepper steps="...">` instead.
+     */
     export let step: $$Props["step"] = undefined;
+    export let steps: $$Props["steps"] = undefined;
 
     export let value: $$Props["value"] = undefined;
 
@@ -104,6 +112,11 @@
 
     $: _month = Temporal.PlainYearMonth.from(value ?? _monthstamp);
     $: _step = step ? (typeof step === "string" ? Math.abs(parseInt(step)) : Math.abs(step)) : 1;
+    $: _steps = steps
+        ? typeof steps === "string"
+            ? Math.abs(parseInt(steps))
+            : Math.abs(steps)
+        : undefined;
 </script>
 
 <WidgetContainer {...$$props} bind:element class="month-stepper {_class}">
@@ -120,7 +133,7 @@
         <WidgetButton
             disabled={disabled || !is_month_in_range(_month, undefined, min)}
             {palette}
-            on:click={on_month_select.bind(null, _step * -1)}
+            on:click={on_month_select.bind(null, (_steps ?? _step) * -1)}
         >
             <slot name="previous">&lt;</slot>
         </WidgetButton>
@@ -128,7 +141,7 @@
         <WidgetButton
             disabled={disabled || !is_month_in_range(_month, max)}
             {palette}
-            on:click={on_month_select.bind(null, _step)}
+            on:click={on_month_select.bind(null, _steps ?? _step)}
         >
             <slot name="next">&gt;</slot>
         </WidgetButton>

--- a/src/lib/components/widgets/yearstepper/YearStepper.svelte
+++ b/src/lib/components/widgets/yearstepper/YearStepper.svelte
@@ -40,7 +40,11 @@
 
         max?: string;
         min?: string;
+        /**
+         * @deprecated Use `<YearStepper steps="...">` instead.
+         */
         step?: number | string;
+        steps?: number | string;
 
         value?: string;
 
@@ -76,7 +80,11 @@
 
     export let max: $$Props["max"] = undefined;
     export let min: $$Props["min"] = undefined;
+    /**
+     * @deprecated Use `<YearStepper steps="...">` instead.
+     */
     export let step: $$Props["step"] = undefined;
+    export let steps: $$Props["steps"] = undefined;
 
     export let value: $$Props["value"] = undefined;
 
@@ -95,6 +103,11 @@
     const _yearstamp = get_yearstamp(calendar ?? DEFAULT_CALENDAR);
 
     $: _step = step ? (typeof step === "string" ? Math.abs(parseInt(step)) : Math.abs(step)) : 1;
+    $: _steps = steps
+        ? typeof steps === "string"
+            ? Math.abs(parseInt(steps))
+            : Math.abs(steps)
+        : undefined;
     $: _year = Temporal.PlainYearMonth.from(value ?? _yearstamp);
 </script>
 
@@ -109,7 +122,7 @@
         <WidgetButton
             disabled={disabled || !is_year_in_range(_year, undefined, min)}
             {palette}
-            on:click={on_year_select.bind(null, _step * -1)}
+            on:click={on_year_select.bind(null, (_steps ?? _step) * -1)}
         >
             <slot name="previous">&lt;</slot>
         </WidgetButton>
@@ -117,7 +130,7 @@
         <WidgetButton
             disabled={disabled || !is_year_in_range(_year, max)}
             {palette}
-            on:click={on_year_select.bind(null, _step)}
+            on:click={on_year_select.bind(null, _steps ?? _step)}
         >
             <slot name="next">&gt;</slot>
         </WidgetButton>


### PR DESCRIPTION
# CHANGELOG

-   Deprecated the following Components / Component Features

    -   Widgets

        -   `DayStepper` / `MonthStepper` / `YearStepper`

            -   **(BREAKING)** `<* step>` — Being consolidated into `steps` property, e.g. `steps="3"`.

                -   **NOTE**: `<* steps>` was made available as an alias in this release, to help with progressively migrating codebases.