### PR TITLE
[0.6.3] Fix Miscellaneous Broken Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   `Aside`
+
+    -   `<Aside.Container actions>` — Fixed property not applying actions to element.
+
+-   `Divider`
+
+    -   `<Divider actions>` — Fixed property not applying actions to element when using text divider.
+    -   `<Divider class>` — Fixed property not applying class to element.
+
+-   `Omni`
+
+    -   `<Omni.Container actions>` — Fixed property not applying actions to element.
+
 ## v0.6.2 - 2022/03/02
 
 -   `DataSelect`

--- a/src/lib/components/layouts/divider/Divider.svelte
+++ b/src/lib/components/layouts/divider/Divider.svelte
@@ -31,6 +31,9 @@
     export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
+    let _class: $$Props["class"] = "";
+    export {_class as class};
+
     export let palette: $$Props["palette"] = undefined;
     export let orientation: $$Props["orientation"] = undefined;
 </script>
@@ -40,8 +43,9 @@
         bind:this={element}
         {...map_global_attributes($$restProps)}
         role="separator"
-        class="divider"
+        class="divider {_class}"
         {...map_data_attributes({orientation, palette})}
+        use:forward_actions={{actions}}
         on:click
         on:contextmenu
         on:dblclick
@@ -63,7 +67,7 @@
     <hr
         bind:this={element}
         {...map_global_attributes($$restProps)}
-        class="divider"
+        class="divider {_class}"
         {...map_data_attributes({orientation, palette})}
         use:forward_actions={{actions}}
         on:click

--- a/src/lib/components/navigation/aside/AsideContainer.svelte
+++ b/src/lib/components/navigation/aside/AsideContainer.svelte
@@ -6,11 +6,15 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Events = IHTML5Events;
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
 
         placement?: PROPERTY_PLACEMENT_X;
@@ -27,6 +31,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -43,6 +48,7 @@
     {...map_global_attributes($$restProps)}
     class="aside {_class}"
     {...map_data_attributes({palette, placement, variation})}
+    use:forward_actions={{actions}}
     on:click
     on:contextmenu
     on:dblclick

--- a/src/lib/components/navigation/omni/OmniContainer.svelte
+++ b/src/lib/components/navigation/omni/OmniContainer.svelte
@@ -6,11 +6,15 @@
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
+    import type {IForwardedActions} from "../../../actions/forward_actions";
+    import {forward_actions} from "../../../actions/forward_actions";
+
     import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Events = IHTML5Events;
 
     type $$Props = {
+        actions?: IForwardedActions;
         element?: HTMLElement;
 
         placement?: PROPERTY_PLACEMENT_Y;
@@ -27,6 +31,7 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
     export let element: $$Props["element"] = undefined;
 
     let _class: $$Props["class"] = "";
@@ -43,6 +48,7 @@
     {...map_global_attributes($$restProps)}
     class="omni {_class}"
     {...map_data_attributes({palette, placement, variation})}
+    use:forward_actions={{actions}}
     on:click
     on:contextmenu
     on:dblclick


### PR DESCRIPTION
# CHANGELOG

-   `Aside`

    -   `<Aside.Container actions>` — Fixed property not applying actions to element.

-   `Divider`

    -   `<Divider actions>` — Fixed property not applying actions to element when using text divider.
    -   `<Divider class>` — Fixed property not applying class to element.

-   `Omni`

    -   `<Omni.Container actions>` — Fixed property not applying actions to element.