### PR TITLE
[0.6.2] Add `DataSelect` Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v0.6.2 - 2022/03/01
+## UNRELEASED
 
 -   `DataSelect`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,14 @@
     -   `<DataSelect logic_name={string}>` — Controls the form name that prefixes all options.
     -   `<DataSelect logic_state={string | string[]}>` — Controls which options are selected.
 
-    -   `<DataSelect searching_algorithm={(item: IDataSelectItem, searching?: string) => boolean}>` — Allows implementing of custom search filtering.
+    -   `<DataSelect searching={string}>` — Controls the current searching filter in the inner `TextInput` value.
+
+        -   `<DataSelect searching_algorithm={(item: IDataSelectItem, searching?: string) => boolean}>` — Allows implementing of custom search filtering.
 
     -   `<DataSelect placeholder={string}>` — Alters displayed text while closed or if no options are selected.
 
     -   `<DataSelect palette={"auto" | "inverse" | "accent" | "dark" | "light" | "alert" | "affirmative" | "informative" | "negative"}>` — Alters the color palette of the inner `TextInput` Component.
-    -   `<DataSelect sizing={"nano", "tiny", "small", "medium", "large", "huge", "massive", `${VIEWPORT}:${SIZE}`}>` — Alters the sizing of the inner `TextInput` Component.
+    -   `<DataSelect sizing={"nano", "tiny", "small", "medium", "large", "huge", "massive", "${VIEWPORT}:${SIZE}"}>`— Alters the sizing of the inner`TextInput` Component.
     -   `<DataSelect variation={"flush"}>` — Alters to render the choices inline instead of a `Popover`.
 
 -   `DataTable`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@
 
         -   `<DataSelect max={number}>` — Controls how many multiple choices a user can select when enabled.
 
-    -   `<DataSelect logic_id={string}>` — Controls the element ID assigned to the inner `Popover` Component.
     -   `<DataSelect logic_name={string}>` — Controls the form name that prefixes all options.
     -   `<DataSelect logic_state={string | string[]}>` — Controls which options are selected.
 
@@ -40,6 +39,10 @@
     -   `<DataTable searching_algorithm>` — Updated to provide `<DataTable searching>` instead of needing to bind to retrieve value.
 
         -   `<DataTable searching_algorithm={(item: IDataSelectItem) => boolean}>` -> `<DataTable searching_algorithm={(item: IDataSelectItem, searching?: string) => boolean}>`
+
+-   `Popover`
+
+    -   `<Popover.Container variation="control">` — Activates the `<Popover.Section>` content when sibling content is focused / hovered.
 
 ## v0.6.1 - 2022/02/25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # CHANGELOG
 
+## v0.6.2 - 2022/03/01
+
+-   `DataSelect`
+
+    -   Added new Component! Similar to `DataTable`, allows you to provide a list of data structures to create a dropdown of selectable options.
+
+    -   `<svelte:fragment slot="default" let:item={IDataSelectItem}>` — Allows for overriding of the default display option text.
+    -   `<svelte:fragment slot="activator">` — Allows for overriding the default inner `TextInput` Component for custom a custom activator.
+
+    -   `<DataSelect items={IDataSelectItem[]}>` — Sets the options displayed to the user.
+
+        -   `IDataSelectItem.disabled: boolean` — Controls if the specific option is disabled.
+        -   `IDataSelectItem.id: string` — Controls the element ID assigned to the option's `<input />` element.
+        -   `IDataSelectItem.palette: "auto" | "inverse" | "accent" | "dark" | "light" | "alert" | "affirmative" | "informative" | "negative"` — Alters the color palette.
+        -   `IDataSelectItem.text: string` — Controls the text displayed to the user for the option.
+        -   `IDataSelectItem.value: string` — Controls the form value associated with the option. If unset, `IDataSelectItem.id` will be used.
+
+    -   `<DataSelect multiple={boolean}>` — Controls whether multiple options can be selected by the user.
+
+        -   `<DataSelect max={number}>` — Controls how many multiple choices a user can select when enabled.
+
+    -   `<DataSelect logic_id={string}>` — Controls the element ID assigned to the inner `Popover` Component.
+    -   `<DataSelect logic_name={string}>` — Controls the form name that prefixes all options.
+    -   `<DataSelect logic_state={string | string[]}>` — Controls which options are selected.
+
+    -   `<DataSelect searching_algorithm={(item: IDataSelectItem, searching?: string) => boolean}>` — Allows implementing of custom search filtering.
+
+    -   `<DataSelect placeholder={string}>` — Alters displayed text while closed or if no options are selected.
+
+    -   `<DataSelect palette={"auto" | "inverse" | "accent" | "dark" | "light" | "alert" | "affirmative" | "informative" | "negative"}>` — Alters the color palette of the inner `TextInput` Component.
+    -   `<DataSelect sizing={"nano", "tiny", "small", "medium", "large", "huge", "massive", `${VIEWPORT}:${SIZE}`}>` — Alters the sizing of the inner `TextInput` Component.
+    -   `<DataSelect variation={"flush"}>` — Alters to render the choices inline instead of a `Popover`.
+
+-   `DataTable`
+
+    -   `<DataTable searching_algorithm>` — Updated to provide `<DataTable searching>` instead of needing to bind to retrieve value.
+
+        -   `<DataTable searching_algorithm={(item: IDataSelectItem) => boolean}>` -> `<DataTable searching_algorithm={(item: IDataSelectItem, searching?: string) => boolean}>`
+
 ## v0.6.1 - 2022/02/25
 
 -   Fixed packaging file inclusion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
         -   `IDataSelectItem.disabled: boolean` — Controls if the specific option is disabled.
         -   `IDataSelectItem.id: string` — Controls the element ID assigned to the option's `<input />` element.
-        -   `IDataSelectItem.palette: "auto" | "inverse" | "accent" | "dark" | "light" | "alert" | "affirmative" | "informative" | "negative"` — Alters the color palette.
+        -   `IDataSelectItem.palette: "auto" | "inverse" | "accent" | "dark" | "light" | "alert" | "affirmative" | "informative" | "negative"` — Alters the color palette of the inner `<Check>` or `<Radio>` Component.
         -   `IDataSelectItem.text: string` — Controls the text displayed to the user for the option.
         -   `IDataSelectItem.value: string` — Controls the form value associated with the option. If unset, `IDataSelectItem.id` will be used.
 
@@ -42,7 +42,7 @@
 
 -   `Popover`
 
-    -   `<Popover.Container variation="control">` — Activates the `<Popover.Section>` content when sibling content is focused / hovered.
+    -   `<Popover.Container variation="control">` — Activates the `<Popover.Section>` content when sibling content is focused.
 
 ## v0.6.1 - 2022/02/25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 
     -   Added new Component! Similar to `DataTable`, allows you to provide a list of data structures to create a dropdown of selectable options.
 
-    -   `<svelte:fragment slot="default" let:item={IDataSelectItem}>` — Allows for overriding of the default display option text.
-    -   `<svelte:fragment slot="activator">` — Allows for overriding the default inner `TextInput` Component for custom a custom activator.
+    -   `<svelte:fragment slot="default" let:index={number} let:item={IDataSelectItem}>` — Allows for overriding of the default display option text.
 
     -   `<DataSelect items={IDataSelectItem[]}>` — Sets the options displayed to the user.
 

