### PR TITLE
[0.6.4] Fixed Missing `<(Card/Tile).Figure fit radius shape>` Property API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   `Card`
+
+    -   Fixed missing `<Card.Footer fit radius shape>` support, to match `<Figure>` Property API.
+
+-   `Tile`
+
+    -   Fixed missing `<Tile.Footer fit radius shape>` support, to match `<Figure>` Property API.
+
 ## v0.6.3 - 2022/03/11
 
 -   `Aside`

--- a/src/lib/components/surfaces/card/Card.stories.svelte
+++ b/src/lib/components/surfaces/card/Card.stories.svelte
@@ -22,6 +22,14 @@
         ["highest", false],
     ];
 
+    const FITS = [
+        ["fill", true],
+        ["contain", false],
+        ["cover", false],
+        ["none", false],
+        ["scale-down", false],
+    ];
+
     const ORIENTATIONS = [
         ["horizontal", true],
         ["vertical", false],
@@ -39,6 +47,22 @@
         ["affirmative", false],
         ["informative", false],
         ["negative", false],
+    ];
+
+    const RADIUS = [
+        ["none", true],
+        ["nano", false],
+        ["tiny", false],
+        ["small", false],
+        ["medium", false],
+        ["large", false],
+        ["huge", false],
+        ["massive", false],
+    ];
+
+    const SHAPES = [
+        ["circle", false],
+        ["pill", false],
     ];
 
     const SIZINGS = [
@@ -175,6 +199,81 @@
             <Card.Container sizing={is_default ? undefined : sizing} width="huge">
                 <Card.Header>
                     {`${sizing.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                </Card.Header>
+
+                <Card.Section>
+                    <Text>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et
+                        consectetur orci. Curabitur a egestas turpis, vitae convallis sapien. Sed
+                        pellentesque rutrum tellus, in iaculis dolor tincidunt non. Orci varius
+                        natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+                    </Text>
+                </Card.Section>
+            </Card.Container>
+        {/each}
+    </Stack.Container>
+</Story>
+
+<Story name="Figure - Fit">
+    <Stack.Container orientation="horizontal" spacing="medium" alignment_y="top" variation="wrap">
+        {#each FITS as [fit, is_default] (fit)}
+            <Card.Container width="huge">
+                <Card.Figure fit={is_default ? undefined : fit}>
+                    <img src={IMAGE_BACKGROUND} />
+                </Card.Figure>
+
+                <Card.Header>
+                    {`${fit.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                </Card.Header>
+
+                <Card.Section>
+                    <Text>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et
+                        consectetur orci. Curabitur a egestas turpis, vitae convallis sapien. Sed
+                        pellentesque rutrum tellus, in iaculis dolor tincidunt non. Orci varius
+                        natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+                    </Text>
+                </Card.Section>
+            </Card.Container>
+        {/each}
+    </Stack.Container>
+</Story>
+
+<Story name="Figure - Radius">
+    <Stack.Container orientation="horizontal" spacing="medium" alignment_y="top" variation="wrap">
+        {#each RADIUS as [radius, is_default] (radius)}
+            <Card.Container width="huge">
+                <Card.Figure radius={is_default ? undefined : radius}>
+                    <img src={IMAGE_BACKGROUND} />
+                </Card.Figure>
+
+                <Card.Header>
+                    {`${radius.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                </Card.Header>
+
+                <Card.Section>
+                    <Text>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et
+                        consectetur orci. Curabitur a egestas turpis, vitae convallis sapien. Sed
+                        pellentesque rutrum tellus, in iaculis dolor tincidunt non. Orci varius
+                        natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+                    </Text>
+                </Card.Section>
+            </Card.Container>
+        {/each}
+    </Stack.Container>
+</Story>
+
+<Story name="Figure - Shape">
+    <Stack.Container orientation="horizontal" spacing="medium" alignment_y="top" variation="wrap">
+        {#each SHAPES as [shape, is_default] (shape)}
+            <Card.Container width="huge">
+                <Card.Figure shape={is_default ? undefined : shape}>
+                    <img src={IMAGE_BACKGROUND} />
+                </Card.Figure>
+
+                <Card.Header>
+                    {`${shape.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
                 </Card.Header>
 
                 <Card.Section>

--- a/src/lib/components/surfaces/card/CardFigure.svelte
+++ b/src/lib/components/surfaces/card/CardFigure.svelte
@@ -1,19 +1,28 @@
 <script lang="ts">
+    import type {PROPERTY_FIT} from "../../../types/fit";
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
+    import type {
+        PROPERTY_RADIUS_BREAKPOINT,
+        PROPERTY_SHAPE_BREAKPOINT,
+    } from "../../../types/shapes";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
-    import {map_global_attributes} from "../../../util/attributes";
+    import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;
         element?: HTMLElement;
+
+        fit?: PROPERTY_FIT;
+        radius?: PROPERTY_RADIUS_BREAKPOINT;
+        shape?: PROPERTY_SHAPE_BREAKPOINT;
     } & IHTML5Properties &
         IGlobalProperties &
         IMarginProperties &
@@ -24,17 +33,22 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
+    export let element: $$Props["element"] = undefined;
+
     let _class: $$Props["class"] = "";
     export {_class as class};
 
-    export let actions: $$Props["actions"] = undefined;
-    export let element: $$Props["element"] = undefined;
+    export let fit: $$Props["fit"] = undefined;
+    export let radius: $$Props["radius"] = undefined;
+    export let shape: $$Props["shape"] = undefined;
 </script>
 
 <figure
     bind:this={element}
     {...map_global_attributes($$restProps)}
     class="card--figure {_class}"
+    {...map_data_attributes({fit, radius, shape})}
     use:forward_actions={{actions}}
     on:click
     on:contextmenu

--- a/src/lib/components/surfaces/card/card.scss
+++ b/src/lib/components/surfaces/card/card.scss
@@ -4,6 +4,7 @@
 @use "../../../../framework/mixins/borders";
 @use "../../../../framework/mixins/backgrounds";
 @use "../../../../framework/mixins/elevations";
+@use "../../../../framework/mixins/fit";
 @use "../../../../framework/mixins/fonts";
 @use "../../../../framework/mixins/intrinsics";
 @use "../../../../framework/mixins/palettes";
@@ -61,6 +62,17 @@
 
         align-items: center;
         justify-content: center;
+
+        @include fit.var-reset-object();
+        @include radius.var-reset();
+
+        @include fit.object();
+        @include radius.all($unit: rem);
+
+        & > * {
+            border-radius: inherit;
+            object-fit: inherit;
+        }
     }
 
     .card--footer {

--- a/src/lib/components/surfaces/tile/Tile.stories.svelte
+++ b/src/lib/components/surfaces/tile/Tile.stories.svelte
@@ -1,5 +1,6 @@
 <script>
     import IMAGE_AVATAR from "../../../../../.storybook/assets/avatar.webp";
+    import IMAGE_BACKGROUND from "../../../../../.storybook/assets/background.webp";
 
     import {Meta, Story, Template} from "@storybook/addon-svelte-csf";
 
@@ -20,6 +21,14 @@
         ["highest", false],
     ];
 
+    const FITS = [
+        ["fill", true],
+        ["contain", false],
+        ["cover", false],
+        ["none", false],
+        ["scale-down", false],
+    ];
+
     const ORIENTATIONS = [
         ["horizontal", true],
         ["vertical", false],
@@ -37,6 +46,22 @@
         ["affirmative", false],
         ["informative", false],
         ["negative", false],
+    ];
+
+    const RADIUS = [
+        ["none", true],
+        ["nano", false],
+        ["tiny", false],
+        ["small", false],
+        ["medium", false],
+        ["large", false],
+        ["huge", false],
+        ["massive", false],
+    ];
+
+    const SHAPES = [
+        ["circle", false],
+        ["pill", false],
     ];
 
     const SIZINGS = [
@@ -177,7 +202,79 @@
     </Stack.Container>
 </Story>
 
-<Story name="Footer Orientation">
+<Story name="Figure - Fit">
+    <Stack.Container orientation="horizontal" spacing="medium" alignment_y="top" variation="wrap">
+        {#each FITS as [fit, is_default] (fit)}
+            <Tile.Container width="content-max">
+                <Tile.Figure fit={is_default ? undefined : fit}>
+                    <img src={IMAGE_BACKGROUND} />
+                </Tile.Figure>
+
+                <Tile.Section>
+                    <Tile.Header>
+                        {`${fit.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                    </Tile.Header>
+
+                    <Text>
+                        <Text is="small">
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        </Text>
+                    </Text>
+                </Tile.Section>
+            </Tile.Container>
+        {/each}
+    </Stack.Container>
+</Story>
+
+<Story name="Figure - Radius">
+    <Stack.Container orientation="horizontal" spacing="medium" alignment_y="top" variation="wrap">
+        {#each RADIUS as [radius, is_default] (radius)}
+            <Tile.Container width="content-max">
+                <Tile.Figure radius={is_default ? undefined : radius}>
+                    <img src={IMAGE_BACKGROUND} />
+                </Tile.Figure>
+
+                <Tile.Section>
+                    <Tile.Header>
+                        {`${radius.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                    </Tile.Header>
+
+                    <Text>
+                        <Text is="small">
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        </Text>
+                    </Text>
+                </Tile.Section>
+            </Tile.Container>
+        {/each}
+    </Stack.Container>
+</Story>
+
+<Story name="Figure - Shape">
+    <Stack.Container orientation="horizontal" spacing="medium" alignment_y="top" variation="wrap">
+        {#each SHAPES as [shape, is_default] (shape)}
+            <Tile.Container width="content-max">
+                <Tile.Figure shape={is_default ? undefined : shape}>
+                    <img src={IMAGE_BACKGROUND} />
+                </Tile.Figure>
+
+                <Tile.Section>
+                    <Tile.Header>
+                        {`${shape.toUpperCase()}${is_default ? " / DEFAULT" : ""}`}
+                    </Tile.Header>
+
+                    <Text>
+                        <Text is="small">
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        </Text>
+                    </Text>
+                </Tile.Section>
+            </Tile.Container>
+        {/each}
+    </Stack.Container>
+</Story>
+
+<Story name="Footer - Orientation">
     <Stack.Container orientation="horizontal" spacing="medium" alignment_y="top" variation="wrap">
         {#each ORIENTATIONS as [orientation, is_default] (orientation)}
             <Tile.Container width="content-max">
@@ -202,7 +299,7 @@
     </Stack.Container>
 </Story>
 
-<Story name="Footer Spacing">
+<Story name="Footer - Spacing">
     <Stack.Container orientation="horizontal" spacing="medium" alignment_y="top" variation="wrap">
         {#each SPACINGS as [spacing, is_default] (spacing)}
             <Tile.Container width="content-max">

--- a/src/lib/components/surfaces/tile/TileFigure.svelte
+++ b/src/lib/components/surfaces/tile/TileFigure.svelte
@@ -1,19 +1,28 @@
 <script lang="ts">
+    import type {PROPERTY_FIT} from "../../../types/fit";
     import type {IGlobalProperties} from "../../../types/global";
     import type {IHTML5Events, IHTML5Properties} from "../../../types/html5";
+    import type {
+        PROPERTY_RADIUS_BREAKPOINT,
+        PROPERTY_SHAPE_BREAKPOINT,
+    } from "../../../types/shapes";
     import type {ISizeProperties} from "../../../types/sizes";
     import type {IMarginProperties, IPaddingProperties} from "../../../types/spacings";
 
     import type {IForwardedActions} from "../../../actions/forward_actions";
     import {forward_actions} from "../../../actions/forward_actions";
 
-    import {map_global_attributes} from "../../../util/attributes";
+    import {map_data_attributes, map_global_attributes} from "../../../util/attributes";
 
     type $$Events = IHTML5Events;
 
     type $$Props = {
         actions?: IForwardedActions;
         element?: HTMLElement;
+
+        fit?: PROPERTY_FIT;
+        radius?: PROPERTY_RADIUS_BREAKPOINT;
+        shape?: PROPERTY_SHAPE_BREAKPOINT;
     } & IHTML5Properties &
         IGlobalProperties &
         IMarginProperties &
@@ -24,17 +33,22 @@
         default: {};
     };
 
+    export let actions: $$Props["actions"] = undefined;
+    export let element: $$Props["element"] = undefined;
+
     let _class: $$Props["class"] = "";
     export {_class as class};
 
-    export let actions: $$Props["actions"] = undefined;
-    export let element: $$Props["element"] = undefined;
+    export let fit: $$Props["fit"] = undefined;
+    export let radius: $$Props["radius"] = undefined;
+    export let shape: $$Props["shape"] = undefined;
 </script>
 
 <figure
     bind:this={element}
     {...map_global_attributes($$restProps)}
     class="tile--figure {_class}"
+    {...map_data_attributes({fit, radius, shape})}
     use:forward_actions={{actions}}
     on:click
     on:contextmenu

--- a/src/lib/components/surfaces/tile/tile.scss
+++ b/src/lib/components/surfaces/tile/tile.scss
@@ -4,6 +4,7 @@
 @use "../../../../framework/mixins/borders";
 @use "../../../../framework/mixins/backgrounds";
 @use "../../../../framework/mixins/elevations";
+@use "../../../../framework/mixins/fit";
 @use "../../../../framework/mixins/fonts";
 @use "../../../../framework/mixins/intrinsics";
 @use "../../../../framework/mixins/palettes";
@@ -50,6 +51,19 @@
         justify-content: center;
 
         @include intrinsics.size-all($namespace: "tile.figure");
+
+        @include fit.var-reset-object();
+        @include radius.var-reset();
+
+        @include fit.object();
+        @include radius.all($unit: rem);
+
+        & > * {
+            border-radius: inherit;
+            object-fit: inherit;
+
+            height: 100%;
+        }
     }
 
     .tile--footer {


### PR DESCRIPTION
# CHANGELOG

-   `Card`

    -   Fixed missing `<Card.Figure fit radius shape>` support, to match `<Figure>` Property API.

-   `Tile`

    -   Fixed missing `<Tile.Figure fit radius shape>` support, to match `<Figure>` Property API.