### PR TITLE
[0.6.2] Last Minute Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## UNRELEASED
 
--   `DateTimeStamp`
-
-    -   `<DateTimeStamp timestamp={number}>` — Added support to handle UNIX Epoch number timestamps, e.g. `1646210184506`
-    -   `<DateTimeStamp timestamp={string}>` — Added support to handle UTC Instant string timestamps, e.g. `2022-03-02T08:28:58.891Z` / `2020-01-23T17:04:36.491865121-08:00`
-
 -   `DataSelect`
 
     -   Added new Component! Similar to `DataTable`, allows you to provide a list of data structures to create a dropdown of selectable options.
@@ -43,6 +38,11 @@
     -   `<DataTable searching_algorithm>` — Updated to provide `<DataTable searching>` instead of needing to bind to retrieve value.
 
         -   `<DataTable searching_algorithm={(item: IDataSelectItem) => boolean}>` -> `<DataTable searching_algorithm={(item: IDataSelectItem, searching?: string) => boolean}>`
+
+-   `DateTimeStamp`
+
+    -   `<DateTimeStamp timestamp={number}>` — Added support to handle UNIX Epoch number timestamps, e.g. `1646210184506`
+    -   `<DateTimeStamp timestamp={string}>` — Added support to handle UTC Instant string timestamps, e.g. `2022-03-02T08:28:58.891Z` / `2020-01-23T17:04:36.491865121-08:00`
 
 -   `Popover`
 

--- a/scripts/flags.js
+++ b/scripts/flags.js
@@ -63,6 +63,7 @@ export const BUILD_FLAGS = make_flag_map(
     "--disable-components-utilities-animation",
     "--disable-components-utilities-portal",
     "--disable-components-utilities-transition",
+    "--disable-components-widgets-dataselect",
     "--disable-globals-alignments",
     "--disable-globals-alignments-responsitivity",
     "--disable-globals-elevations",

--- a/src/framework/framework.scss
+++ b/src/framework/framework.scss
@@ -54,6 +54,8 @@
 @import "../lib/components/utilities/portal/portal";
 @import "../lib/components/utilities/transition/transition";
 
+@import "../lib/components/widgets/dataselect/dataselect";
+
 @import "../lib/components/layouts/center/center";
 @import "../lib/components/layouts/grid/grid";
 @import "../lib/components/layouts/group/group";

--- a/src/lib/components/display/datetimestamp/DateTimeStamp.svelte
+++ b/src/lib/components/display/datetimestamp/DateTimeStamp.svelte
@@ -36,7 +36,7 @@
         minute?: IMinuteFormatOptions["minute"];
         second?: ISecondFormatOptions["second"];
 
-        timestamp: string;
+        timestamp: number | string;
     } & IHTML5Properties &
         IGlobalProperties &
         IMarginProperties;

--- a/src/lib/components/widgets/dataselect/DataSelect.stories.svelte
+++ b/src/lib/components/widgets/dataselect/DataSelect.stories.svelte
@@ -179,7 +179,7 @@
         items={ITEMS.map((item, index) => {
             return {...item, disabled: index % 5 === 0};
         })}
-        logic_name="dataselect-disabled"
+        logic_name="dataselect-item-disabled"
         placeholder="Select a US State..."
     />
 </Story>
@@ -189,7 +189,7 @@
         items={ITEMS.map((item, index) => {
             return {...item, palette: index % 5 === 0 ? "negative" : item.palette};
         })}
-        logic_name="dataselect-palette"
+        logic_name="dataselect-item-palette"
         placeholder="Select a US State..."
     />
 </Story>
@@ -205,7 +205,7 @@
                 <br />
                 <DataSelect
                     items={ITEMS}
-                    logic_name="dataselect-palette-{palette}}"
+                    logic_name="dataselect-palette-{palette}"
                     placeholder="Select a US State..."
                     palette={is_default ? undefined : palette}
                 />
@@ -225,7 +225,7 @@
                 <br />
                 <DataSelect
                     items={ITEMS}
-                    logic_name="dataselect-sizing-{sizing}}"
+                    logic_name="dataselect-sizing-{sizing}"
                     placeholder="Select a US State..."
                     sizing={is_default ? undefined : sizing}
                 />

--- a/src/lib/components/widgets/dataselect/dataselect.default.scss
+++ b/src/lib/components/widgets/dataselect/dataselect.default.scss
@@ -1,0 +1,11 @@
+@use "../../../../framework/abstracts/variables";
+
+@if not env("DISABLE_COMPONENTS_WIDGETS_DATASELECT") {
+    @include variables.define(
+        (
+            "dataselect": (
+                "size.max-height": variables.use("sizes.block.medium"),
+            ),
+        )
+    );
+}

--- a/src/lib/components/widgets/dataselect/dataselect.scss
+++ b/src/lib/components/widgets/dataselect/dataselect.scss
@@ -1,0 +1,9 @@
+@use "../../../../framework/abstracts/variables";
+
+@if not env("DISABLE_COMPONENTS_WIDGETS_DATASELECT") {
+    .data-select.popover {
+        & .scrollable {
+            max-height: min(calc(#{variables.use("dataselect.size.max-height")} * 1rem), 50vh);
+        }
+    }
+}

--- a/src/lib/components/widgets/dropdown/Dropdown.svelte
+++ b/src/lib/components/widgets/dropdown/Dropdown.svelte
@@ -77,7 +77,7 @@
 
     <Popover.Section alignment_x="right" spacing="small">
         <Box elevation="medium" variation="borders" radius="tiny" {palette}>
-            <Scrollable padding="medium" max_height="viewport-50">
+            <Scrollable padding="medium">
                 <slot />
             </Scrollable>
         </Box>

--- a/src/themes/default/_imports.scss
+++ b/src/themes/default/_imports.scss
@@ -45,3 +45,5 @@
     "../../lib/components/typography/code/code.default.scss",
     "../../lib/components/typography/heading/heading.default.scss",
     "../../lib/components/typography/text/text.default.scss";
+
+@import "../../lib/components/widgets/dataselect/dataselect.default.scss";


### PR DESCRIPTION
# CHANGELOG

- `DataSelect`

    - Added maximum block height instead of _just_ 50% of viewport height.

- `DateTimeStamp`

    - `<DateTimeStamp timestamp={number}>` - Fixed missing typing.