--- a/src/lib/components/interactables/form/FormGroup.svelte
+++ b/src/lib/components/interactables/form/FormGroup.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <script lang="ts">
-    import {afterUpdate, createEventDispatcher} from "svelte";
+    import {createEventDispatcher} from "svelte";
 
     type $$Events = {
         change: CustomEvent<void>;

--- a/src/lib/components/overlays/popover/Popover.stories.svelte
+++ b/src/lib/components/overlays/popover/Popover.stories.svelte
@@ -47,6 +47,7 @@
     let target_element;
 
     let logic_state = false;
+    let searching = "";
 
     function on_toggle_click(event) {
         logic_state = !logic_state;
@@ -138,26 +139,36 @@
 
 <Story name="Preview - Control">
     <Popover.Container variation="control">
-        <TextInput placeholder="...filter options" />
+        <TextInput placeholder="...filter options" bind:value={searching} />
 
         <Popover.Section alignment_x="right" spacing="small">
             <Box elevation="medium" padding="medium" variation="borders" radius="tiny">
                 <Menu.Container sizing="tiny">
                     <Menu.Heading>Filter</Menu.Heading>
 
-                    <Menu.Label for="popover-preview-control-cpus">
+                    <Menu.Label
+                        for="popover-preview-control-cpus"
+                        hidden={searching && !"cpus".includes(searching.toLowerCase())}
+                    >
                         CPUs
                         <Spacer />
                         <Check value="cpus" palette="accent" variation="flush" />
                     </Menu.Label>
 
-                    <Menu.Label for="popover-preview-control-hard-drives">
+                    <Menu.Label
+                        for="popover-preview-control-hard-drives"
+                        hidden={searching && !"hard drives".includes(searching.toLowerCase())}
+                    >
                         Hard Drives
                         <Spacer />
                         <Check value="hard-drives" palette="accent" variation="flush" state />
                     </Menu.Label>
 
-                    <Menu.Label for="popover-preview-control-solid-state-drives">
+                    <Menu.Label
+                        for="popover-preview-control-solid-state-drives"
+                        hidden={searching &&
+                            !"solid state drives".includes(searching.toLowerCase())}
+                    >
                         Solid State Drives
                         <Spacer />
                         <Check value="solid-state-drives" palette="accent" variation="flush" />

--- a/src/lib/components/overlays/popover/Popover.stories.svelte
+++ b/src/lib/components/overlays/popover/Popover.stories.svelte
@@ -2,6 +2,8 @@
     import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
 
     import Button from "../../interactables/button/Button.svelte";
+    import Check from "../../interactables/check/Check.svelte";
+    import TextInput from "../../interactables/textinput/TextInput.svelte";
     import Center from "../../layouts/center/Center.svelte";
     import Divider from "../../layouts/divider/Divider.svelte";
     import Spacer from "../../layouts/spacer/Spacer.svelte";
@@ -132,6 +134,38 @@
             </Popover.Container>
         </Omni.Footer>
     </Omni.Container>
+</Story>
+
+<Story name="Preview - Editable">
+    <Popover.Container variation="editable">
+        <TextInput placeholder="...filter options" />
+
+        <Popover.Section alignment_x="right" spacing="small">
+            <Box elevation="medium" variation="borders" radius="tiny">
+                <Menu.Container sizing="tiny">
+                    <Menu.Heading>Filter</Menu.Heading>
+
+                    <Menu.Label for="popover-preview-editable-cpus">
+                        CPUs
+                        <Spacer />
+                        <Check value="cpus" palette="accent" variation="flush" />
+                    </Menu.Label>
+
+                    <Menu.Label for="popover-preview-editable-hard-drives">
+                        Hard Drives
+                        <Spacer />
+                        <Check value="hard-drives" palette="accent" variation="flush" state />
+                    </Menu.Label>
+
+                    <Menu.Label for="popover-preview-editable-solid-state-drives">
+                        Solid State Drives
+                        <Spacer />
+                        <Check value="solid-state-drives" palette="accent" variation="flush" />
+                    </Menu.Label>
+                </Menu.Container>
+            </Box>
+        </Popover.Section>
+    </Popover.Container>
 </Story>
 
 <Story name="Preview - Tooltip">

--- a/src/lib/components/overlays/popover/Popover.stories.svelte
+++ b/src/lib/components/overlays/popover/Popover.stories.svelte
@@ -136,28 +136,28 @@
     </Omni.Container>
 </Story>
 
-<Story name="Preview - Editable">
-    <Popover.Container variation="editable">
+<Story name="Preview - Control">
+    <Popover.Container variation="control">
         <TextInput placeholder="...filter options" />
 
         <Popover.Section alignment_x="right" spacing="small">
-            <Box elevation="medium" variation="borders" radius="tiny">
+            <Box elevation="medium" padding="medium" variation="borders" radius="tiny">
                 <Menu.Container sizing="tiny">
                     <Menu.Heading>Filter</Menu.Heading>
 
-                    <Menu.Label for="popover-preview-editable-cpus">
+                    <Menu.Label for="popover-preview-control-cpus">
                         CPUs
                         <Spacer />
                         <Check value="cpus" palette="accent" variation="flush" />
                     </Menu.Label>
 
-                    <Menu.Label for="popover-preview-editable-hard-drives">
+                    <Menu.Label for="popover-preview-control-hard-drives">
                         Hard Drives
                         <Spacer />
                         <Check value="hard-drives" palette="accent" variation="flush" state />
                     </Menu.Label>
 
-                    <Menu.Label for="popover-preview-editable-solid-state-drives">
+                    <Menu.Label for="popover-preview-control-solid-state-drives">
                         Solid State Drives
                         <Spacer />
                         <Check value="solid-state-drives" palette="accent" variation="flush" />

--- a/src/lib/components/overlays/popover/PopoverContainer.svelte
+++ b/src/lib/components/overlays/popover/PopoverContainer.svelte
@@ -72,7 +72,7 @@
 
     function on_click_inside(event: MouseEvent): void {
         if (once) logic_state = false;
-        else if (_is_editable) {
+        else if (_is_control) {
             const {target} = event;
             if (target && !can_focus(target as Element)) logic_state = false;
         }
@@ -81,11 +81,11 @@
     function on_dismiss(): void {
         if (!logic_state) return;
 
-        if (_is_editable || (_is_popover && dismissible)) logic_state = false;
+        if (_is_control || (_is_popover && dismissible)) logic_state = false;
     }
 
     function on_focus_in(event: FocusEvent): void {
-        if (logic_state || !_is_editable) return;
+        if (logic_state || !_is_control) return;
 
         logic_state = true;
     }
@@ -98,7 +98,7 @@
         logic_state = (event.target as HTMLInputElement).checked;
     }
 
-    $: _is_editable = variation === TOKENS_VARIATION_POPOVER.editable;
+    $: _is_control = variation === TOKENS_VARIATION_POPOVER.control;
     $: _is_popover = !variation || variation === TOKENS_VARIATION_POPOVER.popover;
 
     $: _label = logic_id ? `label[for="${logic_id}"]` : undefined;
@@ -132,7 +132,7 @@
         on_click_outside: on_dismiss,
     }}
     use:lost_focus={{
-        enabled: _is_editable || _is_popover,
+        enabled: _is_control || _is_popover,
         ignore: _label,
         on_lost_focus: on_dismiss,
     }}

--- a/src/lib/components/overlays/popover/PopoverGroup.svelte
+++ b/src/lib/components/overlays/popover/PopoverGroup.svelte
@@ -12,12 +12,8 @@
     export const CONTEXT_POPOVER_FOCUS_TARGET =
         make_scoped_store<PROPERTY_REFERENCE_TARGET>("popover-focus-target");
 
-    export const CONTEXT_POPOVER_DISMISSIBLE = make_scoped_store<boolean>("popover-dismissible");
-
     export const CONTEXT_POPOVER_LOADING =
         make_scoped_store<PROPERTY_BEHAVIOR_LOADING_LAZY>("popover-loading");
-
-    export const CONTEXT_POPOVER_ONCE = make_scoped_store<boolean>("popover-once");
 
     export const CONTEXT_POPOVER_VARIATION =
         make_scoped_store<PROPERTY_VARIATION_POPOVER>("popover-variation");
@@ -36,9 +32,7 @@
 
         focus_target?: PROPERTY_REFERENCE_TARGET;
 
-        dismissible?: boolean;
         loading?: PROPERTY_BEHAVIOR_LOADING_LAZY;
-        once?: boolean;
 
         variation?: PROPERTY_VARIATION_POPOVER;
     };
@@ -54,9 +48,7 @@
 
     export let focus_target: $$Props["focus_target"] = undefined;
 
-    export let dismissible: $$Props["dismissible"] = undefined;
     export let loading: $$Props["loading"] = undefined;
-    export let once: $$Props["once"] = undefined;
 
     export let variation: $$Props["variation"] = undefined;
 
@@ -65,9 +57,7 @@
 
     const _popover_focus_target = CONTEXT_POPOVER_FOCUS_TARGET.create(focus_target);
 
-    const _popover_dismissible = CONTEXT_POPOVER_DISMISSIBLE.create(dismissible);
     const _popover_loading = CONTEXT_POPOVER_LOADING.create(loading);
-    const _popover_once = CONTEXT_POPOVER_ONCE.create(once);
 
     const _popover_variation = CONTEXT_POPOVER_VARIATION.create(variation);
 
@@ -90,9 +80,7 @@
     $: if (_popover_focus_target)
         $_popover_focus_target = focus_target as PROPERTY_REFERENCE_TARGET;
 
-    $: if (_popover_dismissible) $_popover_dismissible = dismissible as boolean;
     $: if (_popover_loading) $_popover_loading = loading as PROPERTY_BEHAVIOR_LOADING_LAZY;
-    $: if (_popover_once) $_popover_once = once as boolean;
 
     $: if (_popover_variation) $_popover_variation = variation as PROPERTY_VARIATION_POPOVER;
 

