### PR TITLE
[0.6.4] Fixed Missing `make_keybind_shortcut` Package Export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## UNRELEASED
+
+-   `keybind`
+
+    -   Fixed `make_keybind_shortcut` missing as a package export.
+    -   Updated `make_keybind_shortcut` action to allow override of preset options aside from `IKeybindOptions.on_bind`.
+
 ## v0.6.3 - 2022/03/11
 
 -   `Aside`

--- a/src/lib/actions/keybind.ts
+++ b/src/lib/actions/keybind.ts
@@ -293,14 +293,14 @@ export const keybind: IKeybindAction = (element, options) => {
 export function make_keybind_shortcut(
     factory_options: Omit<IKeybindOptions, "on_bind">
 ): IKeybindShortcutAction {
-    return (element, {on_bind}) => {
-        const {destroy, update} = keybind(element, {...factory_options, on_bind});
+    return (element, options) => {
+        const {destroy, update} = keybind(element, {...factory_options, ...options});
 
         return {
             destroy,
 
-            update({on_bind}) {
-                update({...factory_options, on_bind});
+            update(options) {
+                update({...factory_options, ...options});
             },
         };
     };

--- a/src/lib/actions/keybind.ts
+++ b/src/lib/actions/keybind.ts
@@ -290,7 +290,7 @@ export const keybind: IKeybindAction = (element, options) => {
  * @param factory_options
  * @returns
  */
-function make_keybind_shortcut(
+export function make_keybind_shortcut(
     factory_options: Omit<IKeybindOptions, "on_bind">
 ): IKeybindShortcutAction {
     return (element, {on_bind}) => {


### PR DESCRIPTION
# CHANGELOG

-   `keybind`

    -   Fixed `make_keybind_shortcut` missing as a package export.
    -   Updated `make_keybind_shortcut` action to allow override of preset options aside from `IKeybindOptions.on_bind`.