--- a/src/lib/components/overlays/popover/PopoverSection.svelte
+++ b/src/lib/components/overlays/popover/PopoverSection.svelte
@@ -105,7 +105,7 @@
         _popover_variation &&
         $_popover_variation === TOKENS_VARIATION_POPOVER.popover;
 
-    // TODO: support auto focus in `variation=editable`
+    // TODO: support auto focus in `variation=control`
 </script>
 
 <section

--- a/src/lib/components/overlays/popover/PopoverSection.svelte
+++ b/src/lib/components/overlays/popover/PopoverSection.svelte
@@ -26,20 +26,15 @@
     import {TOKENS_TRANSITION_NAMES} from "../../../types/transitions";
 
     import {auto_focus} from "../../../actions/auto_focus";
-    import {click_inside} from "../../../actions/click_inside";
-    import {click_outside} from "../../../actions/click_outside";
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
-    import {lost_focus} from "../../../actions/lost_focus";
 
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     import {
-        CONTEXT_POPOVER_DISMISSIBLE,
         CONTEXT_POPOVER_FOCUS_TARGET,
         CONTEXT_POPOVER_ID,
         CONTEXT_POPOVER_LOADING,
-        CONTEXT_POPOVER_ONCE,
         CONTEXT_POPOVER_STATE,
         CONTEXT_POPOVER_VARIATION,
     } from "./PopoverGroup.svelte";
@@ -97,33 +92,20 @@
 
     const _popover_focus_target = CONTEXT_POPOVER_FOCUS_TARGET.get();
 
-    const _popover_dismissible = CONTEXT_POPOVER_DISMISSIBLE.get();
     const _popover_loading = CONTEXT_POPOVER_LOADING.get();
-    const _popover_once = CONTEXT_POPOVER_ONCE.get();
 
     const _popover_variation = CONTEXT_POPOVER_VARIATION.get();
 
-    function on_dismiss(): void {
-        if (_popover_dismissible && $_popover_dismissible && _popover_state && $_popover_state) {
-            $_popover_state = false;
-        }
-    }
-
-    function on_once(): void {
-        if (_popover_once && $_popover_once && _popover_state && $_popover_state) {
-            $_popover_state = false;
-        }
-    }
-
-    $: _animatable =
+    $: _can_animate =
         (_popover_id && $_popover_id) ||
         (_popover_variation && $_popover_variation === TOKENS_VARIATION_POPOVER.tooltip);
-    $: _enabled =
+    $: _can_auto_focus =
         _popover_state &&
         $_popover_state &&
         _popover_variation &&
         $_popover_variation === TOKENS_VARIATION_POPOVER.popover;
-    $: _label = _popover_id ? `label[for="${$_popover_id}"]` : undefined;
+
+    // TODO: support auto focus in `variation=editable`
 </script>
 
 <section
@@ -131,11 +113,11 @@
     {...map_global_attributes($$restProps)}
     class="popover--section {_popover_id ? 'transition' : ''} {_class}"
     {...map_data_attributes({
-        animation: _animatable ? animation ?? TOKENS_TRANSITION_NAMES.clip : undefined,
+        animation: _can_animate ? animation ?? TOKENS_TRANSITION_NAMES.clip : undefined,
         "alignment-x": alignment_x,
         "alignment-y": alignment_y,
-        behavior: _animatable ? "explicit" : "",
-        direction: _animatable
+        behavior: _can_animate ? "explicit" : "",
+        direction: _can_animate
             ? DIRECTIONS_LOOKUP[placement ?? TOKENS_DIRECTIONS.bottom]
             : undefined,
         placement,
@@ -143,21 +125,8 @@
         "spacing-x": spacing_x,
         "spacing-y": spacing_y,
     })}
-    use:click_inside={{
-        ignore: _label,
-        on_click_inside: on_once,
-    }}
-    use:click_outside={{
-        ignore: _label,
-        on_click_outside: on_dismiss,
-    }}
-    use:lost_focus={{
-        enabled: _enabled,
-        ignore: _label,
-        on_lost_focus: on_dismiss,
-    }}
     use:auto_focus={{
-        enabled: _enabled,
+        enabled: _can_auto_focus,
         target: _popover_focus_target ? $_popover_focus_target : null,
     }}
     use:forward_actions={{actions}}

--- a/src/lib/components/overlays/popover/PopoverSection.svelte
+++ b/src/lib/components/overlays/popover/PopoverSection.svelte
@@ -98,7 +98,7 @@
 
     $: _can_animate =
         (_popover_id && $_popover_id) ||
-        (_popover_variation && $_popover_variation === TOKENS_VARIATION_POPOVER.tooltip);
+        (_popover_variation && $_popover_variation !== TOKENS_VARIATION_POPOVER.popover);
     $: _can_auto_focus =
         _popover_state &&
         $_popover_state &&

--- a/src/lib/components/overlays/popover/popover.scss
+++ b/src/lib/components/overlays/popover/popover.scss
@@ -104,7 +104,7 @@
         }
     }
 
-    .popover[data-variation~="editable"]:not(:focus-within),
+    .popover[data-variation~="control"]:not(:focus-within),
     .popover[data-variation~="tooltip"]:not(:active, :hover, :focus-within) {
         & > .popover--section {
             --animation-visible: 0;

--- a/src/lib/components/overlays/popover/popover.scss
+++ b/src/lib/components/overlays/popover/popover.scss
@@ -104,19 +104,18 @@
         }
     }
 
-    .popover[data-variation~="tooltip"] {
-        &:not(:active, :hover, :focus-within) {
-            & > .popover--section {
-                --animation-visible: 0;
+    .popover[data-variation~="editable"]:not(:focus-within),
+    .popover[data-variation~="tooltip"]:not(:active, :hover, :focus-within) {
+        & > .popover--section {
+            --animation-visible: 0;
 
-                pointer-events: none;
-            }
+            pointer-events: none;
         }
+    }
 
-        &:is(:active, :hover, :focus-within) {
-            & > .popover--section {
-                --animation-delay: #{variables.use("popover.tooltip.animation.delay")};
-            }
+    .popover[data-variation~="tooltip"]:is(:active, :hover, :focus-within) {
+        & > .popover--section {
+            --animation-delay: #{variables.use("popover.tooltip.animation.delay")};
         }
     }
 }

--- a/src/lib/components/widgets/dataselect/DataSelect.stories.svelte
+++ b/src/lib/components/widgets/dataselect/DataSelect.stories.svelte
@@ -94,7 +94,6 @@
 <Story name="Preview">
     <DataSelect
         items={ITEMS}
-        logic_id="dataselect-preview"
         logic_name="dataselect-preview"
         logic_state="florida"
         placeholder="Select a US State..."
@@ -102,10 +101,9 @@
     />
 </Story>
 
-<Story name="Multiple - Preview">
+<Story name="Multiple">
     <DataSelect
         items={ITEMS}
-        logic_id="dataselect-multiple"
         logic_name="dataselect-multiple"
         logic_state={["delaware", "florida"]}
         placeholder="Select multiple US States..."
@@ -113,10 +111,11 @@
     />
 </Story>
 
-<Story name="Multiple - Max">
+<Story name="Disabled">...</Story>
+
+<Story name="Max">
     <DataSelect
         items={ITEMS}
-        logic_id="dataselect-multiple-max-one"
         logic_name="dataselect-multiple-max-one"
         logic_state="delaware"
         placeholder="Select one (1) US State..."
@@ -126,7 +125,6 @@
 
     <DataSelect
         items={ITEMS}
-        logic_id="dataselect-multiple-max-five"
         logic_name="dataselect-multiple-max-five"
         logic_state={["californa", "delaware", "florida", "oregon", "utah"]}
         placeholder="Select five (5) US States..."
@@ -142,7 +140,6 @@
 
             <DataSelect
                 items={ITEMS}
-                logic_id="dataselect-flush-singular"
                 logic_name="dataselect-flush-singular"
                 logic_state="delaware"
                 variation="flush"
@@ -156,7 +153,6 @@
 
             <DataSelect
                 items={ITEMS}
-                logic_id="dataselect-flush-multiple"
                 logic_name="dataselect-flush-multiple"
                 logic_state={["californa", "delaware", "florida", "oregon", "utah"]}
                 variation="flush"

--- a/src/lib/components/widgets/dataselect/DataSelect.stories.svelte
+++ b/src/lib/components/widgets/dataselect/DataSelect.stories.svelte
@@ -1,0 +1,169 @@
+<script>
+    import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
+
+    import * as Stack from "../../layouts/stack";
+    import Text from "../../typography/text/Text.svelte";
+
+    import DataSelect from "./DataSelect.svelte";
+
+    const ITEMS = [
+        {text: "Alabama", id: "alabama", palette: "accent"},
+        {text: "Alaska", id: "alaska", palette: "accent"},
+        {text: "Arizona", id: "arizona", palette: "accent"},
+        {text: "Arkansas", id: "arkansas", palette: "accent"},
+        {text: "California", id: "california", palette: "accent"},
+        {text: "Colorado", id: "colorado", palette: "accent"},
+        {text: "Connecticut", id: "connecticut", palette: "accent"},
+        {text: "Delaware", id: "delaware", palette: "accent"},
+        {text: "Florida", id: "florida", palette: "accent"},
+        {text: "Georgia", id: "georgia", palette: "accent"},
+        {text: "Hawaii", id: "hawaii", palette: "accent"},
+        {text: "Idaho", id: "idaho", palette: "accent"},
+        {text: "Illinois", id: "illinois", palette: "accent"},
+        {text: "Indiana", id: "Indiana", palette: "accent"},
+        {text: "Iowa", id: "iowa", palette: "accent"},
+        {text: "Kansas", id: "kansas", palette: "accent"},
+        {text: "Kentucky", id: "kentucky", palette: "accent"},
+        {text: "Louisiana", id: "louisiana", palette: "accent"},
+        {text: "Maine", id: "maine", palette: "accent"},
+        {text: "Maryland", id: "maryland", palette: "accent"},
+        {text: "Massachusetts", id: "massachusetts", palette: "accent"},
+        {text: "Michigan", id: "michigan", palette: "accent"},
+        {text: "Minnesota", id: "minnesota", palette: "accent"},
+        {text: "Mississippi", id: "mississippi", palette: "accent"},
+        {text: "Missouri", id: "missouri", palette: "accent"},
+        {text: "Montana", id: "montana", palette: "accent"},
+        {text: "Nebraska", id: "nebraska", palette: "accent"},
+        {text: "Nevada", id: "nevada", palette: "accent"},
+        {text: "New Hampshire", id: "new-hampshire", palette: "accent"},
+        {text: "New Jersey", id: "new-jersey", palette: "accent"},
+        {text: "New Mexico", id: "new-mexico", palette: "accent"},
+        {text: "New York", id: "new-york", palette: "accent"},
+        {text: "North Carolina", id: "north-carolina", palette: "accent"},
+        {text: "North Dakota", id: "north-dakota", palette: "accent"},
+        {text: "Ohio", id: "ohio", palette: "accent"},
+        {text: "Oklahoma", id: "oklahoma", palette: "accent"},
+        {text: "Oregon", id: "oregon", palette: "accent"},
+        {text: "Pennsylvania", id: "pennsylvania", palette: "accent"},
+        {text: "Rhode Island", id: "rhode-island", palette: "accent"},
+        {text: "South Carolina", id: "south-carolina", palette: "accent"},
+        {text: "South Dakota", id: "south-dakota", palette: "accent"},
+        {text: "Tennessee", id: "tennessee", palette: "accent"},
+        {text: "Texas", id: "texas", palette: "accent"},
+        {text: "Utah", id: "utah", palette: "accent"},
+        {text: "Vermont", id: "vermont", palette: "accent"},
+        {text: "Virginia", id: "virginia", palette: "accent"},
+        {text: "Washington", id: "washington", palette: "accent"},
+        {text: "West Virginia", id: "west-virginia", palette: "accent"},
+        {text: "Wisconsin", id: "wisconsin", palette: "accent"},
+        {text: "Wyoming", id: "wyoming", palette: "accent"},
+    ];
+
+    const PALETTES = [
+        ["neutral", true],
+        ["auto", false],
+        ["inverse", false],
+        ["accent", false],
+        ["off", false],
+        ["dark", false],
+        ["light", false],
+        ["alert", false],
+        ["affirmative", false],
+        ["informative", false],
+        ["negative", false],
+    ];
+
+    const SIZINGS = [
+        ["default", true],
+        ["nano", false],
+        ["tiny", false],
+        ["small", false],
+        ["medium", false],
+        ["large", false],
+        ["huge", false],
+        ["massive", false],
+    ];
+</script>
+
+<Meta title="Widgets/DataSelect" />
+
+<Template>
+    <slot />
+</Template>
+
+<Story name="Preview">
+    <DataSelect
+        items={ITEMS}
+        logic_id="dataselect-preview"
+        logic_name="dataselect-preview"
+        logic_state="florida"
+        placeholder="Select a US State..."
+        palette="accent"
+    />
+</Story>
+
+<Story name="Multiple - Preview">
+    <DataSelect
+        items={ITEMS}
+        logic_id="dataselect-multiple"
+        logic_name="dataselect-multiple"
+        logic_state={["delaware", "florida"]}
+        placeholder="Select multiple US States..."
+        multiple
+    />
+</Story>
+
+<Story name="Multiple - Max">
+    <DataSelect
+        items={ITEMS}
+        logic_id="dataselect-multiple-max-one"
+        logic_name="dataselect-multiple-max-one"
+        logic_state="delaware"
+        placeholder="Select one (1) US State..."
+        max={1}
+        multiple
+    />
+
+    <DataSelect
+        items={ITEMS}
+        logic_id="dataselect-multiple-max-five"
+        logic_name="dataselect-multiple-max-five"
+        logic_state={["californa", "delaware", "florida", "oregon", "utah"]}
+        placeholder="Select five (5) US States..."
+        max={5}
+        multiple
+    />
+</Story>
+
+<Story name="Flush">
+    <Stack.Container orientation="horizontal" spacing="medium" variation="wrap">
+        <div>
+            <Text is="strong">SINGULAR</Text>
+
+            <DataSelect
+                items={ITEMS}
+                logic_id="dataselect-flush-singular"
+                logic_name="dataselect-flush-singular"
+                logic_state="delaware"
+                variation="flush"
+                width="small"
+                height="medium"
+            />
+        </div>
+
+        <div>
+            <Text is="strong">MULTIPLE</Text>
+
+            <DataSelect
+                items={ITEMS}
+                logic_id="dataselect-flush-multiple"
+                logic_name="dataselect-flush-multiple"
+                logic_state={["californa", "delaware", "florida", "oregon", "utah"]}
+                variation="flush"
+                width="small"
+                height="medium"
+                multiple
+            />
+        </div>
+    </Stack.Container>
+</Story>

--- a/src/lib/components/widgets/dataselect/DataSelect.stories.svelte
+++ b/src/lib/components/widgets/dataselect/DataSelect.stories.svelte
@@ -74,10 +74,9 @@
     ];
 
     const SIZINGS = [
-        ["default", true],
+        ["small", true],
         ["nano", false],
         ["tiny", false],
-        ["small", false],
         ["medium", false],
         ["large", false],
         ["huge", false],
@@ -95,7 +94,6 @@
     <DataSelect
         items={ITEMS}
         logic_name="dataselect-preview"
-        logic_state="florida"
         placeholder="Select a US State..."
         palette="accent"
     />
@@ -105,19 +103,16 @@
     <DataSelect
         items={ITEMS}
         logic_name="dataselect-multiple"
-        logic_state={["delaware", "florida"]}
         placeholder="Select multiple US States..."
+        palette="accent"
         multiple
     />
 </Story>
-
-<Story name="Disabled">...</Story>
 
 <Story name="Max">
     <DataSelect
         items={ITEMS}
         logic_name="dataselect-multiple-max-one"
-        logic_state="delaware"
         placeholder="Select one (1) US State..."
         max={1}
         multiple
@@ -126,12 +121,13 @@
     <DataSelect
         items={ITEMS}
         logic_name="dataselect-multiple-max-five"
-        logic_state={["californa", "delaware", "florida", "oregon", "utah"]}
         placeholder="Select five (5) US States..."
         max={5}
         multiple
     />
 </Story>
+
+<Story name="Slot">...</Story>
 
 <Story name="Flush">
     <Stack.Container orientation="horizontal" spacing="medium" variation="wrap">
@@ -141,7 +137,6 @@
             <DataSelect
                 items={ITEMS}
                 logic_name="dataselect-flush-singular"
-                logic_state="delaware"
                 variation="flush"
                 width="small"
                 height="medium"
@@ -154,12 +149,71 @@
             <DataSelect
                 items={ITEMS}
                 logic_name="dataselect-flush-multiple"
-                logic_state={["californa", "delaware", "florida", "oregon", "utah"]}
                 variation="flush"
                 width="small"
                 height="medium"
                 multiple
             />
         </div>
+    </Stack.Container>
+</Story>
+
+<Story name="Item - Disabled">
+    <DataSelect
+        items={ITEMS.map((item, index) => {
+            return {...item, disabled: index % 5 === 0};
+        })}
+        logic_name="dataselect-disabled"
+        placeholder="Select a US State..."
+    />
+</Story>
+
+<Story name="Item - Palette">
+    <DataSelect
+        items={ITEMS.map((item, index) => {
+            return {...item, palette: index % 5 === 0 ? "negative" : item.palette};
+        })}
+        logic_name="dataselect-palette"
+        placeholder="Select a US State..."
+    />
+</Story>
+
+<Story name="Palette">
+    <Stack.Container orientation="horizontal" spacing="medium" variation="wrap">
+        {#each PALETTES as [palette, is_default] (palette)}
+            <div>
+                <Text is="strong">
+                    {`${palette.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                </Text>
+
+                <br />
+                <DataSelect
+                    items={ITEMS}
+                    logic_name="dataselect-palette-{palette}}"
+                    placeholder="Select a US State..."
+                    palette={is_default ? undefined : palette}
+                />
+            </div>
+        {/each}
+    </Stack.Container>
+</Story>
+
+<Story name="Sizing">
+    <Stack.Container orientation="horizontal" spacing="medium" variation="wrap">
+        {#each SIZINGS as [sizing, is_default] (sizing)}
+            <div>
+                <Text is="strong">
+                    {`${sizing.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                </Text>
+
+                <br />
+                <DataSelect
+                    items={ITEMS}
+                    logic_name="dataselect-sizing-{sizing}}"
+                    placeholder="Select a US State..."
+                    sizing={is_default ? undefined : sizing}
+                />
+            </div>
+        {/each}
     </Stack.Container>
 </Story>

--- a/src/lib/components/widgets/dataselect/DataSelect.stories.svelte
+++ b/src/lib/components/widgets/dataselect/DataSelect.stories.svelte
@@ -127,7 +127,23 @@
     />
 </Story>
 
-<Story name="Slot">...</Story>
+<Story name="Slot">
+    <DataSelect
+        items={ITEMS}
+        logic_name="dataselect-disabled"
+        placeholder="Select a US State..."
+        let:index
+        let:item
+    >
+        {#if index % 5 === 0}
+            <Text is="span">
+                <Text is="strong">{item.text.slice(0, 1)}</Text>{item.text.slice(1)}
+            </Text>
+        {:else}
+            {item.text}
+        {/if}
+    </DataSelect>
+</Story>
 
 <Story name="Flush">
     <Stack.Container orientation="horizontal" spacing="medium" variation="wrap">

--- a/src/lib/components/widgets/dataselect/DataSelect.svelte
+++ b/src/lib/components/widgets/dataselect/DataSelect.svelte
@@ -20,6 +20,10 @@
     import Dropdown from "../dropdown/Dropdown.svelte";
     import Inlay from "../inlay/Inlay.svelte";
 
+    type IDataSelectAlgorithm =
+        | ((item: IDataSelectItem) => boolean)
+        | ((item: IDataSelectItem, searching: string) => boolean);
+
     type IDataSelectItem = $$Generic<{
         disabled?: boolean;
 
@@ -45,7 +49,7 @@
 
         placeholder?: string;
 
-        searching_algorithm?: (item: IDataSelectItem, searching?: string) => boolean;
+        searching_algorithm?: IDataSelectAlgorithm;
 
         palette?: PROPERTY_PALETTE;
         sizing?: PROPERTY_SIZING_BREAKPOINT;
@@ -136,7 +140,10 @@
 
     $: _filtered_view =
         IS_BROWSER && is_active && searching
-            ? items.filter((item) => (default_search ?? searching_algorithm)(item, searching))
+            ? // HACK: TypeScript can't infer `searching` from upper enclosure here
+              items.filter((item) =>
+                  (default_search ?? searching_algorithm)(item, searching as string)
+              )
             : items;
 
     $: _selected =

--- a/src/lib/components/widgets/dataselect/DataSelect.svelte
+++ b/src/lib/components/widgets/dataselect/DataSelect.svelte
@@ -195,7 +195,7 @@
         bind:element
         {...$$restProps}
         class="data-select {_class}"
-        variation="editable"
+        variation="control"
         on:active={on_active}
         on:dismiss={on_dismiss}
     >

--- a/src/lib/components/widgets/dataselect/DataSelect.svelte
+++ b/src/lib/components/widgets/dataselect/DataSelect.svelte
@@ -61,7 +61,7 @@
         ISizeProperties;
 
     type $$Slots = {
-        default: {item: IDataSelectItem};
+        default: {index: number; item: IDataSelectItem};
     };
 
     export let element: $$Props["element"] = undefined;
@@ -150,14 +150,14 @@
     <Inlay bind:element {...$$restProps} class="data-select {_class}">
         <Form.Group {logic_name} bind:logic_state>
             <Menu.Container sizing="tiny">
-                {#each items as item (item.id)}
+                {#each items as item, index (item.id)}
                     <Menu.Label
                         for="{logic_name}--{item.id}"
                         disabled={item.disabled ||
                             (multiple && is_multiple_disabled(item, logic_state))}
                         hidden={is_hidden(item, searching)}
                     >
-                        <slot {item}>
+                        <slot {index} {item}>
                             {item.text}
                         </slot>
 
@@ -209,14 +209,14 @@
                 sizing="tiny"
                 style="width:calc({_longest_text}ch + (var(--spacings-block-small) * {_longest_text}ch));"
             >
-                {#each items as item (item.id)}
+                {#each items as item, index (item.id)}
                     <Menu.Label
                         for="{logic_name}--{item.id}"
                         disabled={item.disabled ||
                             (multiple && is_multiple_disabled(item, logic_state))}
                         hidden={is_hidden(item, searching)}
                     >
-                        <slot {item}>
+                        <slot {index} {item}>
                             {item.text}
                         </slot>
 

--- a/src/lib/components/widgets/dataselect/DataSelect.svelte
+++ b/src/lib/components/widgets/dataselect/DataSelect.svelte
@@ -49,6 +49,7 @@
 
         placeholder?: string;
 
+        searching?: string;
         searching_algorithm?: IDataSelectAlgorithm;
 
         palette?: PROPERTY_PALETTE;
@@ -79,6 +80,7 @@
 
     export let placeholder: $$Props["placeholder"] = undefined;
 
+    export let searching: $$Props["searching"] = undefined;
     export let searching_algorithm: $$Props["searching_algorithm"] = undefined;
 
     export let palette: $$Props["palette"] = undefined;
@@ -87,7 +89,6 @@
 
     let is_active: boolean = false;
     let search_element: HTMLInputElement | undefined;
-    let searching: string = "";
 
     function default_search(item: IDataSelectItem, searching: string): boolean {
         const _searching = searching.toLowerCase();
@@ -120,7 +121,6 @@
     }
 
     function on_dismiss(): void {
-        searching = "";
         is_active = false;
     }
 

--- a/src/lib/components/widgets/dataselect/DataSelect.svelte
+++ b/src/lib/components/widgets/dataselect/DataSelect.svelte
@@ -101,8 +101,8 @@
     }
 
     function is_multiple_disabled(
-        logic_state: string | string[] | undefined,
-        item: IDataSelectItem
+        item: IDataSelectItem,
+        logic_state: string | string[] | undefined
     ): boolean {
         if (!logic_state || !_max || _max < 1) return false;
 
@@ -111,7 +111,7 @@
             return logic_state.length >= _max ? !logic_state.includes(value) : false;
         }
 
-        return logic_state !== value;
+        return _max === 1 && logic_state !== value;
     }
 
     function on_active(): void {
@@ -154,7 +154,7 @@
                     <Menu.Label
                         for="{logic_name}--{item.id}"
                         disabled={item.disabled ||
-                            (multiple && is_multiple_disabled(logic_state, item))}
+                            (multiple && is_multiple_disabled(item, logic_state))}
                         hidden={is_hidden(item, searching)}
                     >
                         <slot {item}>
@@ -167,7 +167,7 @@
                                 value={item.value ?? item.id}
                                 variation="flush"
                                 palette={item.palette}
-                                disabled={item.disabled || is_multiple_disabled(logic_state, item)}
+                                disabled={item.disabled || is_multiple_disabled(item, logic_state)}
                             />
                         {:else}
                             <Radio
@@ -213,7 +213,7 @@
                     <Menu.Label
                         for="{logic_name}--{item.id}"
                         disabled={item.disabled ||
-                            (multiple && is_multiple_disabled(logic_state, item))}
+                            (multiple && is_multiple_disabled(item, logic_state))}
                         hidden={is_hidden(item, searching)}
                     >
                         <slot {item}>
@@ -226,7 +226,7 @@
                                 value={item.value ?? item.id}
                                 variation="flush"
                                 palette={item.palette}
-                                disabled={item.disabled || is_multiple_disabled(logic_state, item)}
+                                disabled={item.disabled || is_multiple_disabled(item, logic_state)}
                             />
                         {:else}
                             <Radio

--- a/src/lib/components/widgets/dataselect/DataSelect.svelte
+++ b/src/lib/components/widgets/dataselect/DataSelect.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+    import type {IGlobalProperties} from "../../../types/global";
+    import type {IHTML5Properties} from "../../../types/html5";
+    import type {PROPERTY_PALETTE} from "../../../types/palettes";
+    import type {ISizeProperties} from "../../../types/sizes";
+    import type {PROPERTY_SIZING_BREAKPOINT} from "../../../types/sizings";
+    import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
+    import {PROPERTY_VARIATION_SURFACE, TOKENS_VARIATION_SURFACE} from "../../../types/variations";
+
+    import {IS_BROWSER} from "../../../util/environment";
+    import {debounce} from "../../../util/functional";
+
+    import Check from "../../interactables/check/Check.svelte";
+    import * as Form from "../../interactables/form";
+    import Radio from "../../interactables/radio/Radio.svelte";
+    import Spacer from "../../layouts/spacer/Spacer.svelte";
+    import * as Menu from "../../navigation/menu";
+    import TextInput from "../../interactables/textinput/TextInput.svelte";
+
+    import Dropdown from "../dropdown/Dropdown.svelte";
+    import Inlay from "../inlay/Inlay.svelte";
+
+    type IDataSelectItem = $$Generic<{
+        disabled?: boolean;
+
+        id: string;
+
+        palette?: PROPERTY_PALETTE;
+
+        text: string;
+
+        value?: string;
+    }>;
+
+    type $$Props = {
+        element?: HTMLDivElement;
+
+        items: IDataSelectItem[];
+        max?: number | string;
+        multiple?: boolean;
+
+        logic_id: string;
+        logic_name: string;
+        logic_state?: string | string[];
+        placeholder?: string;
+
+        searching_algorithm?: (item: IDataSelectItem) => boolean;
+
+        palette?: PROPERTY_PALETTE;
+        sizing?: PROPERTY_SIZING_BREAKPOINT;
+        variation?: PROPERTY_VARIATION_SURFACE;
+    } & IHTML5Properties &
+        IGlobalProperties &
+        IMarginProperties &
+        IPaddingProperties &
+        ISizeProperties;
+
+    type $$Slots = {
+        default: {item: IDataSelectItem};
+    };
+
+    export let element: $$Props["element"] = undefined;
+
+    let _class = "";
+    export {_class as class};
+
+    export let items: $$Props["items"];
+    export let max: $$Props["max"] = undefined;
+    export let multiple: $$Props["multiple"] = undefined;
+
+    export let logic_id: $$Props["logic_id"];
+    export let logic_name: $$Props["logic_name"];
+    export let logic_state: $$Props["logic_state"] = "";
+    export let placeholder: $$Props["placeholder"] = undefined;
+
+    export let searching_algorithm: $$Props["searching_algorithm"] = undefined;
+
+    export let palette: $$Props["palette"] = undefined;
+    export let sizing: $$Props["sizing"] = undefined;
+    export let variation: $$Props["variation"] = undefined;
+
+    let is_active: boolean = false;
+    let search_element: HTMLInputElement | undefined;
+    let searching: string = "";
+
+    function default_search(item: IDataSelectItem): boolean {
+        // HACK: TypeScript can't obviously know this is only called whenever
+        // the `searching` property DOES have a string
+        const _searching = searching.toLowerCase();
+
+        return item.text.toLowerCase().includes(_searching);
+    }
+
+    function has_item(logic_state: string | string[] | undefined, item: IDataSelectItem): boolean {
+        const value = item.value ?? item.id;
+
+        return logic_state instanceof Array ? logic_state.includes(value) : logic_state === value;
+    }
+
+    function is_multiple_disabled(
+        logic_state: string | string[] | undefined,
+        item: IDataSelectItem
+    ): boolean {
+        if (!logic_state || !_max || _max < 1) return false;
+
+        const value = item.value ?? item.id;
+        if (logic_state instanceof Array) {
+            return logic_state.length >= _max ? !logic_state.includes(value) : false;
+        }
+
+        return logic_state !== value;
+    }
+
+    function on_active(): void {
+        is_active = true;
+    }
+
+    function on_dismiss(): void {
+        searching = "";
+        is_active = false;
+    }
+
+    function on_searching_input(event: InputEvent): void {
+        const target = event.target as HTMLInputElement | null;
+        if (!target) return;
+
+        searching = target.value;
+    }
+
+    $: _max = typeof max === "string" ? parseInt(max) : max;
+
+    $: _longest_text = items.reduce(
+        (accum, item) => (item.text.length > accum.length ? item.text : accum),
+        ""
+    ).length;
+
+    $: _filtered_view =
+        IS_BROWSER && is_active && searching
+            ? items.filter((item) => (default_search ?? searching_algorithm)(item))
+            : items;
+
+    $: _selected =
+        IS_BROWSER && logic_state
+            ? (multiple
+                  ? items
+                        .filter((item) => has_item(logic_state, item))
+                        .map((item) => item.text)
+                        .join(", ")
+                  : items.find((item) => has_item(logic_state, item))?.text) ?? ""
+            : "";
+</script>
+
+{#if variation === TOKENS_VARIATION_SURFACE.flush}
+    <Inlay bind:element {...$$restProps} class="data-select {_class}">
+        <Form.Group {logic_name} bind:logic_state>
+            <Menu.Container sizing="tiny">
+                {#each _filtered_view as item (item.id)}
+                    <Menu.Label
+                        for="{logic_name}--{item.id}"
+                        disabled={item.disabled ||
+                            (multiple && is_multiple_disabled(logic_state, item))}
+                    >
+                        <slot {item}>
+                            {item.text}
+                        </slot>
+
+                        <Spacer />
+                        {#if multiple}
+                            <Check
+                                value={item.value ?? item.id}
+                                variation="flush"
+                                palette={item.palette}
+                                disabled={item.disabled || is_multiple_disabled(logic_state, item)}
+                            />
+                        {:else}
+                            <Radio
+                                value={item.value ?? item.id}
+                                variation="flush"
+                                palette={item.palette}
+                                disabled={item.disabled}
+                            />
+                        {/if}
+                    </Menu.Label>
+                {/each}
+            </Menu.Container>
+        </Form.Group>
+    </Inlay>
+{:else}
+    <Dropdown
+        bind:element
+        {...$$restProps}
+        class="data-select {_class}"
+        variation="editable"
+        {logic_id}
+        on:active={on_active}
+        on:dismiss={on_dismiss}
+    >
+        <svelte:fragment slot="activator">
+            <TextInput
+                bind:element={search_element}
+                variation={is_active ? undefined : "block"}
+                readonly={!is_active}
+                value={is_active ? searching : _selected}
+                {palette}
+                {placeholder}
+                {sizing}
+                on:input={debounce(on_searching_input, 250)}
+            />
+        </svelte:fragment>
+
+        <Form.Group {logic_name} bind:logic_state>
+            <Menu.Container
+                sizing="tiny"
+                style="width:calc({_longest_text}ch + (var(--spacings-block-small) * {_longest_text}ch));"
+            >
+                {#each _filtered_view as item (item.id)}
+                    <Menu.Label
+                        for="{logic_name}--{item.id}"
+                        disabled={item.disabled ||
+                            (multiple && is_multiple_disabled(logic_state, item))}
+                    >
+                        <slot {item}>
+                            {item.text}
+                        </slot>
+
+                        <Spacer />
+                        {#if multiple}
+                            <Check
+                                value={item.value ?? item.id}
+                                variation="flush"
+                                palette={item.palette}
+                                disabled={item.disabled || is_multiple_disabled(logic_state, item)}
+                            />
+                        {:else}
+                            <Radio
+                                value={item.value ?? item.id}
+                                variation="flush"
+                                palette={item.palette}
+                                disabled={item.disabled}
+                            />
+                        {/if}
+                    </Menu.Label>
+                {/each}
+            </Menu.Container>
+        </Form.Group>
+    </Dropdown>
+{/if}

--- a/src/lib/components/widgets/dataselect/DataSelect.svelte
+++ b/src/lib/components/widgets/dataselect/DataSelect.svelte
@@ -165,16 +165,16 @@
                         {#if multiple}
                             <Check
                                 value={item.value ?? item.id}
+                                disabled={item.disabled || is_multiple_disabled(item, logic_state)}
                                 variation="flush"
                                 palette={item.palette}
-                                disabled={item.disabled || is_multiple_disabled(item, logic_state)}
                             />
                         {:else}
                             <Radio
                                 value={item.value ?? item.id}
+                                disabled={item.disabled}
                                 variation="flush"
                                 palette={item.palette}
-                                disabled={item.disabled}
                             />
                         {/if}
                     </Menu.Label>
@@ -224,16 +224,16 @@
                         {#if multiple}
                             <Check
                                 value={item.value ?? item.id}
+                                disabled={item.disabled || is_multiple_disabled(item, logic_state)}
                                 variation="flush"
                                 palette={item.palette}
-                                disabled={item.disabled || is_multiple_disabled(item, logic_state)}
                             />
                         {:else}
                             <Radio
                                 value={item.value ?? item.id}
+                                disabled={item.disabled}
                                 variation="flush"
                                 palette={item.palette}
-                                disabled={item.disabled}
                             />
                         {/if}
                     </Menu.Label>

--- a/src/lib/components/widgets/dataselect/DataSelect.svelte
+++ b/src/lib/components/widgets/dataselect/DataSelect.svelte
@@ -43,7 +43,6 @@
         max?: number | string;
         multiple?: boolean;
 
-        logic_id: string;
         logic_name: string;
         logic_state?: string | string[];
 
@@ -74,7 +73,6 @@
     export let max: $$Props["max"] = undefined;
     export let multiple: $$Props["multiple"] = undefined;
 
-    export let logic_id: $$Props["logic_id"];
     export let logic_name: $$Props["logic_name"];
     export let logic_state: $$Props["logic_state"] = "";
 
@@ -198,7 +196,6 @@
         {...$$restProps}
         class="data-select {_class}"
         variation="editable"
-        {logic_id}
         on:active={on_active}
         on:dismiss={on_dismiss}
     >

--- a/src/lib/components/widgets/dataselect/DataSelect.svelte
+++ b/src/lib/components/widgets/dataselect/DataSelect.svelte
@@ -42,9 +42,10 @@
         logic_id: string;
         logic_name: string;
         logic_state?: string | string[];
+
         placeholder?: string;
 
-        searching_algorithm?: (item: IDataSelectItem) => boolean;
+        searching_algorithm?: (item: IDataSelectItem, searching?: string) => boolean;
 
         palette?: PROPERTY_PALETTE;
         sizing?: PROPERTY_SIZING_BREAKPOINT;
@@ -71,6 +72,7 @@
     export let logic_id: $$Props["logic_id"];
     export let logic_name: $$Props["logic_name"];
     export let logic_state: $$Props["logic_state"] = "";
+
     export let placeholder: $$Props["placeholder"] = undefined;
 
     export let searching_algorithm: $$Props["searching_algorithm"] = undefined;
@@ -83,9 +85,7 @@
     let search_element: HTMLInputElement | undefined;
     let searching: string = "";
 
-    function default_search(item: IDataSelectItem): boolean {
-        // HACK: TypeScript can't obviously know this is only called whenever
-        // the `searching` property DOES have a string
+    function default_search(item: IDataSelectItem, searching: string): boolean {
         const _searching = searching.toLowerCase();
 
         return item.text.toLowerCase().includes(_searching);
@@ -136,7 +136,7 @@
 
     $: _filtered_view =
         IS_BROWSER && is_active && searching
-            ? items.filter((item) => (default_search ?? searching_algorithm)(item))
+            ? items.filter((item) => (default_search ?? searching_algorithm)(item, searching))
             : items;
 
     $: _selected =

--- a/src/lib/components/widgets/dataselect/DataSelect.svelte
+++ b/src/lib/components/widgets/dataselect/DataSelect.svelte
@@ -100,12 +100,6 @@
         return !(default_search ?? searching_algorithm)(item, searching);
     }
 
-    function has_item(item: IDataSelectItem, logic_state: string | string[] | undefined): boolean {
-        const value = item.value ?? item.id;
-
-        return logic_state instanceof Array ? logic_state.includes(value) : logic_state === value;
-    }
-
     function is_multiple_disabled(
         logic_state: string | string[] | undefined,
         item: IDataSelectItem
@@ -142,14 +136,13 @@
         ""
     ).length;
 
+    $: _texts = Object.fromEntries(items.map((item) => [item.value ?? item.id, item.text]));
+
     $: _selected =
         IS_BROWSER && logic_state
-            ? (multiple
-                  ? items
-                        .filter((item) => has_item(item, logic_state))
-                        .map((item) => item.text)
-                        .join(", ")
-                  : items.find((item) => has_item(item, logic_state))?.text) ?? ""
+            ? logic_state instanceof Array
+                ? logic_state.map((value) => _texts[value]).join(", ")
+                : _texts[logic_state] ?? ""
             : "";
 </script>
 

--- a/src/lib/components/widgets/dataselect/index.ts
+++ b/src/lib/components/widgets/dataselect/index.ts
@@ -1,0 +1,1 @@
+export {default as DataSelect} from "./DataSelect.svelte";

--- a/src/lib/components/widgets/datatable/DataTable.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.svelte
@@ -53,7 +53,7 @@
         sorting_mode?: PROPERTY_SORTING_MODE;
 
         searching?: string;
-        searching_algorithm?: (row: IDataTableRow) => boolean;
+        searching_algorithm?: (row: IDataTableRow, searching?: string) => boolean;
 
         palette?: PROPERTY_PALETTE;
         sizing?: PROPERTY_SIZING;
@@ -100,10 +100,8 @@
     export let sizing: $$Props["sizing"] = undefined;
     export let variation: $$Props["variation"] = undefined;
 
-    function default_search(row: IDataTableRow): boolean {
-        // HACK: TypeScript can't obviously know this is only called whenever
-        // the `searching` property DOES have a string
-        const _searching = (searching as string).toLowerCase();
+    function default_search(row: IDataTableRow, searching: string): boolean {
+        const _searching = searching.toLowerCase();
 
         for (const key in row) {
             const value = row[key].toLowerCase();
@@ -178,9 +176,10 @@
     $: _paging = typeof paging === "string" ? parseInt(paging) : paging ?? 5;
 
     $: _filtered_view = searching
-        ? rows.filter((row, index) => {
-              return searching_algorithm ? searching_algorithm(row) : default_search(row);
-          })
+        ? // HACK: TypeScript can't infer `searching` from upper enclosure here
+          rows.filter((row, index) =>
+              (searching_algorithm ?? default_search)(row, searching as string)
+          )
         : // NOTE: Even if filtering, we need to clone here so later sorting doesn't modify in place
           [...rows];
 

--- a/src/lib/components/widgets/datatable/DataTable.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.svelte
@@ -26,6 +26,10 @@
 
     type IDataTableKey = keyof IDataTableRow;
 
+    type IDataTableAlgorithm =
+        | ((item: IDataTableRow) => boolean)
+        | ((item: IDataTableRow, searching: string) => boolean);
+
     interface IDataTableColumn {
         key: IDataTableKey;
 
@@ -53,7 +57,7 @@
         sorting_mode?: PROPERTY_SORTING_MODE;
 
         searching?: string;
-        searching_algorithm?: (row: IDataTableRow, searching?: string) => boolean;
+        searching_algorithm?: IDataTableAlgorithm;
 
         palette?: PROPERTY_PALETTE;
         sizing?: PROPERTY_SIZING;

--- a/src/lib/components/widgets/datatable/DataTable.svelte
+++ b/src/lib/components/widgets/datatable/DataTable.svelte
@@ -177,16 +177,12 @@
     $: _page = typeof page === "string" ? parseInt(page) : page ?? 1;
     $: _paging = typeof paging === "string" ? parseInt(paging) : paging ?? 5;
 
-    let _filtered_view: IDataTableRow[];
-    $: {
-        _filtered_view = [...rows];
-
-        if (searching) {
-            _filtered_view = _filtered_view.filter((row, index) => {
-                return searching_algorithm ? searching_algorithm(row) : default_search(row);
-            });
-        }
-    }
+    $: _filtered_view = searching
+        ? rows.filter((row, index) => {
+              return searching_algorithm ? searching_algorithm(row) : default_search(row);
+          })
+        : // NOTE: Even if filtering, we need to clone here so later sorting doesn't modify in place
+          [...rows];
 
     $: _pages = Math.ceil(_filtered_view.length / _paging);
 

--- a/src/lib/components/widgets/dropdown/Dropdown.svelte
+++ b/src/lib/components/widgets/dropdown/Dropdown.svelte
@@ -19,7 +19,7 @@
     type $$Props = {
         element?: HTMLDivElement;
 
-        logic_id: string;
+        logic_id?: string;
         logic_state?: boolean;
 
         palette?: PROPERTY_PALETTE;
@@ -41,7 +41,7 @@
     let _class = "";
     export {_class as class};
 
-    export let logic_id: $$Props["logic_id"];
+    export let logic_id: $$Props["logic_id"] = undefined;
     export let logic_state: $$Props["logic_state"] = false;
 
     export let palette: $$Props["palette"] = undefined;

--- a/src/lib/components/widgets/dropdown/Dropdown.svelte
+++ b/src/lib/components/widgets/dropdown/Dropdown.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+    import type {IGlobalProperties} from "../../../types/global";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
+    import type {PROPERTY_PALETTE} from "../../../types/palettes";
+    import type {ISizeProperties} from "../../../types/sizes";
+    import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
+    import type {PROPERTY_VARIATION_POPOVER} from "../../../types/variations";
+
+    import Box from "../../surfaces/box/Box.svelte";
+    import * as Popover from "../../overlays/popover";
+    import Scrollable from "../../layouts/scrollable/Scrollable.svelte";
+
+    type $$Events = {
+        active: CustomEvent<void>;
+
+        dismiss: CustomEvent<void>;
+    } & IHTML5Events;
+
+    type $$Props = {
+        element?: HTMLDivElement;
+
+        logic_id: string;
+        logic_state?: boolean;
+
+        palette?: PROPERTY_PALETTE;
+        variation?: PROPERTY_VARIATION_POPOVER;
+    } & IHTML5Properties &
+        IGlobalProperties &
+        IMarginProperties &
+        IPaddingProperties &
+        ISizeProperties;
+
+    type $$Slots = {
+        default: {};
+
+        activator: {};
+    };
+
+    export let element: $$Props["element"] = undefined;
+
+    let _class = "";
+    export {_class as class};
+
+    export let logic_id: $$Props["logic_id"];
+    export let logic_state: $$Props["logic_state"] = false;
+
+    export let palette: $$Props["palette"] = undefined;
+    export let variation: $$Props["variation"] = undefined;
+</script>
+
+<Popover.Container
+    bind:element
+    {...$$restProps}
+    class="drop-down {_class}"
+    {logic_id}
+    {variation}
+    bind:logic_state
+    dismissible
+    on:active
+    on:dismiss
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
+    <slot name="activator" />
+
+    <Popover.Section alignment_x="right" spacing="small">
+        <Box elevation="medium" variation="borders" radius="tiny" {palette}>
+            <Scrollable padding="medium" max_height="viewport-50">
+                <slot />
+            </Scrollable>
+        </Box>
+    </Popover.Section>
+</Popover.Container>

--- a/src/lib/components/widgets/dropdown/index.ts
+++ b/src/lib/components/widgets/dropdown/index.ts
@@ -1,0 +1,1 @@
+export {default as Dropdown} from "./Dropdown.svelte";

--- a/src/lib/components/widgets/inlay/Inlay.svelte
+++ b/src/lib/components/widgets/inlay/Inlay.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+    import type {IGlobalProperties} from "../../../types/global";
+    import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
+    import type {PROPERTY_PALETTE} from "../../../types/palettes";
+    import type {ISizeProperties} from "../../../types/sizes";
+    import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
+
+    import Box from "../../surfaces/box/Box.svelte";
+    import Scrollable from "../../layouts/scrollable/Scrollable.svelte";
+
+    type $$Events = {
+        active: CustomEvent<void>;
+
+        dismiss: CustomEvent<void>;
+    } & IHTML5Events;
+
+    type $$Props = {
+        element?: HTMLDivElement;
+
+        palette?: PROPERTY_PALETTE;
+    } & IHTML5Properties &
+        IGlobalProperties &
+        IMarginProperties &
+        IPaddingProperties &
+        ISizeProperties;
+
+    type $$Slots = {
+        default: {};
+
+        activator: {};
+    };
+
+    export let element: $$Props["element"] = undefined;
+
+    let _class = "";
+    export {_class as class};
+
+    export let palette: $$Props["palette"] = undefined;
+</script>
+
+<Box
+    bind:element
+    {...$$restProps}
+    class="inlay {_class}"
+    variation="borders"
+    radius="tiny"
+    {palette}
+    on:click
+    on:contextmenu
+    on:dblclick
+    on:focusin
+    on:focusout
+    on:keydown
+    on:keyup
+    on:pointercancel
+    on:pointerdown
+    on:pointerenter
+    on:pointerleave
+    on:pointermove
+    on:pointerout
+    on:pointerup
+>
+    <Scrollable padding="medium" size="100">
+        <slot />
+    </Scrollable>
+</Box>

--- a/src/lib/components/widgets/inlay/index.ts
+++ b/src/lib/components/widgets/inlay/index.ts
@@ -1,0 +1,1 @@
+export {default as Inlay} from "./Inlay.svelte";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -113,6 +113,8 @@ export * from "./components/utilities/viewportrender";
 export * from "./components/widgets/datatable";
 export * from "./components/widgets/daypicker";
 export * from "./components/widgets/daystepper";
+export * from "./components/widgets/dropdown";
+export * from "./components/widgets/inlay";
 export * from "./components/widgets/monthpicker";
 export * from "./components/widgets/monthstepper";
 export * from "./components/widgets/pagination";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -110,6 +110,7 @@ export * from "./components/utilities/serverrender";
 export * from "./components/utilities/transition";
 export * from "./components/utilities/viewportrender";
 
+export * from "./components/widgets/dataselect";
 export * from "./components/widgets/datatable";
 export * from "./components/widgets/daypicker";
 export * from "./components/widgets/daystepper";

--- a/src/lib/types/variations.ts
+++ b/src/lib/types/variations.ts
@@ -44,7 +44,7 @@ export enum TOKENS_VARIATION_GRID {
  * Represents the `Popover`-centric variation tokens that can be applied to Framework Components
  */
 export enum TOKENS_VARIATION_POPOVER {
-    editable = "editable",
+    control = "control",
 
     popover = "popover",
 

--- a/src/lib/types/variations.ts
+++ b/src/lib/types/variations.ts
@@ -44,6 +44,8 @@ export enum TOKENS_VARIATION_GRID {
  * Represents the `Popover`-centric variation tokens that can be applied to Framework Components
  */
 export enum TOKENS_VARIATION_POPOVER {
+    editable = "editable",
+
     popover = "popover",
 
     tooltip = "tooltip",


### PR DESCRIPTION
# CHANGELOG

-   `DataSelect`

    -   Added new Component! Similar to `DataTable`, allows you to provide a list of data structures to create a dropdown of selectable options.

    -   `<svelte:fragment slot="default" let:index={number} let:item={IDataSelectItem}>` — Allows for overriding of the default display option text.

    -   `<DataSelect items={IDataSelectItem[]}>` — Sets the options displayed to the user.

        -   `IDataSelectItem.disabled: boolean` — Controls if the specific option is disabled.
        -   `IDataSelectItem.id: string` — Controls the element ID assigned to the option's `<input />` element.
        -   `IDataSelectItem.palette: "auto" | "inverse" | "accent" | "dark" | "light" | "alert" | "affirmative" | "informative" | "negative"` — Alters the color palette of the inner `<Check>` or `<Radio>` Component.
        -   `IDataSelectItem.text: string` — Controls the text displayed to the user for the option.
        -   `IDataSelectItem.value: string` — Controls the form value associated with the option. If unset, `IDataSelectItem.id` will be used.

    -   `<DataSelect multiple={boolean}>` — Controls whether multiple options can be selected by the user.

        -   `<DataSelect max={number}>` — Controls how many multiple choices a user can select when enabled.

    -   `<DataSelect logic_name={string}>` — Controls the form name that prefixes all options.
    -   `<DataSelect logic_state={string | string[]}>` — Controls which options are selected.

    -   `<DataSelect searching={string}>` — Controls the current searching filter in the inner `TextInput` value.

        -   `<DataSelect searching_algorithm={(item: IDataSelectItem, searching?: string) => boolean}>` — Allows implementing of custom search filtering.

    -   `<DataSelect placeholder={string}>` — Alters displayed text while closed or if no options are selected.

    -   `<DataSelect palette={"auto" | "inverse" | "accent" | "dark" | "light" | "alert" | "affirmative" | "informative" | "negative"}>` — Alters the color palette of the inner `TextInput` Component.
    -   `<DataSelect sizing={"nano", "tiny", "small", "medium", "large", "huge", "massive", "${VIEWPORT}:${SIZE}"}>`— Alters the sizing of the inner`TextInput` Component.
    -   `<DataSelect variation={"flush"}>` — Alters to render the choices inline instead of a `Popover`.

-   `DataTable`

    -   `<DataTable searching_algorithm>` — Updated to provide `<DataTable searching>` instead of needing to bind to retrieve value.

        -   `<DataTable searching_algorithm={(item: IDataSelectItem) => boolean}>` -> `<DataTable searching_algorithm={(item: IDataSelectItem, searching?: string) => boolean}>`

-   `Popover`

    -   `<Popover.Container variation="control">` — Activates the `<Popover.Section>` content when sibling content is focused.